### PR TITLE
#1249

### DIFF
--- a/src/plugins/finalcutpro/viewer/overlays.lua
+++ b/src/plugins/finalcutpro/viewer/overlays.lua
@@ -37,19 +37,41 @@ local menubar           = require("hs.menubar")
 -- CONSTANTS:
 --
 --------------------------------------------------------------------------------
+
+-- STILLS_FOLDER -> string
+-- Constant
+-- Folder name for Stills Cache.
 local STILLS_FOLDER         = "Still Frames"
 
-local DEFAULT_MODE          = "Basic Grid"
+-- DEFAULT_COLOR -> string
+-- Constant
+-- Default Colour Setting.
 local DEFAULT_COLOR         = "#FFFFFF"
+
+-- DEFAULT_ALPHA -> number
+-- Constant
+-- Default Alpha Setting.
 local DEFAULT_ALPHA         = 50
+
+-- DEFAULT_GRID_SPACING -> number
+-- Constant
+-- Default Grid Spacing Setting.
 local DEFAULT_GRID_SPACING  = 20
+
+-- DEFAULT_STILLS_LAYOUT -> number
+-- Constant
+-- Default Stills Layout Setting.
 local DEFAULT_STILLS_LAYOUT = "Left Vertical"
 
+-- NUMBER_OF_MEMORIES -> number
+-- Constant
+-- Number of Stills Memories Available.
 local NUMBER_OF_MEMORIES    = 5
 
+-- FCP_COLOR_BLUE -> string
+-- Constant
+-- Apple's preferred blue colour in Final Cut Pro.
 local FCP_COLOR_BLUE        = "#5760e7"
---local FCP_COLOR_RED         = "#d1393e"
---local FCP_COLOR_GREEN       = "#3f9253"
 
 --------------------------------------------------------------------------------
 --
@@ -63,15 +85,15 @@ local mod = {}
 --- Are all the Viewer Overlay's disabled?
 mod.disabled = config.prop("fcpViewerMasterDisabled", false)
 
---- plugins.finalcutpro.viewer.overlays.gridEnabled <cp.prop: boolean>
+--- plugins.finalcutpro.viewer.overlays.basicGridEnabled <cp.prop: boolean>
 --- Variable
 --- Is Viewer Grid Enabled?
-mod.gridEnabled = config.prop("fcpViewerGridEnabled", false)
+mod.basicGridEnabled = config.prop("fcpViewerBasicGridEnabled", false)
 
---- plugins.finalcutpro.viewer.overlays.gridMode <cp.prop: number>
+--- plugins.finalcutpro.viewer.overlays.draggableGuideEnabled <cp.prop: boolean>
 --- Variable
---- Viewer Grid Mode
-mod.gridMode = config.prop("fcpViewerGridMode", DEFAULT_MODE)
+--- Is Viewer Grid Enabled?
+mod.draggableGuideEnabled = config.prop("fcpViewerDraggableGuideEnabled", false)
 
 --- plugins.finalcutpro.viewer.overlays.gridColor <cp.prop: string>
 --- Variable
@@ -153,8 +175,6 @@ function mod.show()
             --------------------------------------------------------------------------------
             -- Get Preferences:
             --------------------------------------------------------------------------------
-            local mode          = mod.gridMode()
-            local gridEnabled   = mod.gridEnabled()
             local gridColor     = mod.gridColor()
             local gridAlpha     = mod.gridAlpha() / 100
             local gridSpacing   = mod.gridSpacing()
@@ -221,101 +241,98 @@ function mod.show()
             end
 
             --------------------------------------------------------------------------------
-            -- Add Grid:
+            -- Basic Grid:
             --------------------------------------------------------------------------------
-            if gridEnabled then
+            if mod.basicGridEnabled() then
                 --------------------------------------------------------------------------------
-                -- Basic Grid:
+                -- Add Vertical Lines:
                 --------------------------------------------------------------------------------
