### PR TITLE
#491

### DIFF
--- a/src/extensions/cp/config/init.lua
+++ b/src/extensions/cp/config/init.lua
@@ -499,4 +499,97 @@ function fileDroppedToDockIconCallback:callbackFn()
 	return self._callbackFn
 end
 
+--------------------------------------------------------------------------------
+--
+-- DOCK ICON CLICKED CALLBACK:
+--
+--------------------------------------------------------------------------------
+
+--- === cp.config.dockIconClickCallback ===
+---
+--- Callback which triggers when the CommandPost Dock Icon is clicked
+
+local dockIconClickCallback = {}
+dockIconClickCallback._items = {}
+
+mod.dockIconClickCallback = dockIconClickCallback
+
+--- cp.config.dockIconClickCallback:new(id, callbackFn) -> table
+--- Method
+--- Creates a new File Dropped to Dock Icon Callback.
+---
+--- Parameters:
+--- * `id`		- The unique ID for this callback.
+---
+--- Returns:
+---  * table that has been created
+function dockIconClickCallback:new(id, callbackFn)
+
+	if dockIconClickCallback._items[id] ~= nil then
+		error("Duplicate Dock Icon Click Callback: " .. id)
+	end
+	o = {
+		_id = id,
+		_callbackFn = callbackFn,
+	}
+	setmetatable(o, self)
+	self.__index = self
+
+	dockIconClickCallback._items[id] = o
+	return o
+
+end
+
+--- cp.config.dockIconClickCallback:get(id) -> table
+--- Method
+--- Creates a new Dock Icon Click Callback.
+---
+--- Parameters:
+--- * `id`		- The unique ID for the callback you want to return.
+---
+--- Returns:
+---  * table containing the callback
+function dockIconClickCallback:get(id)
+	return self._items[id]
+end
+
+--- cp.config.dockIconClickCallback:getAll() -> table
+--- Method
+--- Returns all of the created Dock Icon Click Callbacks
+---
+--- Parameters:
+--- * None
+---
+--- Returns:
+---  * table containing all of the created callbacks
+function dockIconClickCallback:getAll()
+	return self._items
+end
+
+--- cp.config.dockIconClickCallback:id() -> string
+--- Method
+--- Returns the ID of the current Dock Icon Click Callback
+---
+--- Parameters:
+--- * None
+---
+--- Returns:
+---  * The ID of the current File Dropped to Dock Icon Callback as a `string`
+function dockIconClickCallback:id()
+	return self._id
+end
+
+--- cp.config.dockIconClickCallback:callbackFn() -> function
+--- Method
+--- Returns the callbackFn of the current Dock Icon Click Callback
+---
+--- Parameters:
+--- * None
+---
+--- Returns:
+---  * The callbackFn of the current Shutdown Callback
+function dockIconClickCallback:callbackFn()
+	return self._callbackFn
+end
+
 return mod

--- a/src/extensions/cp/init.lua
+++ b/src/extensions/cp/init.lua
@@ -124,20 +124,6 @@ function mod.init()
 	if errorLogOpenOnClose then hs.openConsole() end
 
 	--------------------------------------------------------------------------------
-	-- Create CommandPost Shutdown Callback:
-	--------------------------------------------------------------------------------
-	hs.shuttingDown = false
-	config.shutdownCallback:new("cp", function()
-		hs.shuttingDown = true
-		if console.hswindow() then
-			config.set("errorLogOpenOnClose", true)
-		else
-			config.set("errorLogOpenOnClose", false)
-		end
-		console.clearConsole()
-	end)
-
-	--------------------------------------------------------------------------------
 	-- Setup Global Shutdown Callback:
 	--------------------------------------------------------------------------------
 	hs.shutdownCallback = function()
@@ -183,12 +169,49 @@ function mod.init()
 	end
 
 	--------------------------------------------------------------------------------
+	-- Setup Global Dock Icon Click Callback:
+	--------------------------------------------------------------------------------
+	hs.dockIconClickCallback = function(value)
+		local dockIconClickCallbacks = config.dockIconClickCallback:getAll()
+		if dockIconClickCallbacks and type(dockIconClickCallbacks) == "table" then
+			for i, v in pairs(dockIconClickCallbacks) do
+				local fn = v:callbackFn()
+				if fn and type(fn) == "function" then
+					fn(value)
+				end
+		    end
+		end
+	end
+
+	--------------------------------------------------------------------------------
+	-- Create CommandPost Dock Icon Click Callback:
+	--------------------------------------------------------------------------------
+	config.dockIconClickCallback:new("cp", function()
+		if debugMode then hs.openConsole() end
+	end)
+
+	--------------------------------------------------------------------------------
+	-- Create CommandPost Shutdown Callback:
+	--------------------------------------------------------------------------------
+	hs.shuttingDown = false
+	config.shutdownCallback:new("cp", function()
+		hs.shuttingDown = true
+		if console.hswindow() then
+			config.set("errorLogOpenOnClose", true)
+		else
+			config.set("errorLogOpenOnClose", false)
+		end
+		console.clearConsole()
+	end)
+
+	--------------------------------------------------------------------------------
 	-- Check Versions & Language:
 	--------------------------------------------------------------------------------
-	local fcpVersion    		= fcp:getVersion()
-	local fcpPath				= fcp:getPath()
-	local osVersion    			= tools.macOSVersion()
-	local fcpLanguage   		= fcp:getCurrentLanguage()
+	local fcpVersion    		= fcp:getVersion() or "Unknown"
+	local fcpPath				= fcp:getPath() or "Unknown"
+	local osVersion    			= tools.macOSVersion() or "Unknown"
+	local fcpLanguage   		= fcp:getCurrentLanguage() or "Unknown"
+	local debugModeStatus		= debugMode or false
 
 	--------------------------------------------------------------------------------
 	-- Clear The Console:
@@ -224,7 +247,7 @@ function mod.init()
 	if fcpPath ~= nil then						writeToConsoleDebug("Final Cut Pro Path:             " .. tostring(fcpPath),                 	true) end
 	if fcpVersion ~= nil then                   writeToConsoleDebug("Final Cut Pro Version:          " .. tostring(fcpVersion),                  true) end
 	if fcpLanguage ~= nil then                  writeToConsoleDebug("Final Cut Pro Language:         " .. tostring(fcpLanguage),                 true) end
-												writeToConsoleDebug("Developer Mode:                 " .. tostring(debugMode))
+												writeToConsoleDebug("Developer Mode:                 " .. tostring(debugModeStatus))
 	console.printStyledtext("")
 
 	--------------------------------------------------------------------------------


### PR DESCRIPTION
* Added dockIconClickCallback
* Clicking on the CommandPost Dock icon now only opens the Error
Console when Developer Mode is enabled
* Closes #491