### PR TITLE
Updated Title & Generator Actions

### DIFF
--- a/src/plugins/finalcutpro/action/manager/activator.lua
+++ b/src/plugins/finalcutpro/action/manager/activator.lua
@@ -186,7 +186,7 @@ end
 --- plugins.finalcutpro.action.activator:preloadChoices([afterSeconds]) -> activator
 --- Method
 --- Indicates the activator should preload the choices after a number of seconds.
---- Defaults to 10 seconds if no value is provided.
+--- Defaults to 6 seconds if no value is provided.
 ---
 --- Parameters:
 --- * `afterSeconds`	- The number of seconds to wait before preloading.
@@ -194,8 +194,11 @@ end
 --- Returns:
 --- * The activator.
 function activator.mt:preloadChoices(afterSeconds)
-	afterSeconds = afterSeconds or 10
-	idle.queue(10, function() self:_findChoices() end)
+	afterSeconds = afterSeconds or 6
+	idle.queue(afterSeconds, function()
+		log.df("Preloading Choices for Chooser...")
+		self:_findChoices() 
+	end)
 	return self
 end
 
@@ -625,17 +628,14 @@ activator.reducedTransparency = prop.new(function()
 end)
 
 local function initChooser(executeFn, rightClickFn, choicesFn, searchSubText)
-	local c = chooser.new(executeFn)
-	:bgDark(true)
-	:rightClickCallback(rightClickFn)
-	:choices(choicesFn)
-	:searchSubText(searchSubText)
-
 	local color = activator.reducedTransparency() and nil or drawing.color.x11.snow
-	c:fgColor(color):subTextColor(color)
-
-	c:refreshChoicesCallback()
-
+	local c = chooser.new(executeFn)
+		:bgDark(true)
+		:rightClickCallback(rightClickFn)
+		:choices(choicesFn)
+		:searchSubText(searchSubText)
+		:fgColor(color):subTextColor(color)
+		:refreshChoicesCallback()
 	return c
 end
 
@@ -691,6 +691,9 @@ function activator.mt:show()
 	--------------------------------------------------------------------------------
 	self:checkReducedTransparency()
 
+	--------------------------------------------------------------------------------
+	-- Refresh Chooser:
+	--------------------------------------------------------------------------------
 	self:refreshChooser()
 
 	--------------------------------------------------------------------------------

--- a/src/plugins/finalcutpro/console/init.lua
+++ b/src/plugins/finalcutpro/console/init.lua
@@ -46,28 +46,13 @@ local PRIORITY = 11000
 --------------------------------------------------------------------------------
 local mod = {}
 
-mod.mainChooser			= nil 		-- the actual hs.chooser
-mod.hiderChooser		= nil		-- the chooser for hiding/unhiding items.
-mod.activeChooser		= nil		-- the currently-visible chooser.
-mod.active 				= false		-- is the Hacks Console Active?
-
 mod.enabled = config.prop("consoleEnabled", true)
-
-mod.reducedTransparency = prop.new(function()
-	return screen.accessibilitySettings()["ReduceTransparency"]
-end)
-
-mod.searchSubtext = config.prop("searchSubtext", true)
-
-mod.lastQueryRemembered = config.prop("consoleLastQueryRemembered", true)
-
-mod.lastQueryValue = config.prop("consoleLastQueryValue", "")
 
 --------------------------------------------------------------------------------
 -- LOAD CONSOLE:
 --------------------------------------------------------------------------------
 function mod.init(actionmanager)
-	mod.actionmanager = mod.actionmanager or actionmanager
+	mod.actionmanager = actionmanager
 	mod.activator = actionmanager.getActivator("finalcutpro.console")
 		:preloadChoices()
 end
@@ -76,14 +61,18 @@ end
 -- REFRESH CONSOLE CHOICES:
 --------------------------------------------------------------------------------
 function mod.refresh()
-	mod.activator:refresh()
+	if mod.activator and mod.enabled() then 
+		mod.activator:refresh()
+	end
 end
 
 --------------------------------------------------------------------------------
 -- SHOW CONSOLE:
 --------------------------------------------------------------------------------
 function mod.show()
