### PR TITLE
Issue/1715 launch fcp with tangent

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -642,12 +642,14 @@ function app.lazy.method:doLaunch()
         If(self.frontmost):Is(false):Then(
             If(self.hsApplication):Then(function(hsApp)
                 hsApp:activate()
+                return true
             end)
             :Otherwise(function()
                 local ok = application.launchOrFocusByBundleID(self:bundleID())
                 if not ok then
                     return Throw("Unable to launch %s.", self:displayName())
                 end
+                return true
             end)
         )
         :Then(WaitUntil(self.frontmost))

--- a/src/plugins/core/tangent/manager/action.lua
+++ b/src/plugins/core/tangent/manager/action.lua
@@ -44,7 +44,7 @@ function action.new(id, name, parent, localActive)
         --- plugins.core.tangent.manager.action.localActive <cp.prop: boolean>
         --- Field
         --- Indicates if the action should ignore the parent's `enabled` state when determining if the action is active.
-        localActive = prop.THIS(localActive),
+        localActive = prop.THIS(localActive == true),
     }, action.mt)
 
     prop.bind(o) {

--- a/src/plugins/core/tangent/manager/action.lua
+++ b/src/plugins/core/tangent/manager/action.lua
@@ -19,17 +19,19 @@ local format            = string.format
 local action = {}
 action.mt = named({})
 
---- plugins.core.tangent.manager.action.new(id[, name]) -> action
+--- plugins.core.tangent.manager.action.new(id[, name[, parent[, localActive]]]) -> action
 --- Constructor
 --- Creates a new `Action` instance.
 ---
 --- Parameters:
 --- * id        - The ID number of the action.
 --- * name      - The name of the action.
+--- * parent    - The parent group. (optional)
+--- * localActive - If set to `true`, the parent's `active` state will be ignored when determining if this action is active. Defaults to `false`.
 ---
 --- Returns:
 --- * the new `action`.
-function action.new(id, name, parent)
+function action.new(id, name, parent, localActive)
     local o = prop.extend({
         id = id,
         _parent = parent,
@@ -38,6 +40,11 @@ function action.new(id, name, parent)
         --- Field
         --- Indicates if the action is enabled.
         enabled = prop.TRUE(),
+
+        --- plugins.core.tangent.manager.action.localActive <cp.prop: boolean>
+        --- Field
+        --- Indicates if the action should ignore the parent's `enabled` state when determining if the action is active.
+        localActive = prop.THIS(localActive),
     }, action.mt)
 
     prop.bind(o) {
@@ -45,7 +52,7 @@ function action.new(id, name, parent)
         --- Field
         --- Indicates if the action is active. It will only be active if
         --- the current action is `enabled` and if the parent group (if present) is `active`.
-        active = parent and parent.active:AND(o.enabled) or o.enabled:IMMUTABLE()
+        active = parent and prop.AND(o.localActive:OR(parent.active), o.enabled) or o.enabled:IMMUTABLE()
     }
 
     o:name(name)

--- a/src/plugins/core/tangent/manager/group.lua
+++ b/src/plugins/core/tangent/manager/group.lua
@@ -26,14 +26,15 @@ local format            = string.format
 local group = {}
 group.mt = {}
 
---- plugins.core.tangent.manager.group.new(name, parent, controls)
+--- plugins.core.tangent.manager.group.new(name[, parent[, localActive]])
 --- Constructor
 --- Creates a new `Group` instance.
 ---
 --- Parameters:
 ---  * name      - The name of the group.
 ---  * parent    - The parent group.
-function group.new(name, parent)
+---  * localActive - If `true`, this group will ignore the parent's `active` status when determining its own `active` status. Defaults to `false`.
+function group.new(name, parent, localActive)
     if is.blank(name) then
         error("Group names cannot be empty")
     end
@@ -45,6 +46,11 @@ function group.new(name, parent)
         --- Field
         --- Indicates if the group is enabled.
         enabled = prop.TRUE(),
+
+        --- plugins.core.tangent.manager.group.localActive <cp.prop: boolean>
+        --- Field
+        --- Indicates if the group should ignore the parent's `enabled` state when determining if the group is active.
+        localActive = prop.THIS(localActive == true)
     }, group.mt)
 
     prop.bind(o) {
@@ -52,7 +58,7 @@ function group.new(name, parent)
         --- Field
         --- Indicates if the group is active. It will only be active if
         --- the current group is `enabled` and if the parent group (if present) is `active`.
-        active = parent and parent.active:AND(o.enabled) or o.enabled:IMMUTABLE(),
+        active = parent and prop.AND(o.localActive:OR(parent.active), o.enabled) or o.enabled:IMMUTABLE(),
     }
 
     return o
