### PR TITLE
#1214 & #1215 - Viewer Overlay Resizes

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -133,6 +133,11 @@ local frontmostApp = nil
 --- Returns the most recent 'registered' app that was active, other than CommandPost itself.
 mod.frontmostApp = prop(function() return frontmostApp end)
 
+--- cp.app.frontmostApp <cp.prop: cp.app; read-only; live>
+--- Field
+--- Returns the most recent 'registered' app that was active, other than CommandPost itself.
+mod.frontmostApp = prop(function() return frontmostApp end)
+
 --- cp.app.forBundleID(bundleID)
 --- Constructor
 --- Returns the `cp.app` for the specified Bundle ID. If the app has already been created,
@@ -519,6 +524,11 @@ function mod.forBundleID(bundleID)
             --- Field
             --- Gets and sets the current locale for the application.
             currentLocale = currentLocale,
+
+            --- cp.app.windowMoved <cp.prop: boolean; live>
+            --- Field
+            --- Triggers `true` when an application window is moved.
+            windowMoved = prop(function(self) return self._moved end, function(value, self) self._moved = value end),
         }
 
         apps[bundleID] = theApp
@@ -838,6 +848,14 @@ local function updateFrontmostApp(app)
     mod.frontmostApp:update()
 end
 
+local function updateWindowMoved(window)
+    local app = findAppForWindow(window)
+    if app then
+        app.windowMoved:value(false)
+        app.windowMoved:value(true)
+    end
+end
+
 -- cp.app._initWatchers() -> none
 -- Method
 -- Initialise all the various application watchers.
@@ -905,6 +923,7 @@ function mod._initWatchers()
     appWindowFilter:subscribe(windowfilter.windowCreated, updateWindowsUI)
     appWindowFilter:subscribe(windowfilter.windowDestroyed, updateWindowsUI)
     appWindowFilter:subscribe(windowfilter.windowFocused, updateFocusedWindowUI)
+    appWindowFilter:subscribe(windowfilter.windowMoved, updateWindowMoved)
 
     mod._appWindowFilter = appWindowFilter
 end

--- a/src/extensions/cp/app/prefs.lua
+++ b/src/extensions/cp/app/prefs.lua
@@ -136,7 +136,7 @@ function mod.bundleID(prefs)
     end
 end
 
-local PLIST_MATCH = "^.-([^/]+)%.plist$"
+local PLIST_MATCH = "^.-([^/]+)%.plist*"
 
 --- cp.app.prefs.watch(prefs, watchFn) -> nil
 --- Function

--- a/src/extensions/cp/apple/finalcutpro/main/Viewer.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/Viewer.lua
@@ -373,7 +373,29 @@ function Viewer.new(app, eventViewer)
                     end
                 end
             end
-        )
+        ),
+
+        --- cp.apple.finalcutpro.main.Viewer.resized <cp.prop: boolean; live>
+        --- Field
+        --- Returns `true` if the Viewer has been resized, otherwise `false`.
+        resized = prop(
+            function(self)
+                local theUI = UI()
+                local currentFrame = theUI and theUI:attributeValue("AXFrame")
+                local previousFrame = o._previousFrame
+                if currentFrame then
+                    if previousFrame then
+                        if currentFrame.h ~= previousFrame.h or currentFrame.w ~= previousFrame.w then
+                            o._previousFrame = currentFrame
+                            return true
+                        end
+                    end
+                    o._previousFrame = currentFrame
+                end
+                return false
+            end
+        ),
+
     }
 
     local checker
@@ -389,12 +411,22 @@ function Viewer.new(app, eventViewer)
     -----------------------------------------------------------------------
     -- Watch the `timecode` field and update `isPlaying`:
     -----------------------------------------------------------------------
