### PR TITLE
#1052

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/plugins.lua
+++ b/src/extensions/cp/apple/finalcutpro/plugins.lua
@@ -1000,7 +1000,7 @@ function mod.mt:scanAppEdelEffects(language)
     local audioEffect = mod.types.audioEffect
     for category, plugins in pairs(mod.appEdelEffects) do
         for _, plugin in ipairs(plugins) do
-            self:registerPlugin(nil, audioEffect, "Logic", category, plugin, language)
+            self:registerPlugin(nil, audioEffect, category, "Logic", plugin, language)
         end
     end
 

--- a/src/plugins/finalcutpro/timeline/pluginactions.lua
+++ b/src/plugins/finalcutpro/timeline/pluginactions.lua
@@ -48,26 +48,6 @@ local GROUP = "fcpx"
 --------------------------------------------------------------------------------
 local mod = {}
 
--- plugins.finalcutpro.timeline.pluginactions._generateActionId(pluginType, action) -> string
--- Function
--- Generates a Action ID.
---
--- Parameters:
---  * pluginType - Plugin Type as string
---  * action - Action Table
---
--- Returns:
---  * Action ID as string
-function mod._generateActionId(_, action)
-    local result = ""
-    if action then
-        if action.name then result = result .. action.name end
-        if action.theme then result = result .. action.theme end
-        if action.category then result = result .. action.category end
-    end
-    return result
-end
-
 --- plugins.finalcutpro.timeline.pluginactions.init(actionmanager, generators, titles, transitions, audioeffects, videoeffects) -> module
 --- Function
 --- Initialise the module.
@@ -105,16 +85,20 @@ function mod.init(actionmanager, generators, titles, transitions, audioeffects, 
             if list then
                 for _,plugin in ipairs(list) do
                     local subText = i18n(pluginType .. "_group")
+                    local category = "none"
                     if plugin.category then
                         subText = subText..": "..plugin.category
+                        category = plugin.category
                     end
+                    local theme = "none"
                     if plugin.theme then
+                        theme = plugin.theme
                         subText = subText.." ("..plugin.theme..")"
                     end
                     choices:add(plugin.name)
                         :subText(subText)
                         :params(plugin)
-                        :id(mod._generateActionId(pluginType, action))
+                        :id(GROUP .. "_" .. pluginType .. "_" .. plugin.name .. "_" .. category .. "_" .. theme)
                 end
             end
         end)

--- a/src/plugins/finalcutpro/timeline/pluginactions.lua
+++ b/src/plugins/finalcutpro/timeline/pluginactions.lua
@@ -114,7 +114,7 @@ function mod.init(actionmanager, generators, titles, transitions, audioeffects, 
                     choices:add(plugin.name)
                         :subText(subText)
                         :params(plugin)
-                        --:id(mod._generateActionId(pluginType, action))
+                        :id(mod._generateActionId(pluginType, action))
                 end
             end
         end)
@@ -126,7 +126,7 @@ function mod.init(actionmanager, generators, titles, transitions, audioeffects, 
                 error(string.format("Unsupported plugin type: %s", pluginType))
             end
         end)
-        --:onActionId(actionId)
+        :onActionId(function() return GROUP .. "_" .. pluginType end)
     end
 
     --------------------------------------------------------------------------------


### PR DESCRIPTION
- Added `onActionId` back into FCPX Plugin Actions to get rid of error
messages in the Error Log
- Fixed bug where Audio Effects Categories and Themes were around the
wrong way in the Plugin Scanner.
- Closes #1052