### PR TITLE
#1783

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/inspector/color/ColorWheels.lua
+++ b/src/extensions/cp/apple/finalcutpro/inspector/color/ColorWheels.lua
@@ -97,7 +97,6 @@ function ColorWheels:initialize(parent)
     -- NOTE: There is a bug in 10.4 where updating the slider alone doesn't update the temperature value.
     -- link these fields so they mirror each other.
     self:temperatureSlider().value:mirror(self:temperatureTextField().value)
-    self:tintSlider().value:mirror(self:tintTextField().value)
     self:mixSlider().value:mirror(self:mixTextField().value)
 end
 
@@ -159,7 +158,7 @@ end
 --- Field
 --- The tint for the corrector. A number from `-50` to `50`.
 function ColorWheels.lazy.prop:tint()
-    return self:tintSlider().value
+    return self:tintTextField().value
 end
 
 --- cp.apple.finalcutpro.inspector.color.ColorWheels.hue <cp.prop: number>
@@ -427,7 +426,7 @@ function ColorWheels.lazy.method:tintTextField()
             return ui and childMatching(ui, TextField.matches)
         end,
         toRegionalNumber, toRegionalNumberString
-    )
+    ):forceFocus()
 end
 
 --- cp.apple.finalcutpro.inspector.color.ColorWheels:hueRow() -> cp.ui.PropertyRow

--- a/src/extensions/cp/ui/TextField.lua
+++ b/src/extensions/cp/ui/TextField.lua
@@ -86,12 +86,11 @@ function TextField.lazy.prop:value()
                 local focused
                 if self._forceFocus then
                     focused = self:focused()
-                    self:focused(true)
+                    if not focused then
+                        self:focused(true)
+                    end
                 end
                 ui:setAttributeValue("AXValue", value)
-                if self._forceFocus then
-                    self:focused(focused)
-                end
                 ui:performAction("AXConfirm")
             end
         end

--- a/src/plugins/finalcutpro/tangent/color.lua
+++ b/src/plugins/finalcutpro/tangent/color.lua
@@ -337,7 +337,10 @@ function plugin.init(deps)
         If(function() return tintChange ~= 0 end)
         :Then(cw:doShow())
         :Then(function()
-            cw:show():tintSlider():shiftValue(tintChange)
+            local currentValue = cw:show():tint()
+            if currentValue then
+                cw:tint(currentValue+tintChange)
+            end
             tintChange = 0
             return true
         end)
@@ -346,9 +349,18 @@ function plugin.init(deps)
         :Then(cw:doShow())
         :Then(function()
             local currentValue = cw:show():hue()
-            if currentValue then
-                cw:hue(currentValue+hueChange)
+
+            local newValue = currentValue + hueChange
+            if newValue > 361 then
+                newValue = 0
+            elseif newValue < 0 then
+                newValue = 360
             end
+
+            if currentValue then
+                cw:hue(newValue)
+            end
+
             hueChange = 0
             return true
         end)


### PR DESCRIPTION
- Improved performance of `cp.ui.TextField` value changes
- Colour Wheel Tint Controls now use the `TextField` so that decimal
place values can be used.
- Colour Wheel Hue Controls now circle back from 360 to 0.
- Closes #1783