### PR TITLE
#1559

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/plugins.lua
+++ b/src/extensions/cp/apple/finalcutpro/plugins.lua
@@ -965,6 +965,10 @@ function mod.mt:scanUserMotionTemplates(locale)
     --------------------------------------------------------------------------------
     local path = "~/Movies/Motion Templates.localized"
     local pathToAbsolute = fs.pathToAbsolute(path)
+    if not pathToAbsolute then
+        report("Folder does not exist: %s", path)
+        return nil
+    end
 
     --------------------------------------------------------------------------------
     -- Restore from cache:


### PR DESCRIPTION
- Fixes potential `nil` error when scanning for Motion Templates
- Closes #1559