### PR TITLE
#1189

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/plugins.lua
+++ b/src/extensions/cp/apple/finalcutpro/plugins.lua
@@ -936,6 +936,10 @@ function mod.mt:scanSystemMotionTemplates(language)
     --------------------------------------------------------------------------------
     local path = "/Library/Application Support/Final Cut Pro/Templates.localized"
     local pathToAbsolute = fs.pathToAbsolute(path)
+    if not pathToAbsolute then
+        log.df("Folder does not exist: %s", path)
+        return nil
+    end
 
     --------------------------------------------------------------------------------
     -- Restore from cache:


### PR DESCRIPTION
- Fixed an error that would occur if "/Library/Application
Support/Final Cut Pro/Templates.localized" does not exist on a users
machine
- Closes #1189