### PR TITLE
#1682

### DIFF
--- a/src/plugins/finalcutpro/hud/panels/notes/html/panel.html
+++ b/src/plugins/finalcutpro/hud/panels/notes/html/panel.html
@@ -5,7 +5,9 @@
 		background: #cccccc;
 	}
 	trix-editor {
-		height: 150px;
+		height: 150px !important;
+		max-height: 150px !important;
+	  	overflow-y: auto !important;
 	}
 	#location {
 		padding-bottom: 10px;


### PR DESCRIPTION
- Fixed a bug in the Notes Panel of the HUD where the Trix Editor
wasn’t a fixed height
- Closes #1682