### PR TITLE
#1733

### DIFF
--- a/src/extensions/hs/tangent/init.lua
+++ b/src/extensions/hs/tangent/init.lua
@@ -1054,7 +1054,7 @@ end
 --- Notes:
 ---  * Full documentation for the Tangent API can be downloaded [here](http://www.tangentwave.co.uk/download/developer-support-pack/).
 ---  * The callback function should expect 1 argument and should not return anything.
---   * The 1 argument will be a table, which can contain one or many commands. Each command is it's own table with the following contents:
+---  * The 1 argument will be a table, which can contain one or many commands. Each command is it's own table with the following contents:
 ---    * id - the message ID of the incoming message
 ---    * metadata - A table of data for the Tangent command (see below).
 ---  * The metadata table will return the following, depending on the `id` for the callback:
@@ -1258,7 +1258,7 @@ end
 --- Function
 --- Updates the Hub with a menu value.
 --- The Hub then updates the displays of any panels which are currently
---    showing the menu.
+--- showing the menu.
 --- If a value of `nil` is sent then the Hub will not attempt to display a
 --- value for the menu. However the `atDefault` flag will still be recognised.
 ---

--- a/src/plugins/finalcutpro/hud/manager/init.lua
+++ b/src/plugins/finalcutpro/hud/manager/init.lua
@@ -27,9 +27,11 @@ local tools         = require("cp.tools")
 local moses         = require("moses")
 local panel         = require("panel")
 
+local doAfter       = timer.doAfter
 local forBundleID   = app.forBundleID
 local processInfo   = hs.processInfo
 local sortedIndex   = moses.sortedIndex
+local waitUntil     = timer.waitUntil
 
 --------------------------------------------------------------------------------
 --
@@ -526,7 +528,9 @@ function mod.new()
             :canCustomize(true)
             :autosaves(true)
             :setCallback(function(_, _, cbID)
-                mod.refresh(cbID)
+                waitUntil(function() return not mod._webview:loading() end, function()
+                    mod.refresh(cbID)
+                end, 0.01)
             end)
 
         local theToolbar = mod._toolbar
@@ -885,9 +889,9 @@ end
 --- Returns:
 ---  * None
 function mod.updateVisibility()
-    timer.doAfter(0.000000000001, function()
+    doAfter(0.000000000001, function()
         showOrHideHUD()
-        timer.doAfter(0.5, showOrHideHUD)
+        doAfter(0.5, showOrHideHUD)
     end)
 end
 


### PR DESCRIPTION
- Cleans up the Preferences & HUD Manager to prevent freezing when
changing panels really quickly.
- Fixed some typos in `hs.tangent`
- Closes #1733