### PR TITLE
#561

### DIFF
--- a/src/plugins/finalcutpro/commands/init.lua
+++ b/src/plugins/finalcutpro/commands/init.lua
@@ -40,7 +40,7 @@ function plugin.init()
 	--------------------------------------------------------------------------------
 	cmds:watch({
 		activate	= function()
-			log.df("Final Cut Pro Activated by Commands Plugin")
+			--log.df("Final Cut Pro Activated by Commands Plugin")
 			fcp:launch()
 		end,
 	})

--- a/src/plugins/finalcutpro/hacks/shortcuts/init.lua
+++ b/src/plugins/finalcutpro/hacks/shortcuts/init.lua
@@ -472,6 +472,15 @@ function plugin.init(deps, env)
 			commands.group(v):enable()
 		end
 
+		--------------------------------------------------------------------------------
+		-- Check to see if Final Cut Pro is running:
+		--------------------------------------------------------------------------------
+		if fcp:isFrontmost() then
+			mod.fcpxCmds:enable()
+		else
+			mod.fcpxCmds:disable()
+		end
+
 	end)
 
 	--------------------------------------------------------------------------------


### PR DESCRIPTION
- Final Cut Pro shortcuts are now only enabled when CommandPost starts
if Final Cut Pro is frontmost.
- Closes #561