### PR TITLE
#404 - make cp.template less annoying

### DIFF
--- a/src/extensions/cp/feedback/html/feedback.htm
+++ b/src/extensions/cp/feedback/html/feedback.htm
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
 	 <style>
-	 	body \{
+	 	body {
 	 		background-color: #ececec;
 	 		font-family: -apple-system;
 	 		font-size: 13px;
 	 	}
-		.button \{
+		.button {
 			text-decoration: none;
 			color: black;
 			padding: 2px 18px;
@@ -18,21 +18,21 @@
 			border-radius: 3px;
 			cursor: default;
 		}
-		.button:active \{
+		.button:active {
 			color: white;
 		 	border-color:#1262fb;
 		 	background-image:-webkit-linear-gradient(#6fb4f7, #1981fb);
 		}
-		.button.selected \{
+		.button.selected {
 			color: white;
 		 	border-color:#1262fb;
 		 	background-image:-webkit-linear-gradient(#6fb4f7, #1981fb);
 		}
-		.button.disabled \{
+		.button.disabled {
 			color: #999!important;
 			background-image: -webkit-linear-gradient(#fbf8f8 0%, #f0f0f0 30%, #e3e3e3 45%, #d7d7d7 60%, #cbc9c9 100%);
 		}
-		.textarea \{
+		.textarea {
 		 	-webkit-box-sizing: border-box;
 		 	padding: 4px 4px;
 			margin: 10px 0px;
@@ -44,30 +44,30 @@
 		    max-height: 200px;
 		    overflow: auto;
 		}
-		.main-form \{
+		.main-form {
 			width: 350px;
 			display: block;
 		}
-		.bottom-buttons \{
+		.bottom-buttons {
 			text-align: right;
 		}
-		.email-note \{
+		.email-note {
 			padding: 10px 0px;
 		}
-		.user-details \{
+		.user-details {
 			padding: 10px 0px;
 			text-align: center;
 		}
-		.user-details input \{
+		.user-details input {
 			width: 45%;
 		}
-		.contact-checkbox input \{
+		.contact-checkbox input {
 			margin-right: 5px;
 		}
-		.error \{
+		.error {
 			border:1px solid #fc615d;
 		}
-		.loading \{
+		.loading {
 			display: none;
 			z-index: 999;
 			position: absolute;
@@ -79,7 +79,7 @@
 			font-size: 25px;
 			text-align: center;
 		}
-		.loading-text \{
+		.loading-text {
   			display: table-cell;
 			vertical-align: middle;
 		}
@@ -120,12 +120,12 @@
 			<textarea id="form-feedback" name="form-feedback" style="display:none"></textarea>
 			<div id="console-output" hidden>{{ consoleOutput }}</div>
 			<textarea id="form-console-output" name="form-console-output" style="display:none"></textarea>
-			{% for i, v in ipairs(screenshots) do }}
+			{{% for i, v in ipairs(screenshots) do }}
 				<div id="screenshot{{ i }}" hidden>
 					<img id='base64image{{ i }}' src='data:image/jpeg;base64, {{ v }}' />
 				</div>
 				<textarea id="form-screenshot{{ i }}" name="form-screenshot{{ i }}" style="display:none"></textarea>
-			{% end }}
+			{{% end }}
 		</form>
 		<script>
 
@@ -144,17 +144,17 @@
 			sel.addRange(range);
 
 			/* FOCUS AT END OF TEXTBOX: */
-			function placeCaretAtEnd(el) \{
+			function placeCaretAtEnd(el) {
 				el.focus();
 				if (typeof window.getSelection != "undefined"
-						&& typeof document.createRange != "undefined") \{
+						&& typeof document.createRange != "undefined") {
 					var range = document.createRange();
 					range.selectNodeContents(el);
 					range.collapse(false);
 					var sel = window.getSelection();
 					sel.removeAllRanges();
 					sel.addRange(range);
-				} else if (typeof document.body.createTextRange != "undefined") \{
+				} else if (typeof document.body.createTextRange != "undefined") {
 					var textRange = document.body.createTextRange();
 					textRange.moveToElementText(el);
 					textRange.collapse(false);
@@ -163,40 +163,40 @@
 			}
 
 			/* SUBMIT FORM: */
-			function submitForm() \{
+			function submitForm() {
 
 				document.getElementById("loading").style.display = "table";
 
-				if (document.getElementById("include-contact-info").checked) \{
-					try \{
+				if (document.getElementById("include-contact-info").checked) {
+					try {
 						var settings = new Array(document.getElementById("fullname").value, document.getElementById("email").value);
 						webkit.messageHandlers.feedback.postMessage(settings);
-					} catch(err) \{
+					} catch(err) {
 						console.log('The controller does not exist yet');
 					}
-				} else \{
+				} else {
 					document.getElementById("fullname").disabled = false;
 					document.getElementById("email").disabled = false;
 					document.getElementById("fullname").value = "Anonymous";
 					document.getElementById("email").value = "anonymous@anonymous.com";
 				}
 
-				if (document.getElementById("include-log-files").checked) \{
+				if (document.getElementById("include-log-files").checked) {
 					document.getElementById("form-console-output").value = document.getElementById("console-output").innerHTML;
 				}
 
-				if (!document.getElementById("bugreport-comments").hidden) \{
+				if (!document.getElementById("bugreport-comments").hidden) {
 					 document.getElementById("form-feedback").value = document.getElementById("bugreport-comments").innerHTML;
-				} else if (!document.getElementById("feature-request-comments").hidden) \{
+				} else if (!document.getElementById("feature-request-comments").hidden) {
 				 	document.getElementById("form-feedback").value = document.getElementById("feature-request-comments").innerHTML;
-				} else if (!document.getElementById("support-comments").hidden) \{
+				} else if (!document.getElementById("support-comments").hidden) {
 				 	document.getElementById("form-feedback").value = document.getElementById("support-comments").innerHTML;
 				};
 
-				if (document.getElementById("include-screnshots").checked) \{
-					{% for i, v in ipairs(screenshots) do }}
+				if (document.getElementById("include-screnshots").checked) {
+					{{% for i, v in ipairs(screenshots) do }}
 						document.getElementById("form-screenshot{{ i }}").value = document.getElementById("screenshot{{ i }}").innerHTML;
-					{% end }}
+					{{% end }}
 				}
 
 				document.getElementById("feedback-form").submit();
@@ -204,7 +204,7 @@
 			}
 
 			/* SEND BUTTON PRESSED: */
-			document.getElementById("button-send").onclick = function() \{
+			document.getElementById("button-send").onclick = function() {
 
 				var includeContactInfo = document.getElementById("include-contact-info").checked;
 				var fullnameValid = !(document.getElementById("fullname").value == "{{ defaultUserFullName }}");
@@ -215,52 +215,52 @@
 				var newSupportValue = document.getElementById("support-comments").innerHTML;
 
 				var userCommentsValid = true;
-				if (!document.getElementById("bugreport-comments").hidden) \{
-					if ( defaultBugReportValue == newBugReportValue ) \{
+				if (!document.getElementById("bugreport-comments").hidden) {
+					if ( defaultBugReportValue == newBugReportValue ) {
 						document.getElementById("bugreport-comments").className = "textarea error";
 						userCommentsValid = false;
-					} else \{
+					} else {
 						document.getElementById("bugreport-comments").className = "textarea";
 					}
-				} else if (!document.getElementById("feature-request-comments").hidden) \{
-					if ( defaultFeatureRequestValue == newFeatureRequestValue ) \{
+				} else if (!document.getElementById("feature-request-comments").hidden) {
+					if ( defaultFeatureRequestValue == newFeatureRequestValue ) {
 						document.getElementById("feature-request-comments").className = "textarea error";
 						userCommentsValid = false;
-					} else \{
+					} else {
 						document.getElementById("feature-request-comments").className = "textarea";
 					}
-				} else if (!document.getElementById("support-comments").hidden) \{
+				} else if (!document.getElementById("support-comments").hidden) {
 
-					if ( defaultSupportValue == newSupportValue ) \{
+					if ( defaultSupportValue == newSupportValue ) {
 						document.getElementById("support-comments").className = "textarea error";
 						userCommentsValid = false;
-					} else \{
+					} else {
 						document.getElementById("support-comments").className = "textarea";
 					}
 
 				};
 
-				if (includeContactInfo) \{
-					if (fullnameValid && emailValid && userCommentsValid) \{
+				if (includeContactInfo) {
+					if (fullnameValid && emailValid && userCommentsValid) {
 						submitForm();
-					} else if (!fullnameValid && !emailValid ) \{
+					} else if (!fullnameValid && !emailValid ) {
 						document.getElementById("fullname").className = "error";
 						document.getElementById("email").className = "error";
-					} else if (!fullnameValid) \{
+					} else if (!fullnameValid) {
 						document.getElementById("fullname").className = "error";
 						document.getElementById("email").className = "";
-					} else if (!emailValid) \{
+					} else if (!emailValid) {
 						document.getElementById("fullname").className = "";
 						document.getElementById("email").className = "error";
 					};
-				} else \{
-					if (userCommentsValid) \{
+				} else {
+					if (userCommentsValid) {
 						submitForm();
 					}
 				};
 
 			};
-			document.getElementById("button-bug-report").onclick = function() \{
+			document.getElementById("button-bug-report").onclick = function() {
 				document.getElementById("bugreport-comments").hidden = false;
 				document.getElementById("feature-request-comments").hidden = true;
 				document.getElementById("support-comments").hidden = true;
@@ -277,7 +277,7 @@
 				sel.addRange(range);
 
 			};
-			document.getElementById("button-feature-request").onclick = function() \{
+			document.getElementById("button-feature-request").onclick = function() {
 				document.getElementById("bugreport-comments").hidden = true;
 				document.getElementById("feature-request-comments").hidden = false;
 				document.getElementById("support-comments").hidden = true;
@@ -286,7 +286,7 @@
 				document.getElementById("button-support").className = "button";
 				placeCaretAtEnd( document.getElementById("feature-request-comments") );
 			};
-			document.getElementById("button-support").onclick = function() \{
+			document.getElementById("button-support").onclick = function() {
 				document.getElementById("bugreport-comments").hidden = true;
 				document.getElementById("feature-request-comments").hidden = true;
 				document.getElementById("support-comments").hidden = false;
@@ -295,7 +295,7 @@
 				document.getElementById("button-support").className = "button selected";
 				placeCaretAtEnd( document.getElementById("support-comments") );
 			};
-			document.getElementById("include-contact-info").onclick = function() \{
+			document.getElementById("include-contact-info").onclick = function() {
 				document.getElementById("fullname").disabled = !document.getElementById("fullname").disabled;
 				document.getElementById("email").disabled = !document.getElementById("email").disabled;
 			};

--- a/src/plugins/core/preferences/manager/html/panel.htm
+++ b/src/plugins/core/preferences/manager/html/panel.htm
@@ -2,13 +2,13 @@
 <html lang="en">
 	<head>
 		 <style>
-			body \{
+			body {
 				background-color: #ececec;
 				font-family: -apple-system;
 				font-size: 13px;
 				overflow:hidden;
 			}
-			.button \{
+			.button {
 				text-decoration: none;
 				color: black;
 				padding: 2px 18px;
@@ -20,21 +20,21 @@
 				cursor: default;
 				text-align: center;
 			}
-			.button:active \{
+			.button:active {
 				color: white;
 				border-color:#1262fb;
 				background-image:-webkit-linear-gradient(#6fb4f7, #1981fb);
 			}
-			.button.selected \{
+			.button.selected {
 				color: white;
 				border-color:#1262fb;
 				background-image:-webkit-linear-gradient(#6fb4f7, #1981fb);
 			}
-			.button.disabled \{
+			.button.disabled {
 				color: #999!important;
 				background-image: -webkit-linear-gradient(#fbf8f8 0%, #f0f0f0 30%, #e3e3e3 45%, #d7d7d7 60%, #cbc9c9 100%);
 			}
-			.textarea \{
+			.textarea {
 				-webkit-box-sizing: border-box;
 				padding: 4px 4px;
 				margin: 10px 0px;
@@ -46,7 +46,7 @@
 				max-height: 200px;
 				overflow: auto;
 			}
-			.uiItem \{
+			.uiItem {
 				padding-left:20px;
 				margin-top: 0px;
 				margin-bottom: 2px;
@@ -57,7 +57,7 @@
 		<script>
 			// Disable Right Clicking:
 			/*
-			document.addEventListener("contextmenu", function(e)\{
+			document.addEventListener("contextmenu", function(e){
 			    e.preventDefault();
 			}, false);
 			*/

--- a/src/plugins/core/welcome/manager/html/template.htm
+++ b/src/plugins/core/welcome/manager/html/template.htm
@@ -7,289 +7,289 @@
 		<style>
 			/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 			/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
-			html \{ font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
+			html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
 			/** Remove default margin. */
-			body \{ margin: 0; }
+			body { margin: 0; }
 
 			/* HTML5 display definitions ========================================================================== */
 			/** Correct `block` display not defined for any HTML5 element in IE 8/9. Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox. Correct `block` display not defined for `main` in IE 11. */
-			article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary \{ display: block; }
+			article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary { display: block; }
 
 			/** 1. Correct `inline-block` display not defined in IE 8/9. 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera. */
-			audio, canvas, progress, video \{ display: inline-block; /* 1 */ vertical-align: baseline; /* 2 */ }
+			audio, canvas, progress, video { display: inline-block; /* 1 */ vertical-align: baseline; /* 2 */ }
 
 			/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
-			audio:not([controls]) \{ display: none; height: 0; }
+			audio:not([controls]) { display: none; height: 0; }
 
 			/** Address `[hidden]` styling not present in IE 8/9/10. Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22. */
-			[hidden], template \{ display: none; }
+			[hidden], template { display: none; }
 
 			/* Links ========================================================================== */
 			/** Remove the gray background color from active links in IE 10. */
-			a \{ background-color: transparent; }
+			a { background-color: transparent; }
 
 			/** Improve readability when focused and also mouse hovered in all browsers. */
-			a:active, a:hover \{ outline: 0; }
+			a:active, a:hover { outline: 0; }
 
 			/* Text-level semantics ========================================================================== */
 			/** Address styling not present in IE 8/9/10/11, Safari, and Chrome. */
-			abbr[title] \{ border-bottom: 1px dotted; }
+			abbr[title] { border-bottom: 1px dotted; }
 
 			/** Address style set to `bolder` in Firefox 4+, Safari, and Chrome. */
-			b, strong \{ font-weight: bold; }
+			b, strong { font-weight: bold; }
 
 			/** Address styling not present in Safari and Chrome. */
-			dfn \{ font-style: italic; }
+			dfn { font-style: italic; }
 
 			/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari, and Chrome. */
-			h1 \{ font-size: 2em; margin: 0.67em 0; }
+			h1 { font-size: 2em; margin: 0.67em 0; }
 
 			/** Address styling not present in IE 8/9. */
-			mark \{ background: #ff0; color: #000; }
+			mark { background: #ff0; color: #000; }
 
 			/** Address inconsistent and variable font size in all browsers. */
-			small \{ font-size: 80%; }
+			small { font-size: 80%; }
 
 			/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
-			sub, sup \{ font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
+			sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-			sup \{ top: -0.5em; }
+			sup { top: -0.5em; }
 
-			sub \{ bottom: -0.25em; }
+			sub { bottom: -0.25em; }
 
 			/* Embedded content ========================================================================== */
 			/** Remove border when inside `a` element in IE 8/9/10. */
-			img \{ border: 0; }
+			img { border: 0; }
 
 			/** Correct overflow not hidden in IE 9/10/11. */
-			svg:not(:root) \{ overflow: hidden; }
+			svg:not(:root) { overflow: hidden; }
 
 			/* Grouping content ========================================================================== */
 			/** Address margin not present in IE 8/9 and Safari. */
-			figure \{ margin: 1em 40px; }
+			figure { margin: 1em 40px; }
 
 			/** Address differences between Firefox and other browsers. */
-			hr \{ box-sizing: content-box; height: 0; }
+			hr { box-sizing: content-box; height: 0; }
 
 			/** Contain overflow in all browsers. */
-			pre \{ overflow: auto; }
+			pre { overflow: auto; }
 
 			/** Address odd `em`-unit font size rendering in all browsers. */
-			code, kbd, pre, samp \{ font-family: monospace, monospace; font-size: 1em; }
+			code, kbd, pre, samp { font-family: monospace, monospace; font-size: 1em; }
 
 			/* Forms ========================================================================== */
 			/** Known limitation: by default, Chrome and Safari on OS X allow very limited styling of `select`, unless a `border` property is set. */
 			/** 1. Correct color not being inherited. Known issue: affects color of disabled elements. 2. Correct font properties not being inherited. 3. Address margins set differently in Firefox 4+, Safari, and Chrome. */
-			button, input, optgroup, select, textarea \{ color: inherit; /* 1 */ font: inherit; /* 2 */ margin: 0; /* 3 */ }
+			button, input, optgroup, select, textarea { color: inherit; /* 1 */ font: inherit; /* 2 */ margin: 0; /* 3 */ }
 
 			/** Address `overflow` set to `hidden` in IE 8/9/10/11. */
-			button \{ overflow: visible; }
+			button { overflow: visible; }
 
 			/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera. Correct `select` style inheritance in Firefox. */
-			button, select \{ text-transform: none; }
+			button, select { text-transform: none; }
 
 			/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
-			button, html input[type="button"], input[type="reset"], input[type="submit"] \{ -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
+			button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
 			/** Re-set default cursor for disabled elements. */
-			button[disabled], html input[disabled] \{ cursor: default; }
+			button[disabled], html input[disabled] { cursor: default; }
 
 			/** Remove inner padding and border in Firefox 4+. */
-			button::-moz-focus-inner, input::-moz-focus-inner \{ border: 0; padding: 0; }
+			button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
 			/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
-			input \{ line-height: normal; }
+			input { line-height: normal; }
 
 			/** It's recommended that you don't attempt to style these elements. Firefox's implementation doesn't respect box-sizing, padding, or width.  1. Address box sizing set to `content-box` in IE 8/9/10. 2. Remove excess padding in IE 8/9/10. */
-			input[type="checkbox"], input[type="radio"] \{ box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
+			input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
 			/** Fix the cursor style for Chrome's increment/decrement buttons. For certain `font-size` values of the `input`, it causes the cursor style of the decrement button to change from `default` to `text`. */
-			input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-outer-spin-button \{ height: auto; }
+			input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-outer-spin-button { height: auto; }
 
 			/** 1. Address `appearance` set to `searchfield` in Safari and Chrome. 2. Address `box-sizing` set to `border-box` in Safari and Chrome (include `-moz` to future-proof). */
-			input[type="search"] \{ -webkit-appearance: textfield; /* 1 */ /* 2 */ box-sizing: content-box; }
+			input[type="search"] { -webkit-appearance: textfield; /* 1 */ /* 2 */ box-sizing: content-box; }
 
 			/** Remove inner padding and search cancel button in Safari and Chrome on OS X. Safari (but not Chrome) clips the cancel button when the search input has padding (and `textfield` appearance). */
-			input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration \{ -webkit-appearance: none; }
+			input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
 			/** Define consistent border, margin, and padding. */
-			fieldset \{ border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
+			fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
 			/** 1. Correct `color` not being inherited in IE 8/9/10/11. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
-			legend \{ border: 0; /* 1 */ padding: 0; /* 2 */ }
+			legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
 			/** Remove default vertical scrollbar in IE 8/9/10/11. */
-			textarea \{ overflow: auto; }
+			textarea { overflow: auto; }
 
 			/** Don't inherit the `font-weight` (applied by a rule above). NOTE: the default cannot safely be changed in Chrome and Safari on OS X. */
-			optgroup \{ font-weight: bold; }
+			optgroup { font-weight: bold; }
 
 			/* Tables ========================================================================== */
 			/** Remove most spacing between table cells. */
-			table \{ border-collapse: collapse; border-spacing: 0; }
+			table { border-collapse: collapse; border-spacing: 0; }
 
-			td, th \{ padding: 0; }
+			td, th { padding: 0; }
 
-			.highlight table td \{ padding: 5px; }
+			.highlight table td { padding: 5px; }
 
-			.highlight table pre \{ margin: 0; }
+			.highlight table pre { margin: 0; }
 
-			.highlight .cm \{ color: #999988; font-style: italic; }
+			.highlight .cm { color: #999988; font-style: italic; }
 
-			.highlight .cp \{ color: #999999; font-weight: bold; }
+			.highlight .cp { color: #999999; font-weight: bold; }
 
-			.highlight .c1 \{ color: #999988; font-style: italic; }
+			.highlight .c1 { color: #999988; font-style: italic; }
 
-			.highlight .cs \{ color: #999999; font-weight: bold; font-style: italic; }
+			.highlight .cs { color: #999999; font-weight: bold; font-style: italic; }
 
-			.highlight .c, .highlight .cd \{ color: #999988; font-style: italic; }
+			.highlight .c, .highlight .cd { color: #999988; font-style: italic; }
 
-			.highlight .err \{ color: #a61717; background-color: #e3d2d2; }
+			.highlight .err { color: #a61717; background-color: #e3d2d2; }
 
-			.highlight .gd \{ color: #000000; background-color: #ffdddd; }
+			.highlight .gd { color: #000000; background-color: #ffdddd; }
 
-			.highlight .ge \{ color: #000000; font-style: italic; }
+			.highlight .ge { color: #000000; font-style: italic; }
 
-			.highlight .gr \{ color: #aa0000; }
+			.highlight .gr { color: #aa0000; }
 
-			.highlight .gh \{ color: #999999; }
+			.highlight .gh { color: #999999; }
 
-			.highlight .gi \{ color: #000000; background-color: #ddffdd; }
+			.highlight .gi { color: #000000; background-color: #ddffdd; }
 
-			.highlight .go \{ color: #888888; }
+			.highlight .go { color: #888888; }
 
-			.highlight .gp \{ color: #555555; }
+			.highlight .gp { color: #555555; }
 
-			.highlight .gs \{ font-weight: bold; }
+			.highlight .gs { font-weight: bold; }
 
-			.highlight .gu \{ color: #aaaaaa; }
+			.highlight .gu { color: #aaaaaa; }
 
-			.highlight .gt \{ color: #aa0000; }
+			.highlight .gt { color: #aa0000; }
 
-			.highlight .kc \{ color: #000000; font-weight: bold; }
+			.highlight .kc { color: #000000; font-weight: bold; }
 
-			.highlight .kd \{ color: #000000; font-weight: bold; }
+			.highlight .kd { color: #000000; font-weight: bold; }
 
-			.highlight .kn \{ color: #000000; font-weight: bold; }
+			.highlight .kn { color: #000000; font-weight: bold; }
 
-			.highlight .kp \{ color: #000000; font-weight: bold; }
+			.highlight .kp { color: #000000; font-weight: bold; }
 
-			.highlight .kr \{ color: #000000; font-weight: bold; }
+			.highlight .kr { color: #000000; font-weight: bold; }
 
-			.highlight .kt \{ color: #445588; font-weight: bold; }
+			.highlight .kt { color: #445588; font-weight: bold; }
 
-			.highlight .k, .highlight .kv \{ color: #000000; font-weight: bold; }
+			.highlight .k, .highlight .kv { color: #000000; font-weight: bold; }
 
-			.highlight .mf \{ color: #009999; }
+			.highlight .mf { color: #009999; }
 
-			.highlight .mh \{ color: #009999; }
+			.highlight .mh { color: #009999; }
 
-			.highlight .il \{ color: #009999; }
+			.highlight .il { color: #009999; }
 
-			.highlight .mi \{ color: #009999; }
+			.highlight .mi { color: #009999; }
 
-			.highlight .mo \{ color: #009999; }
+			.highlight .mo { color: #009999; }
 
-			.highlight .m, .highlight .mb, .highlight .mx \{ color: #009999; }
+			.highlight .m, .highlight .mb, .highlight .mx { color: #009999; }
 
-			.highlight .sb \{ color: #d14; }
+			.highlight .sb { color: #d14; }
 
-			.highlight .sc \{ color: #d14; }
+			.highlight .sc { color: #d14; }
 
-			.highlight .sd \{ color: #d14; }
+			.highlight .sd { color: #d14; }
 
-			.highlight .s2 \{ color: #d14; }
+			.highlight .s2 { color: #d14; }
 
-			.highlight .se \{ color: #d14; }
+			.highlight .se { color: #d14; }
 
-			.highlight .sh \{ color: #d14; }
+			.highlight .sh { color: #d14; }
 
-			.highlight .si \{ color: #d14; }
+			.highlight .si { color: #d14; }
 
-			.highlight .sx \{ color: #d14; }
+			.highlight .sx { color: #d14; }
 
-			.highlight .sr \{ color: #009926; }
+			.highlight .sr { color: #009926; }
 
-			.highlight .s1 \{ color: #d14; }
+			.highlight .s1 { color: #d14; }
 
-			.highlight .ss \{ color: #990073; }
+			.highlight .ss { color: #990073; }
 
-			.highlight .s \{ color: #d14; }
+			.highlight .s { color: #d14; }
 
-			.highlight .na \{ color: #008080; }
+			.highlight .na { color: #008080; }
 
-			.highlight .bp \{ color: #999999; }
+			.highlight .bp { color: #999999; }
 
-			.highlight .nb \{ color: #0086B3; }
+			.highlight .nb { color: #0086B3; }
 
-			.highlight .nc \{ color: #445588; font-weight: bold; }
+			.highlight .nc { color: #445588; font-weight: bold; }
 
-			.highlight .no \{ color: #008080; }
+			.highlight .no { color: #008080; }
 
-			.highlight .nd \{ color: #3c5d5d; font-weight: bold; }
+			.highlight .nd { color: #3c5d5d; font-weight: bold; }
 
-			.highlight .ni \{ color: #800080; }
+			.highlight .ni { color: #800080; }
 
-			.highlight .ne \{ color: #990000; font-weight: bold; }
+			.highlight .ne { color: #990000; font-weight: bold; }
 
-			.highlight .nf \{ color: #990000; font-weight: bold; }
+			.highlight .nf { color: #990000; font-weight: bold; }
 
-			.highlight .nl \{ color: #990000; font-weight: bold; }
+			.highlight .nl { color: #990000; font-weight: bold; }
 
-			.highlight .nn \{ color: #555555; }
+			.highlight .nn { color: #555555; }
 
-			.highlight .nt \{ color: #000080; }
+			.highlight .nt { color: #000080; }
 
-			.highlight .vc \{ color: #008080; }
+			.highlight .vc { color: #008080; }
 
-			.highlight .vg \{ color: #008080; }
+			.highlight .vg { color: #008080; }
 
-			.highlight .vi \{ color: #008080; }
+			.highlight .vi { color: #008080; }
 
-			.highlight .nv \{ color: #008080; }
+			.highlight .nv { color: #008080; }
 
-			.highlight .ow \{ color: #000000; font-weight: bold; }
+			.highlight .ow { color: #000000; font-weight: bold; }
 
-			.highlight .o \{ color: #000000; font-weight: bold; }
+			.highlight .o { color: #000000; font-weight: bold; }
 
-			.highlight .w \{ color: #bbbbbb; }
+			.highlight .w { color: #bbbbbb; }
 
-			.highlight \{ background-color: #f8f8f8; }
+			.highlight { background-color: #f8f8f8; }
 
-			* \{ box-sizing: border-box; }
+			* { box-sizing: border-box; }
 
-			body \{ padding: 0; margin: 0; font-family: -apple-system; font-size: 16px; line-height: 1.5; color: #606c71;
+			body { padding: 0; margin: 0; font-family: -apple-system; font-size: 16px; line-height: 1.5; color: #606c71;
 				background-color: #159957;
 				background-image: linear-gradient(120deg, #ba1d22, #7164e0);
 				overflow:hidden;
 			}
 
-			a \{ color: #1e6bb8; text-decoration: none; }
-			a:hover \{ text-decoration: underline; }
+			a { color: #1e6bb8; text-decoration: none; }
+			a:hover { text-decoration: underline; }
 
-			.button \{ text-transform: uppercase; display: inline-block; margin-bottom: 1rem; color: rgba(255, 255, 255, 0.7); background-color: rgba(255, 255, 255, 0.08); border-color: rgba(255, 255, 255, 0.2); border-style: solid; border-width: 1px; border-radius: 0.3rem; transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
-			.button:hover \{ color: rgba(255, 255, 255, 0.8); text-decoration: none; background-color: rgba(255, 255, 255, 0.2); border-color: rgba(255, 255, 255, 0.3); }
-			.button + .button \{ margin-left: 1rem; }
-			.button \{ padding: 0.6rem 0.9rem; font-size: 0.9rem; }
+			.button { text-transform: uppercase; display: inline-block; margin-bottom: 1rem; color: rgba(255, 255, 255, 0.7); background-color: rgba(255, 255, 255, 0.08); border-color: rgba(255, 255, 255, 0.2); border-style: solid; border-width: 1px; border-radius: 0.3rem; transition: color 0.2s, background-color 0.2s, border-color 0.2s; }
+			.button:hover { color: rgba(255, 255, 255, 0.8); text-decoration: none; background-color: rgba(255, 255, 255, 0.2); border-color: rgba(255, 255, 255, 0.3); }
+			.button + .button { margin-left: 1rem; }
+			.button { padding: 0.6rem 0.9rem; font-size: 0.9rem; }
 
-			.content \{
+			.content {
 				color: #fff;
 				text-align: center;
 				padding: 2rem 6rem;
 			}
 
-			.content-heading \{ margin-top: 0; margin-bottom: 0.1rem; font-size: 2.25rem; }
-			.content-tagline \{ margin-bottom: 2rem; font-weight: normal; opacity: 0.7; font-size: 1.15rem; }
+			.content-heading { margin-top: 0; margin-bottom: 0.1rem; font-size: 2.25rem; }
+			.content-tagline { margin-bottom: 2rem; font-weight: normal; opacity: 0.7; font-size: 1.15rem; }
 
-			.progress-dots \{
+			.progress-dots {
 				color: #c5c2c2;
 				font-size: 1em;
 				padding: 0;
 				letter-spacing: 5px;
 			}
 
-			.selected-dot \{
+			.selected-dot {
 				color: #3c3131;
 			}
 

--- a/src/plugins/finalcutpro/hud/html/hud.html
+++ b/src/plugins/finalcutpro/hud/html/hud.html
@@ -3,7 +3,7 @@
 	<head>
 		<!-- Style Sheets: -->
 		<style>
-		body \{
+		body {
 			background-color:#1f1f1f;
 			color: #bfbebb;
 			font-family: -apple-system;
@@ -11,7 +11,7 @@
 			font-weight: lighter;
 			overflow:hidden;
 		}
-		.button \{
+		.button {
 			text-align: center;
 			display:block;
 			width: 85%;
@@ -28,21 +28,21 @@
 			margin-left: auto;
 		    margin-right: auto;
 		}
-		table \{
+		table {
 			width:100%;
 			text-align:left;
 		}
-		th \{
+		th {
 			width:50%;
 		}
-		h1 \{
+		h1 {
 			font-size: 12px;
 			font-weight: bold;
 			text-align: center;
 			margin: 0px;
 			padding: 0px;
 		}
-		hr \{
+		hr {
 			height:1px;
 			border-width:0;
 			color:gray;
@@ -54,7 +54,7 @@
 			margin-right: auto;
 			border-style: inset;
 		}
-		input[type=text] \{
+		input[type=text] {
 			width: 100%;
 			padding: 5px 5px;
 			margin: 8px 0;
@@ -65,10 +65,10 @@
 			color: white;
 			text-align:center;
 		}
-		.good \{
+		.good {
 			color: #3f9253;
 		}
-		.bad \{
+		.bad {
 			color: #d1393e;
 		}
 		</style>
@@ -77,18 +77,18 @@
 		<script>
 
 			// Disable Right Clicking:
-			document.addEventListener("contextmenu", function(e)\{
+			document.addEventListener("contextmenu", function(e){
 			    e.preventDefault();
 			}, false);
 
 			// Something has been dropped onto our Dropbox:
-			function dropboxAction() \{
+			function dropboxAction() {
 				var x = document.getElementById("dropbox");
 				var dropboxValue = x.value;
 
-				try \{
+				try {
 					webkit.messageHandlers.hud.postMessage(dropboxValue);
-				} catch(err) \{
+				} catch(err) {
 					console.log('The controller does not exist yet');
 				}
 


### PR DESCRIPTION
* Updated `cp.template` to use `{{` and `{{%` to escape, and made escaping single `{` characters with `\{` optional for most cases.
* Updated the HTML templates to use the new syntax.