-	mod.activator:show()
+	if mod.activator and mod.enabled() then 
+		mod.activator:show()
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -103,22 +92,26 @@ local plugin = {
 
 function plugin.init(deps)
 
+	--------------------------------------------------------------------------------
+	-- Initialise Module:
+	--------------------------------------------------------------------------------
 	mod.init(deps.actionmanager)
 
-	-- Add the command trigger
+	--------------------------------------------------------------------------------
+	-- Add the command trigger:
+	--------------------------------------------------------------------------------
 	deps.fcpxCmds:add("cpConsole")
 		:groupedBy("commandPost")
 		:whenActivated(function() mod.show() end)
 		:activatedBy():ctrl("space")
 
-	-- Add the 'Console' menu items
-	--[[
+	--------------------------------------------------------------------------------
+	-- Add the 'Console' menu item:
+	--------------------------------------------------------------------------------
 	local menu = deps.tools:addMenu(PRIORITY, function() return i18n("console") end)
-
 	menu:addItem(1000, function()
 		return { title = i18n("enableConsole"),	fn = function() mod.enabled:toggle() end, checked = mod.enabled() }
 	end)
-	--]]
 
 	return mod
 

--- a/src/plugins/finalcutpro/timeline/audioeffects.lua
+++ b/src/plugins/finalcutpro/timeline/audioeffects.lua
@@ -4,9 +4,9 @@
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
---- === plugins.finalcutpro.timeline.videoeffects ===
+--- === plugins.finalcutpro.timeline.audioeffects ===
 ---
---- Controls Final Cut Pro's Effects.
+--- Controls Final Cut Pro's Audio Effects.
 
 --------------------------------------------------------------------------------
 --
@@ -27,16 +27,38 @@ local dialog			= require("cp.dialog")
 --------------------------------------------------------------------------------
 local mod = {}
 
+--- plugins.finalcutpro.timeline.audioeffects.init() -> none
+--- Function
+--- Initialise the Module
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The Module
 function mod.init(touchbar)
 	mod.touchbar = touchbar
 	return mod
 end
 
---------------------------------------------------------------------------------
--- SHORTCUT PRESSED:
--- The shortcut may be a number from 1-5, in which case the 'assigned' shortcut is applied,
--- or it may be the name of the effect to apply in the current FCPX language.
---------------------------------------------------------------------------------
+--- plugins.finalcutpro.timeline.audioeffects(action) -> boolean
+--- Function
+--- Applies the specified action as a audio effect. Expects action to be a table with the following structure:
+---
+--- ```lua
+--- { name = "XXX", category = "YYY", theme = "ZZZ" }
+--- ```
+---
+--- ...where `"XXX"`, `"YYY"` and `"ZZZ"` are in the current FCPX language. The `category` and `theme` are optional,
+--- but if they are known it's recommended to use them, or it will simply execute the first matching audio effect with that name.
+---
+--- Alternatively, you can also supply a string with just the name.
+---
+--- Parameters:
+--- * `action`		- A table with the name/category/theme for the audio effect to apply, or a string with just the name.
+---
+--- Returns:
+--- * `true` if a matching audio effect was found and applied to the timeline.
 function mod.apply(action)
 
 	--------------------------------------------------------------------------------
@@ -68,6 +90,9 @@ function mod.apply(action)
 	local effectsShowing = effects:isShowing()
 	local effectsLayout = effects:saveLayout()
 
+	--------------------------------------------------------------------------------
+	-- Make sure FCPX is at the front.
+	--------------------------------------------------------------------------------
 	fcp:launch()
 
 	--------------------------------------------------------------------------------
@@ -78,7 +103,11 @@ function mod.apply(action)
 	--------------------------------------------------------------------------------
 	-- Make sure "Installed Effects" is selected:
 	--------------------------------------------------------------------------------
-	effects:showInstalledEffects()
+	local group = effects:group():UI()		
+	local groupValue = group:attributeValue("AXValue")	
+	if groupValue ~= fcp:string("PEMediaBrowserInstalledEffectsMenuItem") then
+		effects:showInstalledEffects()
+	end
 
 	--------------------------------------------------------------------------------
 	-- Make sure there's nothing in the search box:
@@ -88,7 +117,11 @@ function mod.apply(action)
 	--------------------------------------------------------------------------------
 	-- Click 'All':
 	--------------------------------------------------------------------------------
-	effects:showAllTransitions()
+	if category then
+		transitions:showTransitionsCategory(category)
+	else
+		transitions:showAllTransitions()
+	end
 
 	--------------------------------------------------------------------------------
 	-- Perform Search:

--- a/src/plugins/finalcutpro/timeline/transitions.lua
+++ b/src/plugins/finalcutpro/timeline/transitions.lua
@@ -27,16 +27,38 @@ local fcp				= require("cp.apple.finalcutpro")
 --------------------------------------------------------------------------------
 local mod = {}
 
+--- plugins.finalcutpro.timeline.transitions.init() -> none
+--- Function
+--- Initialise the Module
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The Module
 function mod.init(touchbar)
 	mod.touchbar = touchbar
 	return mod
 end
 
---------------------------------------------------------------------------------
--- TRANSITIONS SHORTCUT PRESSED:
--- The shortcut may be a number from 1-5, in which case the 'assigned' shortcut is applied,
--- or it may be the name of the transition to apply in the current FCPX language.
---------------------------------------------------------------------------------
+--- plugins.finalcutpro.timeline.transitions(action) -> boolean
+--- Function
+--- Applies the specified action as a transition. Expects action to be a table with the following structure:
+---
+--- ```lua
+--- { name = "XXX", category = "YYY", theme = "ZZZ" }
+--- ```
+---
+--- ...where `"XXX"`, `"YYY"` and `"ZZZ"` are in the current FCPX language. The `category` and `theme` are optional,
+--- but if they are known it's recommended to use them, or it will simply execute the first matching transition with that name.
+---
+--- Alternatively, you can also supply a string with just the name.
+---
+--- Parameters:
+--- * `action`		- A table with the name/category/theme for the transition to apply, or a string with just the name.
+---
+--- Returns:
+--- * `true` if a matching transition was found and applied to the timeline.
 function mod.apply(action)
 
 	--------------------------------------------------------------------------------
@@ -67,7 +89,12 @@ function mod.apply(action)
 	local transitions = fcp:transitions()
 	local transitionsShowing = transitions:isShowing()
 	local transitionsLayout = transitions:saveLayout()
-
+	
+	--------------------------------------------------------------------------------
+	-- Make sure FCPX is at the front.
+	--------------------------------------------------------------------------------
+	fcp:launch()
+	
 	--------------------------------------------------------------------------------
 	-- Make sure panel is open:
 	--------------------------------------------------------------------------------
@@ -76,7 +103,11 @@ function mod.apply(action)
 	--------------------------------------------------------------------------------
 	-- Make sure "Installed Transitions" is selected:
 	--------------------------------------------------------------------------------
-	transitions:showInstalledTransitions()
+	local group = transitions:group():UI()		
+	local groupValue = group:attributeValue("AXValue")	
+	if groupValue ~= fcp:string("PEMediaBrowserInstalledTransitionsMenuItem") then
+		transitions:showInstalledTransitions()
+	end
 
 	--------------------------------------------------------------------------------
 	-- Make sure there's nothing in the search box:

--- a/src/plugins/finalcutpro/timeline/videoeffects.lua
+++ b/src/plugins/finalcutpro/timeline/videoeffects.lua
@@ -6,7 +6,7 @@
 
 --- === plugins.finalcutpro.timeline.videoeffects ===
 ---
---- Controls Final Cut Pro's Effects.
+--- Controls Final Cut Pro's Video Effects.
 
 --------------------------------------------------------------------------------
 --
@@ -27,16 +27,38 @@ local dialog			= require("cp.dialog")
 --------------------------------------------------------------------------------
 local mod = {}
 
+--- plugins.finalcutpro.timeline.videoeffects.init() -> none
+--- Function
+--- Initialise the Module
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The Module
 function mod.init(touchbar)
 	mod.touchbar = touchbar
 	return mod
 end
 
---------------------------------------------------------------------------------
--- SHORTCUT PRESSED:
--- The shortcut may be a number from 1-5, in which case the 'assigned' shortcut is applied,
--- or it may be the name of the effect to apply in the current FCPX language.
---------------------------------------------------------------------------------
+--- plugins.finalcutpro.timeline.videoeffects(action) -> boolean
+--- Function
+--- Applies the specified action as a video effect. Expects action to be a table with the following structure:
+---
+--- ```lua
+--- { name = "XXX", category = "YYY", theme = "ZZZ" }
+--- ```
+---
+--- ...where `"XXX"`, `"YYY"` and `"ZZZ"` are in the current FCPX language. The `category` and `theme` are optional,
+--- but if they are known it's recommended to use them, or it will simply execute the first matching video effect with that name.
+---
+--- Alternatively, you can also supply a string with just the name.
+---
+--- Parameters:
+--- * `action`		- A table with the name/category/theme for the video effect to apply, or a string with just the name.
+---
+--- Returns:
+--- * `true` if a matching video effect was found and applied to the timeline.
 function mod.apply(action)
 
 	--------------------------------------------------------------------------------
@@ -68,17 +90,24 @@ function mod.apply(action)
 	local effectsShowing = effects:isShowing()
 	local effectsLayout = effects:saveLayout()
 
+	--------------------------------------------------------------------------------
+	-- Make sure FCPX is at the front.
+	--------------------------------------------------------------------------------
 	fcp:launch()
 
 	--------------------------------------------------------------------------------
 	-- Make sure panel is open:
 	--------------------------------------------------------------------------------
-	effects:show()
-
+	effects:show()	
+	
 	--------------------------------------------------------------------------------
 	-- Make sure "Installed Effects" is selected:
 	--------------------------------------------------------------------------------
-	effects:showInstalledEffects()
+	local group = effects:group():UI()		
+	local groupValue = group:attributeValue("AXValue")	
+	if groupValue ~= fcp:string("PEMediaBrowserInstalledEffectsMenuItem") then
+		effects:showInstalledEffects()
+	end
 
 	--------------------------------------------------------------------------------
 	-- Make sure there's nothing in the search box:
@@ -88,7 +117,11 @@ function mod.apply(action)
 	--------------------------------------------------------------------------------
 	-- Click 'All':
 	--------------------------------------------------------------------------------
-	effects:showAllTransitions()
+	if category then
+		transitions:showTransitionsCategory(category)
+	else
+		transitions:showAllTransitions()
+	end
 
 	--------------------------------------------------------------------------------
 	-- Perform Search:


### PR DESCRIPTION
- Updated the way Titles & Generators are added to the timeline
- Added caching for Titles & Generators
- Only click “Installed Transitions/Effects” if needed to speed things
up
- Clean up Console Code
- Closes #757