-                if mode == "Basic Grid" then
-                    --------------------------------------------------------------------------------
-                    -- Add Vertical Lines:
-                    --------------------------------------------------------------------------------
-                    for i=1, frame.w, frame.w/gridSpacing do
-                        mod._canvas:appendElements({
-                            type = "rectangle",
-                            frame = { x = i, y = 0, h = frame.h, w = 1},
-                            fillColor = fillColor,
-                            action = "fill",
-                        })
-                    end
-
-                    --------------------------------------------------------------------------------
-                    -- Add Horizontal Lines:
-                    --------------------------------------------------------------------------------
-                    for i=1, frame.h, frame.w/gridSpacing do
-                        mod._canvas:appendElements({
-                            type = "rectangle",
-                            frame = { x = 0, y = i, h = 1, w = frame.w},
-                            fillColor = fillColor,
-                            action = "fill",
-                        })
-                    end
-                --------------------------------------------------------------------------------
-                -- Draggable Guide:
-                --------------------------------------------------------------------------------
-                elseif mode == "Draggable Guide" then
-                    local savedX, savedY
-                    if guidePosition.x and guidePosition.y then
-                        savedX = guidePosition.x
-                        savedY = guidePosition.y
-                    else
-                        savedX = frame.w/2
-                        savedY = frame.h/2
-                    end
+                for i=1, frame.w, frame.w/gridSpacing do
                     mod._canvas:appendElements({
-                        id = "dragVertical",
-                        action = "stroke",
-                        closed = false,
-                        coordinates = { { x = savedX, y = 0 }, { x = savedX, y = frame.h } },
-                        strokeColor = fillColor,
-                        strokeWidth = 2,
-                        type = "segments",
-                    })
-                    mod._canvas:appendElements({
-                        id = "dragHorizontal",
-                        action = "stroke",
-                        closed = false,
-                        coordinates = { { x = 0, y = savedY }, { x = frame.w, y = savedY } },
-                        strokeColor = fillColor,
-                        strokeWidth = 2,
-                        type = "segments",
-                    })
-                    mod._canvas:appendElements({
-                        id = "dragCentreKill",
-                        action = "fill",
-                        center = { x = savedX, y = savedY },
-                        radius = 8,
+                        type = "rectangle",
+                        frame = { x = i, y = 0, h = frame.h, w = 1},
                         fillColor = fillColor,
-                        type = "circle",
-                        compositeRule = "clear",
-                    })
-                    mod._canvas:appendElements({
-                        id = "dragCentre",
                         action = "fill",
-                        center = { x = savedX, y = savedY },
-                        radius = 8,
-                        fillColor = fillColor,
-                        type = "circle",
-                        trackMouseDown = true,
-                        trackMouseUp = true,
                     })
-                    mod._canvas:clickActivating(false)
-                    mod._canvas:canvasMouseEvents(true, true, true, true)
-                    mod._canvas:mouseCallback(function(_, event, id, x, y)
-                        if id == "dragCentre" and event == "mouseDown" then
-                            mod._dragging = true
-                        end
-                        if mod._dragging and event == "mouseUp" then
-                            mod._dragging = false
-                            mod._canvas["dragCentre"].center = {x = x, y = y }
-                            mod._canvas["dragCentreKill"].center = {x = x, y = y }
-                            mod._canvas["dragVertical"].coordinates = { { x = x, y = 0 }, { x = x, y = frame.h } }
-                            mod._canvas["dragHorizontal"].coordinates = { { x = 0, y = y }, { x = frame.w, y = y } }
-                            mod.guidePosition({x=x, y=y})
-                        end
-                    end)
                 end
+
+                --------------------------------------------------------------------------------
+                -- Add Horizontal Lines:
+                --------------------------------------------------------------------------------
+                for i=1, frame.h, frame.w/gridSpacing do
+                    mod._canvas:appendElements({
+                        type = "rectangle",
+                        frame = { x = 0, y = i, h = 1, w = frame.w},
+                        fillColor = fillColor,
+                        action = "fill",
+                    })
+                end
+            end
+
+            --------------------------------------------------------------------------------
+            -- Draggable Guide:
+            --------------------------------------------------------------------------------
+            if mod.draggableGuideEnabled() then
+                local savedX, savedY
+                if guidePosition.x and guidePosition.y then
+                    savedX = guidePosition.x
+                    savedY = guidePosition.y
+                else
+                    savedX = frame.w/2
+                    savedY = frame.h/2
+                end
+                mod._canvas:appendElements({
+                    id = "dragVertical",
+                    action = "stroke",
+                    closed = false,
+                    coordinates = { { x = savedX, y = 0 }, { x = savedX, y = frame.h } },
+                    strokeColor = fillColor,
+                    strokeWidth = 2,
+                    type = "segments",
+                })
+                mod._canvas:appendElements({
+                    id = "dragHorizontal",
+                    action = "stroke",
+                    closed = false,
+                    coordinates = { { x = 0, y = savedY }, { x = frame.w, y = savedY } },
+                    strokeColor = fillColor,
+                    strokeWidth = 2,
+                    type = "segments",
+                })
+                mod._canvas:appendElements({
+                    id = "dragCentreKill",
+                    action = "fill",
+                    center = { x = savedX, y = savedY },
+                    radius = 8,
+                    fillColor = fillColor,
+                    type = "circle",
+                    compositeRule = "clear",
+                })
+                mod._canvas:appendElements({
+                    id = "dragCentre",
+                    action = "fill",
+                    center = { x = savedX, y = savedY },
+                    radius = 8,
+                    fillColor = fillColor,
+                    type = "circle",
+                    trackMouseDown = true,
+                    trackMouseUp = true,
+                    trackMouseMove = true,
+                })
+                mod._canvas:clickActivating(false)
+                mod._canvas:canvasMouseEvents(true, true, true, true)
+                mod._canvas:mouseCallback(function(_, event, id, x, y)
+                    if id == "dragCentre" and event == "mouseDown" then
+                        mod._dragging = not mod._dragging
+                    end
+                    if mod._dragging then
+                        mod._canvas["dragCentre"].center = {x = x, y = y }
+                        mod._canvas["dragCentreKill"].center = {x = x, y = y }
+                        mod._canvas["dragVertical"].coordinates = { { x = x, y = 0 }, { x = x, y = frame.h } }
+                        mod._canvas["dragHorizontal"].coordinates = { { x = 0, y = y }, { x = frame.w, y = y } }
+                        mod.guidePosition({x=x, y=y})
+                    end
+                end)
             end
 
             --------------------------------------------------------------------------------
