### PR TITLE
#1458 * Fixed Rx code for pasting text as a caption. * Added the new `Retry` statement to `cp.rx.go` imports.

### DIFF
--- a/src/extensions/cp/rx/go.lua
+++ b/src/extensions/cp/rx/go.lua
@@ -67,6 +67,7 @@ local Given         = require("cp.rx.go.Given")
 local If            = require("cp.rx.go.If")
 local Last          = require("cp.rx.go.Last")
 local List          = require("cp.rx.go.List")
+local Retry         = require("cp.rx.go.Retry")
 local Require       = require("cp.rx.go.Require")
 local Throw         = require("cp.rx.go.Throw")
 local WaitUntil     = require("cp.rx.go.WaitUntil")
@@ -84,6 +85,7 @@ return {
     First = First,
     Last = Last,
     List = List,
+    Retry = Retry,
     Throw = Throw,
     Done = Done,
     If = If,


### PR DESCRIPTION
Fixes #1458.