### PR TITLE
Fixes Issues #524 #521 #522

### DIFF
--- a/src/plugins/core/preferences/manager/init.lua
+++ b/src/plugins/core/preferences/manager/init.lua
@@ -48,7 +48,7 @@ mod._handlers			= {}
 --------------------------------------------------------------------------------
 -- SETTINGS:
 --------------------------------------------------------------------------------
-mod.defaultWindowStyle	= {"titled", "closable", "nonactivating", "resizable"}
+mod.defaultWindowStyle	= {"titled", "closable", "nonactivating"}
 mod.defaultWidth 		= 524
 mod.defaultHeight 		= 338
 mod.defaultTitle 		= i18n("preferences")
@@ -156,7 +156,7 @@ function mod.init()
 		:allowNewWindows(false)
 		:allowTextEntry(true)
 		:windowTitle(mod.defaultTitle)
-		:toolbar(mod.toolbar)
+		:attachedToolbar(mod.toolbar)
 
 	return mod
 end
@@ -216,7 +216,7 @@ function mod.selectPanel(id)
 		log.df("Size: %s", hs.inspect(mod.webview:hswindow():size()))
 	end
 	--]]
-	
+
 	if not mod.webview then
 		return
 	end
@@ -229,7 +229,7 @@ function mod.selectPanel(id)
 		-- Resize Panel:
 		--------------------------------------------------------------------------------
 		if v.id == id and v.height and mod.webview:hswindow() then
-			mod.webview:hswindow():setSize({w = mod.defaultWidth, h = v.height })
+			mod.webview:size({w = mod.defaultWidth, h = v.height })
 		end
 
 		local style = v.id == id and "block" or "none"

--- a/src/plugins/finalcutpro/hacks/shortcuts/init.lua
+++ b/src/plugins/finalcutpro/hacks/shortcuts/init.lua
@@ -295,33 +295,7 @@ end
 --- Returns:
 ---  * `true` if Hacks Shortcuts are enabled otherwise `false`
 function mod.enabled()
-
-	if fcp:application() then
-		local searchString = "<key>cpToggleMovingMarkers</key>"
-		local filePathNSProCommands = fcp:getPath() .. "/Contents/Resources/NSProCommands.plist"
-
-		if tools.doesFileExist(filePathNSProCommands) then
-
-			local file = io.open(filePathNSProCommands, "r")
-			if file then
-
-				io.input(file)
-				local fileContents = io.read("*a")
-				io.close(file)
-
-				local result = string.find(fileContents, searchString) ~= nil
-
-				config.set("enableHacksShortcutsInFinalCutPro", result)
-				return result
-
-			end
-		end
-
-		log.ef("Could not find NSProCommands.plist. This shouldn't ever happen.")
-		config.set("enableHacksShortcutsInFinalCutPro", false)
-	end
-	return false
-
+	return mod.shortcuts.hacksShortcutsEnabled()
 end
 
 --- plugins.finalcutpro.hacks.shortcuts.setEditable() -> none
@@ -468,7 +442,7 @@ function plugin.init(deps, env)
 	mod.globalCmds 	= deps.globalCmds
 	mod.fcpxCmds	= deps.fcpxCmds
 
-	mod._shortcuts	= deps.shortcuts
+	mod.shortcuts	= deps.shortcuts
 
 	mod.commandSetsPath = env:pathToAbsolute("/") .. "/commandsets/"
 
@@ -499,9 +473,9 @@ function plugin.init(deps, env)
 				label		= i18n("enableHacksShortcuts"),
 				onchange	= function()
 					mod.toggleEditable()
-					mod._shortcuts.updateCustomShortcutsVisibility()
+					mod.shortcuts.updateCustomShortcutsVisibility()
 				end,
-				checked=mod.isEditable
+				checked=mod.enabled
 			}
 		)
 	end


### PR DESCRIPTION
* Fixed the way cp.apple.finalcutpro determines the currently active
instance of Final Cut Pro
* Fixed Hacks Shortcuts Detection
* Preferences Window is now not able to be resized by user
* Updated Preferences Toolbar to work with latest CommandPost-App
* Closes #524
* Closes #521
* Closes #522