### PR TITLE
#512 - Select Color Board Puck Shortcuts Don't Work

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.3.3.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.3.3.lua
@@ -1,4 +1,25 @@
 return {
+	ColorBoard = {
+		ColorSatExp				= "_NS:279",
+
+		ColorReset				= "_NS:269",
+		ColorGlobalPuck			= "_NS:259",
+		ColorShadowsPuck		= "_NS:254",
+		ColorMidtonesPuck		= "_NS:249",
+		ColorHighlightsPuck		= "_NS:239",
+
+		SatReset				= "_NS:532",
+		SatGlobalPuck			= "_NS:523",
+		SatShadowsPuck			= "_NS:518",
+		SatMidtonesPuck			= "_NS:513",
+		SatHighlightsPuck		= "_NS:508",
+
+		ExpReset				= "_NS:406",
+		ExpGlobalPuck			= "_NS:397",
+		ExpShadowsPuck			= "_NS:392",
+		ExpMidtonesPuck			= "_NS:387",
+		ExpHighlightsPuck		= "_NS:382",
+	},
 	EffectsBrowser = {
 		Contents				= "_NS:52",
 	},


### PR DESCRIPTION
* Updated _NS values for Color Board in 10.3.3
* Closes #512