### PR TITLE
Fix issues loading plists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ luac.out
 *.hex
 
 build
+temp

--- a/src/hs/plist/test.lua
+++ b/src/hs/plist/test.lua
@@ -1,0 +1,22 @@
+--- Tests the plist library
+
+local log = require("hs.logger").new("plist.test")
+local plister = require("hs.plist")
+local inspect = require("hs.inspect")
+local fcp = require("hs.finalcutpro")
+
+local function runTest()
+	local plistFile = "hs/fcpxhacks/plist/10-3/old/NSProCommandGroups.plist"
+	--local plistFile = "hs/plist/example.commandset"
+	--local plistFile = fcp.getActiveCommandSetPath()
+
+	log.d("TEST: Reading "..inspect(plistFile))
+
+	local nsProCmds = plister.fileToTable(plistFile)
+
+	log.d("TEST: "..inspect(nsProCmds))
+	
+	
+end
+
+return runTest	


### PR DESCRIPTION
Looks like the issue was trying to load a binary file as an XML. Given the unpredictability of whether it will be binary or XML, I’ve added a ‘fileToTable’ method.
Also added some handling for paths which have a space in the path name by getting the absolute path (hs.execute seems to have issues when using “~” inside quotes).