### PR TITLE
#1073 - Watch Folder File Extensions should be case insensitive

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/MenuBar.lua
+++ b/src/extensions/cp/apple/finalcutpro/MenuBar.lua
@@ -132,8 +132,11 @@ end
 ---    `require("cp.apple.finalcutpro"):menuBar():selectMenu({"View", "Browser", "Toggle Filmstrip/List View"})`
 function MenuBar:selectMenu(path)
     local menuItemUI = self:findMenuUI(path)
-    if menuItemUI then
-        return menuItemUI:performAction("AXPress")
+    if menuItemUI and menuItemUI:attributeValue("AXEnabled") then
+        local result = menuItemUI:performAction("AXPress")
+        if result then
+            return true
+        end
     end
     return false
 end

--- a/src/plugins/compressor/watchfolders/panels/media/init.lua
+++ b/src/plugins/compressor/watchfolders/panels/media/init.lua
@@ -624,7 +624,7 @@ function mod.watchFolderTriggered(files, eventFlags)
                 --------------------------------------------------------------------------------
                 -- Check Extensions:
                 --------------------------------------------------------------------------------
-                if ((fnutils.contains(allowedExtensions, file:sub(-3)) or fnutils.contains(allowedExtensions, file:sub(-4)))) and tools.doesFileExist(file) then
+                if ((fnutils.contains(allowedExtensions, string.lower(file:sub(-3))) or fnutils.contains(allowedExtensions, string.lower(file:sub(-4))))) and tools.doesFileExist(file) then
                     autoFiles[#autoFiles + 1] = file
                 end
             end

--- a/src/plugins/finalcutpro/watchfolders/panels/fcpxml/init.lua
+++ b/src/plugins/finalcutpro/watchfolders/panels/fcpxml/init.lua
@@ -526,7 +526,7 @@ function mod.watchFolderTriggered(files, eventFlags)
                 --------------------------------------------------------------------------------
                 -- Check Extensions:
                 --------------------------------------------------------------------------------
-                if file:sub(-7) == ".fcpxml" and tools.doesFileExist(file) then
+                if string.lower(file:sub(-7)) == ".fcpxml" and tools.doesFileExist(file) then
                     if mod.automaticallyImport() then
                         autoFiles[#autoFiles + 1] = file
                     else

--- a/src/plugins/finalcutpro/watchfolders/panels/media/init.lua
+++ b/src/plugins/finalcutpro/watchfolders/panels/media/init.lua
@@ -39,6 +39,7 @@ local timer				= require("hs.timer")
 local config			= require("cp.config")
 local dialog			= require("cp.dialog")
 local fcp				= require("cp.apple.finalcutpro")
+local just              = require("cp.just")
 local tools				= require("cp.tools")
 
 --------------------------------------------------------------------------------
@@ -386,21 +387,21 @@ function mod.insertFilesIntoFinalCutPro(files)
 		local audioExtensions = fcp.ALLOWED_IMPORT_AUDIO_EXTENSIONS
 		local imageExtensions = fcp.ALLOWED_IMPORT_IMAGE_EXTENSIONS
 		if mod.videoTag() ~= "" then
-			if (fnutils.contains(videoExtensions, file:sub(-3)) or fnutils.contains(videoExtensions, file:sub(-4))) and tools.doesFileExist(file) then
+			if (fnutils.contains(videoExtensions, string.lower(file:sub(-3))) or fnutils.contains(videoExtensions, string.lower(file:sub(-4)))) and tools.doesFileExist(file) then
 				if not fs.tagsAdd(file, {mod.videoTag()}) then
 					log.ef("Failed to add Finder Tag (%s) to: %s", mod.videoTag(), file)
 				end
 			end
 		end
 		if mod.audioTag() ~= "" then
-			if (fnutils.contains(audioExtensions, file:sub(-3)) or fnutils.contains(audioExtensions, file:sub(-4))) and tools.doesFileExist(file) then
+			if (fnutils.contains(audioExtensions, string.lower(file:sub(-3))) or fnutils.contains(audioExtensions, string.lower(file:sub(-4)))) and tools.doesFileExist(file) then
 				if not fs.tagsAdd(file, {mod.audioTag()}) then
 					log.ef("Failed to add Finder Tag (%s) to: %s", mod.videoTag(), file)
 				end
 			end
 		end
 		if mod.imageTag() ~= "" then
-			if (fnutils.contains(imageExtensions, file:sub(-3)) or fnutils.contains(imageExtensions, file:sub(-4))) and tools.doesFileExist(file) then
+			if (fnutils.contains(imageExtensions, string.lower(file:sub(-3))) or fnutils.contains(imageExtensions, string.lower(file:sub(-4)))) and tools.doesFileExist(file) then
 				if not fs.tagsAdd(file, {mod.imageTag()}) then
 					log.ef("Failed to add Finder Tag (%s) to: %s", mod.videoTag(), file)
 				end
@@ -436,13 +437,25 @@ function mod.insertFilesIntoFinalCutPro(files)
 		return nil
 	end
 
+    --------------------------------------------------------------------------------
+    -- Make sure Final Cut Pro is Active:
+    --------------------------------------------------------------------------------
+    result = just.doUntil(function()
+        fcp:launch()
+        return fcp:isFrontmost()
+    end, 5, 0.1)
+    if not result then
+        dialog.displayErrorMessage("Failed to launch to Final Cut Pro. Error occured in Final Cut Pro Media Watch Folder.")
+        return false
+    end
+
 	--------------------------------------------------------------------------------
 	-- Check if Timeline can be enabled:
 	--------------------------------------------------------------------------------
-	result = fcp:menuBar():isEnabled({"Window", "Go To", "Timeline"})
-	if result then
-		fcp:selectMenu({"Window", "Go To", "Timeline"})
-	else
+	result = just.doUntil(function()
+	    return fcp:selectMenu({"Window", "Go To", "Timeline"})
+	end, 5, 0.1)
+	if not result then
 		dialog.displayErrorMessage("Failed to activate timeline. Error occured in Final Cut Pro Media Watch Folder.")
 		return nil
 	end
@@ -450,10 +463,10 @@ function mod.insertFilesIntoFinalCutPro(files)
 	--------------------------------------------------------------------------------
 	-- Perform Paste:
 	--------------------------------------------------------------------------------
-	result = fcp:menuBar():isEnabled({"Edit", "Paste as Connected Clip"})
-	if result then
-		fcp:selectMenu({"Edit", "Paste as Connected Clip"})
-	else
+	result = just.doUntil(function()
+	    return fcp:selectMenu({"Edit", "Paste as Connected Clip"})
+	end, 5, 0.1)
+	if not result then
 		dialog.displayErrorMessage("Failed to trigger the 'Paste' Shortcut. Error occured in Final Cut Pro Media Watch Folder.")
 		return nil
 	end
@@ -697,7 +710,7 @@ function mod.watchFolderTriggered(files, eventFlags)
 				-- Check Extensions:
 				--------------------------------------------------------------------------------
 				local allowedExtensions = fcp.ALLOWED_IMPORT_ALL_EXTENSIONS
-				if (fnutils.contains(allowedExtensions, file:sub(-3)) or fnutils.contains(allowedExtensions, file:sub(-4))) and tools.doesFileExist(file) then
+				if (fnutils.contains(allowedExtensions, string.lower(file:sub(-3))) or fnutils.contains(allowedExtensions, string.lower(file:sub(-4)))) and tools.doesFileExist(file) then
 					if newFile or movedFile then
 						--log.df("File finished copying: %s", file)
 						if mod.automaticallyImport() then


### PR DESCRIPTION
- Watch Folder Extensions should now be case insensitive
- Tweaked `MenuBar:selectMenu()` so that it returns `true` if
successful otherwise `false`, as per in-line documentation
- Made some tweaks to the Final Cut Pro Media Watch Folder Plugin - but
I’m still having issues with it.
- Closes #1073