### PR TITLE
#456

### DIFF
--- a/src/plugins/core/preferences/panels/shortcuts/html/panel.html
+++ b/src/plugins/core/preferences/panels/shortcuts/html/panel.html
@@ -13,7 +13,7 @@
 		background-color: #ffffff;
 		text-align: left;
 	}
-	
+
 	.shortcuts td {
 	  white-space: nowrap;
 	  overflow: hidden;
@@ -32,7 +32,7 @@
 	.rowModifier {
 		width: 18%;
 	}
-	
+
 	.rowModifier select {
 		width: 100%;
 	}
@@ -40,7 +40,7 @@
 	.rowKeyCode {
 		width: 27%;
 	}
-	
+
 	.rowKeyCode select {
 		width: 100%;
 	}
@@ -85,8 +85,9 @@
 		background-color: #006dd4;
 		color: white;
 	}
-	
+
 	.buttons {
+		padding-top: 10px;
 		text-align: right;
 	}
 </style>

--- a/src/plugins/core/preferences/panels/shortcuts/init.lua
+++ b/src/plugins/core/preferences/panels/shortcuts/init.lua
@@ -73,9 +73,9 @@ local function resetShortcuts()
 		if shortcutsFile then
 			log.df("Removing shortcuts file: '%s'", shortcutsFile)
 			os.remove(shortcutsFile)
-			dialog.displayAlertMessage(i18n("shortcutsResetComplete"))
-			hs.reload()
 		end
+		dialog.displayMessage(i18n("shortcutsResetComplete"), {"OK"})
+		hs.reload()
 	end
 end
 
@@ -116,7 +116,7 @@ local function controllerCallback(message)
 			if body.keyCode and body.keyCode ~= "" then
 				theCommand:activatedBy(modifiers, body.keyCode)
 			end
-			
+
 			commands.saveToFile(DEFAULT_SHORTCUTS)
 		else
 			log.wf("Unable to find command to update: %s:%s", group, command)


### PR DESCRIPTION
- Fixed bug where CommandPost wouldn’t restart when Restoring Default
Shortcuts when a pre-existing shortcut file doesn’t exist.
- Closes #456