@@ -102,23 +108,24 @@ function group.mt:controls()
     end
 end
 
---- plugins.core.tangent.manager.group:group(name) -> group
+--- plugins.core.tangent.manager.group:group(name[, localActive]) -> group
 --- Method
 --- Adds a subgroup to this group.
 ---
 --- Parameters
 ---  * name  - the name of the new sub-group
+---  * localActive - If `true`, this group will ignore the parent's `active` status when determining its own `active` status. Defaults to `false`.
 ---
 --- Returns:
 ---  * The new `group`
-function group.mt:group(name)
+function group.mt:group(name, localActive)
     local groups = self._groups
     if not groups then
         groups = {}
         self._groups = groups
     end
 
-    local g = group.new(name, self)
+    local g = group.new(name, self, localActive)
     insert(groups, g)
 
     return g

--- a/src/plugins/core/tangent/manager/group.lua
+++ b/src/plugins/core/tangent/manager/group.lua
@@ -146,24 +146,25 @@ function group.mt:_unregisterAll(controlList)
     end
 end
 
---- plugins.core.tangent.manager.group:action(id[, name]) -> action
+--- plugins.core.tangent.manager.group:action(id[, name[, localActive]]) -> action
 --- Method
 --- Adds an `action` to this group.
 ---
 --- Parameters
 ---  * id    - The ID number of the new action
 ---  * name  - The name of the action.
+---  * localActive - If true, the parent group's `active` state is ignored when determining if this action is active.
 ---
 --- Returns:
 ---  * The new `action`
-function group.mt:action(id, name)
+function group.mt:action(id, name, localActive)
     local actions = self._actions
     if not actions then
         actions = {}
         self._actions = actions
     end
 
-    local a = action.new(id, name, self)
+    local a = action.new(id, name, self, localActive)
     insert(actions, a)
 
     self:_register(a)

--- a/src/plugins/finalcutpro/tangent/open.lua
+++ b/src/plugins/finalcutpro/tangent/open.lua
@@ -1,6 +1,6 @@
---- === plugins.finalcutpro.tangent.timeline ===
+--- === plugins.finalcutpro.tangent.open ===
 ---
---- Final Cut Pro Tangent Timeline Group/Management
+--- Final Cut Pro Tangent Open FCPX.
 
 local require = require
 
@@ -23,7 +23,7 @@ local plugin = {
 function plugin.init(deps)
     local fcpGroup = deps.fcpGroup
     local id = 0x00050000
-    fcpGroup:action(id, i18n("cpLaunchFinalCutPro" .. "_title"))
+    fcpGroup:action(id, i18n("cpLaunchFinalCutPro" .. "_title"), true)
         :onPress(fcp:doLaunch())
 
     return fcpGroup


### PR DESCRIPTION
- Added the `localActive` parameter to Tangent `group:action()` method.
- Added `localActive` to `group.new` and `group:group`
- Added `localActive` option for Tangent Actions to specify that they are ignoring the parent `active` state when determining if they are active now.
- Returned a value from If statements for app:doLaunch()
- Closes #1715 