### PR TITLE
#1634

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/menu.lua
+++ b/src/extensions/cp/apple/finalcutpro/menu.lua
@@ -45,6 +45,8 @@ local missingMenuMap = {
     { path = {"Clip"},                          child = "Open in Angle Editor",     key = "FFOpenInAngleEditor" },
     { path = {"Window", "Show in Workspace"},   child = "Sidebar",                  key = "PEEventsLibrary" },
     { path = {"Window", "Show in Workspace"},   child = "Timeline",                 key = "PETimeline" },
+    { path = {"Window", "Show in Workspace"},   child = "Event Viewer",             key = "PEEventViewer" },
+    { path = {"Window", "Show in Workspace"},   child = "Timeline Index",           key = "PEDataList" },
 }
 
 menu:addMenuFinder(function(parentItem, path, childName)


### PR DESCRIPTION
- Added a workaround for the fact that
`require("cp.apple.finalcutpro"):menu():selectMenu({"Window", "Show in
Workspace", "Event Viewer”})` fails when you’re in German for some
strange reason, but works in every other language.
- Closes #1634