-    o.timecode:watch(function(_)
+    o.timecode:watch(function()
         if not checker:running() then
-            -- update the first time.
+            -----------------------------------------------------------------------
+            -- Update the first time:
+            -----------------------------------------------------------------------
             o.isPlaying:update()
         end
         checker:start()
+    end)
+
+    -----------------------------------------------------------------------
+    -- Watch for the Viewer being resized:
+    -----------------------------------------------------------------------
+    app.app.windowMoved:watch(function()
+        o.resized:update()
+        o.resized:update()
     end)
 
     --- cp.apple.finalcutpro.main.Viewer.formatUI <cp.prop: hs._asm.axuielement; read-only>

--- a/src/extensions/cp/apple/finalcutpro/main/Viewer.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/Viewer.lua
@@ -19,7 +19,7 @@ local log                               = require("hs.logger").new("viewer")
 local canvas                            = require("hs.canvas")
 local eventtap                          = require("hs.eventtap")
 local geometry                          = require("hs.geometry")
-local delayedTimer                      = require("hs.timer").delayed
+local timer                             = require("hs.timer")
 
 --------------------------------------------------------------------------------
 -- CommandPost Extensions:
@@ -41,13 +41,14 @@ local id                                = require("cp.apple.finalcutpro.ids") "V
 --------------------------------------------------------------------------------
 -- Local Lua Functions:
 --------------------------------------------------------------------------------
-local floor                             = math.floor
-local match, sub, find                  = string.match, string.sub, string.find
-local childrenWithRole                  = axutils.childrenWithRole
-local childrenMatching                  = axutils.childrenMatching
+local cache                             = axutils.cache
 local childFromLeft, childFromRight     = axutils.childFromLeft, axutils.childFromRight
 local childFromTop, childFromBottom     = axutils.childFromTop, axutils.childFromBottom
-local cache                             = axutils.cache
+local childrenMatching                  = axutils.childrenMatching
+local childrenWithRole                  = axutils.childrenWithRole
+local delayedTimer                      = timer.delayed
+local floor                             = math.floor
+local match, sub, find                  = string.match, string.sub, string.find
 
 --------------------------------------------------------------------------------
 --
@@ -379,7 +380,7 @@ function Viewer.new(app, eventViewer)
         --- Field
         --- Returns `true` if the Viewer has been resized, otherwise `false`.
         resized = prop(
-            function(self)
+            function()
                 local theUI = UI()
                 local currentFrame = theUI and theUI:attributeValue("AXFrame")
                 local previousFrame = o._previousFrame
@@ -426,7 +427,7 @@ function Viewer.new(app, eventViewer)
     -----------------------------------------------------------------------
     app.app.windowMoved:watch(function()
         o.resized:update()
-        o.resized:update()
+        timer.doAfter(0.01, function() o.resized:update() end)
     end)
 
     --- cp.apple.finalcutpro.main.Viewer.formatUI <cp.prop: hs._asm.axuielement; read-only>

--- a/src/extensions/cp/apple/finalcutpro/main/Viewer.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/Viewer.lua
@@ -47,7 +47,6 @@ local childFromTop, childFromBottom     = axutils.childFromTop, axutils.childFro
 local childrenMatching                  = axutils.childrenMatching
 local childrenWithRole                  = axutils.childrenWithRole
 local delayedTimer                      = timer.delayed
-local floor                             = math.floor
 local match, sub, find                  = string.match, string.sub, string.find
 
 --------------------------------------------------------------------------------

--- a/src/plugins/finalcutpro/viewer/overlays.lua
+++ b/src/plugins/finalcutpro/viewer/overlays.lua
@@ -697,6 +697,15 @@ function plugin.init(deps)
     fcp.isFrontmost:watch(mod.update)
 
     --------------------------------------------------------------------------------
+    -- Update Canvas when Final Cut Pro's Viewer is resized or moved:
+    --------------------------------------------------------------------------------
+    fcp:viewer().resized:watch(function(value)
+        if value then
+            mod.update()
+        end
+    end)
+
+    --------------------------------------------------------------------------------
     -- Setup Commands:
     --------------------------------------------------------------------------------
     if deps.fcpxCmds then

--- a/src/plugins/finalcutpro/viewer/overlays.lua
+++ b/src/plugins/finalcutpro/viewer/overlays.lua
@@ -704,6 +704,16 @@ function plugin.init(deps)
             mod.update()
         end
     end)
+    fcp.app.windowMoved:watch(function(value)
+        if value then
+            mod.update()
+        end
+    end)
+
+    --------------------------------------------------------------------------------
+    -- Force initial update:
+    --------------------------------------------------------------------------------
+    mod.update()
 
     --------------------------------------------------------------------------------
     -- Setup Commands:


### PR DESCRIPTION
- Add `cp.prop`’s for watching application window moves and Viewer resizes
- Viewer Overlays now automatically resize if the Viewer is resized
- Closes #1215
- Closes #1214