### PR TITLE
Feature/issue 869 color inspector

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.3.2.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.3.2.lua
@@ -85,7 +85,6 @@ return {
 	},
 	TimelineAppearance = {
 		Toggle								= "_NS:154",
-		ClipHeight							= "_NS:104",
 		ZoomAmount							= "_NS:56",
 	},
 	TimelineToolbar = {

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.3.2.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.3.2.lua
@@ -64,9 +64,6 @@ return {
 		NothingToInspect					= "_NS:53",
 	},
 	LibrariesBrowser = {
-		ToggleViewMode						= "_NS:82",
-		AppearanceAndFiltering				= "_NS:68",
-		SearchToggle						= "_NS:92",
 		Search								= "_NS:34",
 		Sidebar								= "_NS:9",
 	},

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.3.3.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.3.3.lua
@@ -40,7 +40,6 @@ return {
 		Content								= "_NS:18",
 	},
 	TimelineAppearance = {
-		ClipHeight							= "_NS:85",
 		ZoomAmount							= "_NS:35",
 	},
 }

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
@@ -8,7 +8,6 @@ return {
 	EffectsBrowser = {
 		Sidebar								= "_NS:90",
 		Contents							= "_NS:53",
-		Sidebar								= "_NS:90",
 	},
 	LibrariesBrowser = {
 		ToggleViewMode						= "_NS:89",

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
@@ -10,9 +10,6 @@ return {
 		Contents							= "_NS:53",
 	},
 	LibrariesBrowser = {
-		ToggleViewMode						= "_NS:89",
-		AppearanceAndFiltering				= "_NS:75",
-		SearchToggle						= "_NS:99",
 		FilterToggle						= "_NS:9",
 	},
 	ColorBoard = {

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
@@ -15,9 +15,6 @@ return {
 		SearchToggle						= "_NS:99",
 		FilterToggle						= "_NS:9",
 	},
-	TimelineAppearance = {
-		ClipHeight							= "_NS:62",
-	},
 	ColorBoard = {
 		ColorBoard							= "Color Inspector",
 

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
@@ -6,6 +6,7 @@ return {
 		PitchShifter						= "Pitch Shifter",
 	},
 	EffectsBrowser = {
+		Sidebar								= "_NS:90",
 		Contents							= "_NS:53",
 	},
 	TimelineAppearance = {

--- a/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
+++ b/src/extensions/cp/apple/finalcutpro/ids/v/10.4.0.lua
@@ -10,6 +10,12 @@ return {
 		Contents							= "_NS:53",
 		Sidebar								= "_NS:90",
 	},
+	LibrariesBrowser = {
+		ToggleViewMode						= "_NS:89",
+		AppearanceAndFiltering				= "_NS:75",
+		SearchToggle						= "_NS:99",
+		FilterToggle						= "_NS:9",
+	},
 	TimelineAppearance = {
 		ClipHeight							= "_NS:62",
 	},

--- a/src/extensions/cp/apple/finalcutpro/main/Inspector.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/Inspector.lua
@@ -13,7 +13,7 @@
 -- EXTENSIONS:
 --
 --------------------------------------------------------------------------------
-local log								= require("hs.logger").new("timline")
+local log								= require("hs.logger").new("inspector")
 local inspect							= require("hs.inspect")
 
 local just								= require("cp.just")

--- a/src/extensions/cp/apple/finalcutpro/main/LibrariesBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/LibrariesBrowser.lua
@@ -143,7 +143,7 @@ end
 function Libraries:toggleViewMode()
 	if not self._viewMode then
 		self._viewMode = Button:new(self, function()
-			return axutils.childWithID(self:UI(), id "ToggleViewMode")
+			return axutils.childFromRight(axutils.childrenWithRole(self:UI(), "AXButton"), 3)
 		end)
 	end
 	return self._viewMode
@@ -153,7 +153,7 @@ end
 function Libraries:appearanceAndFiltering()
 	if not self._appearanceAndFiltering then
 		self._appearanceAndFiltering = Button:new(self, function()
-			return axutils.childWithID(self:UI(), id "AppearanceAndFiltering")
+			return axutils.childFromRight(axutils.childrenWithRole(self:UI(), "AXButton"), 2)
 		end)
 	end
 	return self._appearanceAndFiltering
@@ -163,7 +163,7 @@ end
 function Libraries:searchToggle()
 	if not self._searchToggle then
 		self._searchToggle = Button:new(self, function()
-			return axutils.childWithID(self:UI(), id "SearchToggle")
+			return axutils.childFromRight(axutils.childrenWithRole(self:UI(), "AXButton"), 1)
 		end)
 	end
 	return self._searchToggle

--- a/src/extensions/cp/apple/finalcutpro/main/TimelineAppearance.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/TimelineAppearance.lua
@@ -114,7 +114,9 @@ end
 function TimelineAppearance:clipHeight()
 	if not self._clipHeight then
 		self._clipHeight = Slider:new(self, function()
-			return axutils.childWithID(self:UI(), id "ClipHeight")
+			return axutils.childMatching(self:UI(), function(e)
+				return e:attributeValue("AXRole") == "AXSlider" and e:attributeValue("AXMaxValue") == 210
+			end)
 		end)
 	end
 	return self._clipHeight

--- a/src/extensions/cp/ids/init.lua
+++ b/src/extensions/cp/ids/init.lua
@@ -82,7 +82,7 @@ function mod.mt:currentVersion()
 end
 
 function mod.mt:versions()
-	if not mod._versions then
+	if not self._versions then
 		local versions = {}
 		local path = fs.pathToAbsolute(self.path)
 		for file in fs.dir(path) do
@@ -95,9 +95,9 @@ function mod.mt:versions()
 			end
 		end
 		table.sort(versions)
-		mod._versions = versions
+		self._versions = versions
 	end
-	return mod._versions
+	return self._versions
 end
 
 --- cp.ids:previousVersion([version]) -> semver

--- a/src/extensions/tests/init.lua
+++ b/src/extensions/tests/init.lua
@@ -4,6 +4,7 @@ return test.suite("cp"):with(
 	"tests.test_fcp",
 	"tests.test_fcpplugins",
 	"tests.test_html",
+	"tests.test_ids",
 	"tests.test_just",
 	"tests.test_localized",
 	"tests.test_matcher",

--- a/src/extensions/tests/test_fcp.lua
+++ b/src/extensions/tests/test_fcp.lua
@@ -172,9 +172,10 @@ return test.suite("cp.apple.finalcutpro"):with(
 		-- Check the search UI
 		ok(libraries:searchToggle():isShowing())
 		-- Show the search field if necessary
-		while not libraries:search():isShowing() or not libraries:filterToggle():isShowing() do
+		if not libraries:search():isShowing() or not libraries:filterToggle():isShowing() then
 			libraries:searchToggle():press()
 		end
+
 		ok(libraries:search():isShowing())
 		ok(libraries:filterToggle():isShowing())
 		-- turn it back off
@@ -369,7 +370,7 @@ return test.suite("cp.apple.finalcutpro"):with(
 
 	-- Quit FCPX and remove Test Library from Temporary Directory:
 	-- log.df("Quitting FCPX and deleting Test Library...")
-	fcp:quit()
-	fs.rmdir(temporaryDirectory)
+	-- fcp:quit()
+	-- fs.rmdir(temporaryDirectory)
 
 end)


### PR DESCRIPTION
Fixed some issues with _NS:ID values in FCPX 10.4 and utilised the `cp.ids` API.