### PR TITLE
#505

### DIFF
--- a/src/extensions/cp/dialog/init.lua
+++ b/src/extensions/cp/dialog/init.lua
@@ -25,16 +25,23 @@ local inspect									= require("hs.inspect")
 local osascript									= require("hs.osascript")
 local screen									= require("hs.screen")
 local sharing									= require("hs.sharing")
-local inspect									= require("hs.inspect")
+local window									= require("hs.window")
 
+local config									= require("cp.config")
 local fcp										= require("cp.finalcutpro")
 local tools										= require("cp.tools")
-local config									= require("cp.config")
 
 --------------------------------------------------------------------------------
 -- COMMON APPLESCRIPT:
 --------------------------------------------------------------------------------
 local function as(appleScript)
+
+	local originalFrontmostWindow = window.frontmostWindow()
+
+	local whichBundleID = hs.processInfo["bundleID"]
+	if originalFrontmostWindow and originalFrontmostWindow:application():bundleID() == fcp.BUNDLE_ID then
+		whichBundleID = fcp.BUNDLE_ID
+	end
 
 	local appleScriptStart = [[
 		set yesButton to "]] .. i18n("yes") .. [["
@@ -48,11 +55,7 @@ local function as(appleScript)
 		set errorMessageStart to "]] .. i18n("commonErrorMessageStart") .. [[\n\n"
 		set errorMessageEnd to "\n\n]] .. i18n("commonErrorMessageEnd") .. [["
 
-		set finalCutProBundleID to "]] .. fcp:getBundleID() .. [["
-
-		set frontmostApplication to (path to frontmost application as text)
-		tell application frontmostApplication
-			activate
+		tell application id "]] .. whichBundleID .. [["
 	]]
 
 	local appleScriptEnd = [[
@@ -60,6 +63,11 @@ local function as(appleScript)
 	]]
 
 	local _, result = osascript.applescript(appleScriptStart .. appleScript .. appleScriptEnd)
+
+	if originalFrontmostWindow and whichBundleID == hs.processInfo["bundleID"] then
+		originalFrontmostWindow:focus()
+	end
+
 	return result
 
 end


### PR DESCRIPTION
* Changed the way `cp.dialog` works. Now if Final Cut Pro is frontmost,
then the alerts will be inserted into Final Cut Pro, otherwise it will
display as if it’s from CommandPost (as opposed to whatever app was
previously frontmost).