### PR TITLE
#406 Proxy Icon wackiness in El Capitan

### DIFF
--- a/src/plugins/core/menu/manager/init.lua
+++ b/src/plugins/core/menu/manager/init.lua
@@ -109,6 +109,8 @@ function manager.updateMenubarIcon()
 	title = title .. titleSuffix
 
 	manager.menubar:setIcon(icon)
+	-- HACK for #406: For some reason setting the title to " " temporarily fixes El Capitan
+	manager.menubar:setTitle(" ")
 	manager.menubar:setTitle(title)
 
 end

--- a/src/plugins/finalcutpro/menu/proxyicon.lua
+++ b/src/plugins/finalcutpro/menu/proxyicon.lua
@@ -15,12 +15,8 @@
 --------------------------------------------------------------------------------
 local log				= require("hs.logger").new("preferences")
 
-local application		= require("hs.application")
-local console			= require("hs.console")
-
 local config			= require("cp.config")
 local fcp				= require("cp.finalcutpro")
-local dialog			= require("cp.dialog")
 
 --------------------------------------------------------------------------------
 --
@@ -84,9 +80,9 @@ function mod.generateProxyTitle()
 	if mod.getEnableProxyMenuIcon() then
 		local FFPlayerQuality = fcp:getPreference("FFPlayerQuality")
 		if FFPlayerQuality == mod.PROXY_QUALITY then
-			return " " .. mod.PROXY_ICON
+			return " " .. mod.PROXY_ICON .. "  "
 		else
-			return " " .. mod.ORIGINAL_ICON
+			return " " .. mod.ORIGINAL_ICON .. "  "
 		end
 	end
 

--- a/src/plugins/finalcutpro/menu/proxyicon.lua
+++ b/src/plugins/finalcutpro/menu/proxyicon.lua
@@ -80,9 +80,9 @@ function mod.generateProxyTitle()
 	if mod.getEnableProxyMenuIcon() then
 		local FFPlayerQuality = fcp:getPreference("FFPlayerQuality")
 		if FFPlayerQuality == mod.PROXY_QUALITY then
-			return " " .. mod.PROXY_ICON .. "  "
+			return " " .. mod.PROXY_ICON
 		else
-			return " " .. mod.ORIGINAL_ICON .. "  "
+			return " " .. mod.ORIGINAL_ICON
 		end
 	end
 


### PR DESCRIPTION
This workaround makes it work in El Capitan. Can you confirm it still works in Sierra and if so, merge. Thanks!