@@ -380,13 +397,7 @@ function mod.update()
         --------------------------------------------------------------------------------
         -- Show the grid if enabled:
         --------------------------------------------------------------------------------
-        local activeMemory = mod.activeMemory()
-        local gridEnabled = mod.gridEnabled()
-
-        --log.df("activeMemory: %s", activeMemory)
-        --log.df("gridEnabled: %s", gridEnabled)
-
-        if (gridEnabled or activeMemory ~= 0) and not mod.disabled() then
+        if not mod.disabled() and (mod.basicGridEnabled() or mod.draggableGuideEnabled() or mod.activeMemory() ~= 0) then
             mod.show()
         else
             mod.hide()
@@ -397,7 +408,6 @@ function mod.update()
         --------------------------------------------------------------------------------
         mod.hide()
         if mod._eventtap then
-            --log.df("Stopping Keyboard Monitor")
             mod._eventtap:stop()
         end
     end
@@ -503,28 +513,6 @@ function mod.viewMemory(id)
     mod.update()
 end
 
---- plugins.finalcutpro.viewer.overlays.setGrid(id) -> none
---- Function
---- Sets a Grid Type.
----
---- Parameters:
----  * id - The ID of the memory you want to retrieve.
----
---- Returns:
----  * None
-function mod.setGrid(id)
-    local gridMode = mod.gridMode()
-    if gridMode == id then
-        mod.gridEnabled:toggle()
-    else
-        if not mod.gridEnabled() then
-            mod.gridEnabled(true)
-        end
-    end
-    mod.gridMode(id)
-    mod.update()
-end
-
 --- plugins.finalcutpro.viewer.overlays.setGridSpacing(value) -> none
 --- Function
 --- Sets Grid Spacing.
@@ -611,8 +599,8 @@ local function contextualMenu(event)
                     { title = i18n("disableAllOverlays"), checked = mod.disabled(), fn = function() mod.disabled:toggle(); mod.update() end },
                     { title = "-", disabled = true },
                     { title = string.upper(i18n("gridOverlay")) .. ":", disabled = true },
-                    { title = "  " .. i18n("basicGrid"),        checked = mod.gridEnabled() and mod.gridMode() == "Basic Grid", fn = function() mod.setGrid("Basic Grid") end },
-                    { title = "  " .. i18n("draggableGuide"),   checked = mod.gridEnabled() and mod.gridMode() == "Draggable Guide", fn = function() mod.setGrid("Draggable Guide") end },
+                    { title = "  " .. i18n("basicGrid"),        checked = mod.basicGridEnabled(), fn = function() mod.basicGridEnabled:toggle(); mod.update(); end },
+                    { title = "  " .. i18n("draggableGuide"),   checked = mod.draggableGuideEnabled(), fn = function() mod.draggableGuideEnabled:toggle(); mod.update(); end },
                     --{ title = "  Rule of Thirds", checked = false },
                     { title = "-", disabled = true },
                     { title = string.upper(i18n("gridStyle")) .. ":", disabled = true },
@@ -714,11 +702,11 @@ function plugin.init(deps)
     if deps.fcpxCmds then
         deps.fcpxCmds
             :add("cpViewerBasicGrid")
-            :whenActivated(function() mod.setGrid("Basic Grid") end)
+            :whenActivated(function() mod.basicGridEnabled:toggle(); mod.update() end)
 
         deps.fcpxCmds
             :add("cpViewerDraggableGuide")
-            :whenActivated(function() mod.setGrid("Draggable Guide") end)
+            :whenActivated(function() mod.draggableGuideEnabled:toggle(); mod.update() end)
 
         deps.fcpxCmds
             :add("cpToggleAllViewerOverlays")


### PR DESCRIPTION
- Draggable Guide now gives live update. To get around (what I assume
is a) `hs.canvas` limitation, you no longer click and hold the mouse
key down to drag - you click once to enable dragging, then click again
to disable (i.e. it’s a toggle).
- You can now turn on both the “Basic Grid” and “Draggable Guides” at
the same time.
- Closes #1249