### PR TITLE
#722

### DIFF
--- a/src/extensions/cp/idle/init.lua
+++ b/src/extensions/cp/idle/init.lua
@@ -1,0 +1,73 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+--                           I D L E   Q U E U E                              --
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+--- === cp.idle ===
+---
+--- This library allows tasks to be queue for execution when the computer has
+--- been idle for a specified amount of time. 'Idle' is defined as no keyboard
+--- or mouse movement.
+---
+local log						= require("hs.logger").new("idle")
+
+local host						= require("hs.host")
+local timer						= require("hs.timer")
+
+local insert, remove			= table.insert, table.remove
+
+local mod = {}
+local queue = {}
+local checkTimer = nil
+
+local function checkQueue()
+	if #queue == 0 and checkTimer:running() then
+		checkTimer:stop()
+	else
+		local newQueue = {}
+		local count = #queue
+		for _,item in ipairs(queue) do
+			-- we check idle time on every queued item
+			local idleTime = host.idleTime()
+			if item.seconds < idleTime then
+				-- run the action, checking for errors
+				local ok, result = xpcall(item.action, debug.traceback)
+				if not ok then
+					log.ef("Error while processing idle queue:\n%s", result)
+					if item.retryOnError then
+						insert(newQueue, item)
+					end
+				end
+			else
+				insert(newQueue, item)
+			end
+		end
+
+		queue = newQueue
+	end
+end
+
+checkTimer = timer.new(1, checkQueue, true)
+
+--- cp.idle.queue(idleSeconds, actionFn[, retryOnError]) -> nothing
+--- Function
+--- Adds an action to the idle queue, which will be run after the the computer has been idle
+--- for at least the specified number of seconds. It may be longer, if other items are on the queue,
+--- or if other tasks are running in the application.
+---
+--- Parameters:
+--- * `idleSeconds`		- The number of seconds of idle time must have elapsed run the action
+--- * `actionFn`		- The function to execute
+--- * `retryOnError`	- Optional. If set to `true`, the action will try running again if there is an error.
+---
+--- Returns:
+--- * Nothing
+function mod.queue(idleSeconds, actionFn, retryOnError)
+	insert(queue, {seconds = idleSeconds, action = actionFn, retryOnError = retryOnError})
+	if not checkTimer:running() then
+		checkTimer:start()
+	end
+end
+
+return mod

--- a/src/plugins/finalcutpro/action/manager/activator.lua
+++ b/src/plugins/finalcutpro/action/manager/activator.lua
@@ -179,9 +179,23 @@ function activator.new(id, manager)
 	--- If `true` (the default), the activator can be configured by right-clicking on the main chooser.
 	o.configurable = config.prop(prefix .. "configurable", true):bind(o)
 
-	if fcp:isRunning() then timer.doAfter(3, function() o:_findChoices() end) end
-
 	return o
+end
+
+--- plugins.finalcutpro.action.activator:preloadChoices([afterSeconds]) -> activator
+--- Method
+--- Indicates the activator should preload the choices after a number of seconds.
+--- Defaults to 20 seconds if no value is provided.
+---
+--- Parameters:
+--- * `afterSeconds`	- The number of seconds to wait before preloading.
+---
+--- Returns:
+--- * The activator.
+function activator.mt:preloadChoices(afterSeconds)
+	afterSeconds = afterSeconds or 20
+	timer.doAfter(20, function() o:_findChoices() end)
+	return self
 end
 
 --- plugins.finalcutpro.action.activator:id() -> string

--- a/src/plugins/finalcutpro/action/manager/activator.lua
+++ b/src/plugins/finalcutpro/action/manager/activator.lua
@@ -37,6 +37,7 @@ local screen					= require("hs.screen")
 local timer						= require("hs.timer")
 local application				= require("hs.application")
 local fcp						= require("cp.apple.finalcutpro")
+local idle						= require("cp.idle")
 
 local setmetatable				= setmetatable
 local sort, insert				= table.sort, table.insert
@@ -185,7 +186,7 @@ end
 --- plugins.finalcutpro.action.activator:preloadChoices([afterSeconds]) -> activator
 --- Method
 --- Indicates the activator should preload the choices after a number of seconds.
---- Defaults to 20 seconds if no value is provided.
+--- Defaults to 10 seconds if no value is provided.
 ---
 --- Parameters:
 --- * `afterSeconds`	- The number of seconds to wait before preloading.
@@ -193,8 +194,8 @@ end
 --- Returns:
 --- * The activator.
 function activator.mt:preloadChoices(afterSeconds)
-	afterSeconds = afterSeconds or 20
-	timer.doAfter(20, function() o:_findChoices() end)
+	afterSeconds = afterSeconds or 10
+	idle.queue(10, function() self:_findChoices() end)
 	return self
 end
 

--- a/src/plugins/finalcutpro/console/init.lua
+++ b/src/plugins/finalcutpro/console/init.lua
@@ -69,7 +69,7 @@ mod.lastQueryValue = config.prop("consoleLastQueryValue", "")
 function mod.init(actionmanager)
 	mod.actionmanager = mod.actionmanager or actionmanager
 	mod.activator = actionmanager.getActivator("finalcutpro.console")
-		:preloadChoices(20)
+		:preloadChoices()
 end
 
 --------------------------------------------------------------------------------

--- a/src/plugins/finalcutpro/console/init.lua
+++ b/src/plugins/finalcutpro/console/init.lua
@@ -69,6 +69,7 @@ mod.lastQueryValue = config.prop("consoleLastQueryValue", "")
 function mod.init(actionmanager)
 	mod.actionmanager = mod.actionmanager or actionmanager
 	mod.activator = actionmanager.getActivator("finalcutpro.console")
+		:preloadChoices(20)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
* Moved 'preloadChoices' to an optional method
* Default to 20 seconds after the CP starts to preload Console choices.