### PR TITLE
#226

### DIFF
--- a/src/hs/fcpxhacks/modules/clipboard.lua
+++ b/src/hs/fcpxhacks/modules/clipboard.lua
@@ -168,10 +168,10 @@ function clipboard.processContent(data)
 		-- Just process the contained items directly
 		return clipboard.processObject(data.containedItems)
 	end
-	
+
 	local displayName = data.displayName
 	local count = displayName and 1 or 0
-	
+
 	if clipboard.getClassname(data) == CLIPBOARD.GAP then
 		displayName = nil
 		count = 0
@@ -470,17 +470,20 @@ local newPlist = [[
 				--------------------------------------------------------------------------------
 				-- Clipboard History:
 				--------------------------------------------------------------------------------
-				local currentClipboardItem = {currentClipboardData, currentClipboardLabel}
+				local enableClipboardHistory = settings.get("fcpxHacks.enableClipboardHistory") or false
+				if enableClipboardHistory then
+					local currentClipboardItem = {currentClipboardData, currentClipboardLabel}
 
-				while (#(clipboard.history) >= clipboard.historyMaximumSize) do
-					table.remove(clipboard.history,1)
+					while (#(clipboard.history) >= clipboard.historyMaximumSize) do
+						table.remove(clipboard.history,1)
+					end
+					table.insert(clipboard.history, currentClipboardItem)
+
+					--------------------------------------------------------------------------------
+					-- Update Settings:
+					--------------------------------------------------------------------------------
+					settings.set("fcpxHacks.clipboardHistory", clipboard.history)
 				end
-				table.insert(clipboard.history, currentClipboardItem)
-
-				--------------------------------------------------------------------------------
-				-- Update Settings:
-				--------------------------------------------------------------------------------
-				settings.set("fcpxHacks.clipboardHistory", clipboard.history)
 
 				--------------------------------------------------------------------------------
 				-- Refresh Menubar:

--- a/src/hs/fcpxhacks/modules/fcpx10-3.lua
+++ b/src/hs/fcpxhacks/modules/fcpx10-3.lua
@@ -432,7 +432,8 @@ function loadScript()
 		-- Clipboard Watcher:
 		--------------------------------------------------------------------------------
 		local enableClipboardHistory = settings.get("fcpxHacks.enableClipboardHistory") or false
-		if enableClipboardHistory then clipboard.startWatching() end
+		local enableSharedClipboard = settings.get("fcpxHacks.enableSharedClipboard") or false
+		if enableClipboardHistory or enableSharedClipboard then clipboard.startWatching() end
 
 		--------------------------------------------------------------------------------
 		-- Notification Watcher:
@@ -1411,7 +1412,7 @@ end
 		--------------------------------------------------------------------------------
 		local settingsSharedClipboardTable = {}
 
-		if enableSharedClipboard and enableClipboardHistory then
+		if enableSharedClipboard then
 
 			--------------------------------------------------------------------------------
 			-- Get list of files:
@@ -1808,13 +1809,16 @@ end
 			{ title = i18n("iMessage"), 																fn = function() toggleNotificationPlatform("iMessage") end, 		checked = notificationPlatform["iMessage"] == true },
 		}
 		local toolsSettings = {
-			{ title = i18n("enableTouchBar"), 															fn = toggleTouchBar, 												checked = displayTouchBar, 									disabled = not touchBarSupported},
-			{ title = i18n("enableHacksHUD"), 															fn = toggleEnableHacksHUD, 											checked = enableHacksHUD},
-			{ title = i18n("enableMobileNotifications"),												menu = settingsNotificationPlatform },
 			{ title = i18n("enableClipboardHistory"),													fn = toggleEnableClipboardHistory, 									checked = enableClipboardHistory},
-			{ title = i18n("enableSharedClipboard"), 													fn = toggleEnableSharedClipboard, 									checked = enableSharedClipboard,							disabled = not enableClipboardHistory},
+			{ title = i18n("enableSharedClipboard"), 													fn = toggleEnableSharedClipboard, 									checked = enableSharedClipboard},
+			{ title = "-" },
+			{ title = i18n("enableHacksHUD"), 															fn = toggleEnableHacksHUD, 											checked = enableHacksHUD},
 			{ title = i18n("enableXMLSharing"),															fn = toggleEnableXMLSharing, 										checked = enableXMLSharing},
+			{ title = "-" },
+			{ title = i18n("enableTouchBar"), 															fn = toggleTouchBar, 												checked = displayTouchBar, 									disabled = not touchBarSupported},
 			{ title = i18n("enableVoiceCommands"),														fn = toggleEnableVoiceCommands, 									checked = settings.get("fcpxHacks.enableVoiceCommands") },
+			{ title = "-" },
+			{ title = i18n("enableMobileNotifications"),												menu = settingsNotificationPlatform },
 		}
 		local toolsTable = {
 			{ title = string.upper(i18n("tools")) .. ":", 												disabled = true },
@@ -3473,11 +3477,18 @@ end
 	-- TOGGLE CLIPBOARD HISTORY:
 	--------------------------------------------------------------------------------
 	function toggleEnableClipboardHistory()
+
+		local enableSharedClipboard = settings.get("fcpxHacks.enableSharedClipboard") or false
 		local enableClipboardHistory = settings.get("fcpxHacks.enableClipboardHistory") or false
+
 		if not enableClipboardHistory then
-			clipboard.startWatching()
+			if not enableSharedClipboard then
+				clipboard.startWatching()
+			end
 		else
-			clipboard.stopWatching()
+			if not enableSharedClipboard then
+				clipboard.stopWatching()
+			end
 		end
 		settings.set("fcpxHacks.enableClipboardHistory", not enableClipboardHistory)
 		refreshMenuBar()
@@ -3489,6 +3500,7 @@ end
 	function toggleEnableSharedClipboard()
 
 		local enableSharedClipboard = settings.get("fcpxHacks.enableSharedClipboard") or false
+		local enableClipboardHistory = settings.get("fcpxHacks.enableClipboardHistory") or false
 
 		if not enableSharedClipboard then
 
@@ -3503,6 +3515,10 @@ end
 				--------------------------------------------------------------------------------
 				sharedClipboardWatcher = pathwatcher.new(result, sharedClipboardFileWatcher):start()
 
+				if not enableClipboardHistory then
+					clipboard.startWatching()
+				end
+
 			else
 				debugMessage("Enabled Shared Clipboard Choose Path Cancelled.")
 				settings.set("fcpxHacks.sharedClipboardPath", nil)
@@ -3515,6 +3531,10 @@ end
 			-- Stop Watching for Shared Clipboard Changes:
 			--------------------------------------------------------------------------------
 			sharedClipboardWatcher:stop()
+
+			if not enableClipboardHistory then
+				clipboard.stopWatching()
+			end
 
 		end
 


### PR DESCRIPTION
- "Enable Shared Clipboard" can now be enabled without having to enable
"Enable Clipboard History" first
- Changed order/layout of Tools Options menubar