### PR TITLE
#1003

### DIFF
--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -588,7 +588,7 @@ end
 --- Returns:
 ---  * `true` if the directory exists otherwise `false`
 function tools.doesDirectoryExist(path)
-	if path then
+	if path and type(path) == "string" then
 	    local attr = fs.attributes(path)
     	return attr and attr.mode == 'directory'
     else
@@ -606,12 +606,15 @@ end
 --- Returns:
 ---  * `true` if the file exists otherwise `false`
 function tools.doesFileExist(path)
-	if path == nil then return nil end
-    local attr = fs.attributes(path)
-    if type(attr) == "table" then
-    	return true
+	if path and type(path) == "string" then
+        local attr = fs.attributes(path)
+        if type(attr) == "table" then
+            return true
+        else
+            return false
+        end
     else
-    	return false
+        return false
     end
 end
 

--- a/src/plugins/finalcutpro/text2speech/init.lua
+++ b/src/plugins/finalcutpro/text2speech/init.lua
@@ -503,8 +503,17 @@ function mod._completeProcess()
         --------------------------------------------------------------------------------
         clips = libraries:selectedClipsUI()
         if #clips ~= 1 then
-            dialog.displayErrorMessage("Wrong number of clips selected.")
-            return false
+            --------------------------------------------------------------------------------
+            -- Maybe Reveal in Browser failed, so let's try again.
+            --------------------------------------------------------------------------------
+            log.df("Reveal in Browser might have failed, so let's try again.")
+            fcp:selectMenu({"Window", "Go To", "Timeline"})
+            fcp:selectMenu({"File", "Reveal in Browser"})
+            clips = libraries:selectedClipsUI()
+            if #clips ~= 1 then
+                dialog.displayErrorMessage("Wrong number of clips selected.")
+                return false
+            end
         end
 
         --------------------------------------------------------------------------------
@@ -882,7 +891,7 @@ function mod.show()
         if not folderResult then
             return nil
         else
-            mod.path(result)
+            mod.path(folderResult)
         end
     end
 


### PR DESCRIPTION
- Fixed bug in Text to Speech `mod.path()`
- Added workaround if “Reveal in Browser” fails the first time
- Closes #1003