### PR TITLE
#1825

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -13,30 +13,30 @@ local require                   = require
 
 local hs                        = hs
 
-local log                       = require("hs.logger").new("app")
+local log                       = require "hs.logger".new "app"
 
-local application               = require("hs.application")
-local applicationwatcher		= require("hs.application.watcher")
-local ax                        = require("hs._asm.axuielement")
-local fs                        = require("hs.fs")
-local inspect                   = require("hs.inspect")
-local task                      = require("hs.task")
-local timer                     = require("hs.timer")
+local application               = require "hs.application"
+local applicationwatcher        = require "hs.application.watcher"
+local ax                        = require "hs._asm.axuielement"
+local fs                        = require "hs.fs"
+local inspect                   = require "hs.inspect"
+local task                      = require "hs.task"
+local timer                     = require "hs.timer"
 
-local axutils                   = require("cp.ui.axutils")
-local go                        = require("cp.rx.go")
-local just                      = require("cp.just")
-local languageID                = require("cp.i18n.languageID")
-local lazy                      = require("cp.lazy")
-local localeID                  = require("cp.i18n.localeID")
-local menu                      = require("cp.app.menu")
-local notifier					= require("cp.ui.notifier")
-local prefs                     = require("cp.app.prefs")
-local prop                      = require("cp.prop")
-local tools                     = require("cp.tools")
+local axutils                   = require "cp.ui.axutils"
+local go                        = require "cp.rx.go"
+local just                      = require "cp.just"
+local languageID                = require "cp.i18n.languageID"
+local lazy                      = require "cp.lazy"
+local localeID                  = require "cp.i18n.localeID"
+local menu                      = require "cp.app.menu"
+local notifier                  = require "cp.ui.notifier"
+local prefs                     = require "cp.app.prefs"
+local prop                      = require "cp.prop"
+local tools                     = require "cp.tools"
 
-local v							= require("semver")
-local class                     = require("middleclass")
+local v                         = require "semver"
+local class                     = require "middleclass"
 
 local doAfter                   = timer.doAfter
 local format                    = string.format
@@ -45,7 +45,6 @@ local insert                    = table.insert
 local printf                    = hs.printf
 local processInfo               = hs.processInfo
 local WaitUntil, Throw, If      = go.WaitUntil, go.Throw, go.If
-
 
 local app = class("app"):include(lazy)
 

--- a/src/extensions/cp/app/prefs.lua
+++ b/src/extensions/cp/app/prefs.lua
@@ -16,12 +16,11 @@
 --- end
 --- ```
 
-local require               = require
+local require       = require
 
-local cfprefs               = require("hs._asm.cfpreferences")
-local pathwatcher			      = require("hs.pathwatcher")
-local prop                  = require("cp.prop")
-
+local cfprefs       = require "hs._asm.cfpreferences"
+local pathwatcher   = require "hs.pathwatcher"
+local prop          = require "cp.prop"
 
 local mod = {}
 mod.mt = {}

--- a/src/plugins/finalcutpro/menu/menuaction.lua
+++ b/src/plugins/finalcutpro/menu/menuaction.lua
@@ -5,7 +5,7 @@
 
 local require = require
 
-local log				= require "hs.logger".new "menuaction"
+--local log				= require "hs.logger".new "menuaction"
 
 local fnutils           = require "hs.fnutils"
 local image             = require "hs.image"

--- a/src/plugins/finalcutpro/menu/menuaction.lua
+++ b/src/plugins/finalcutpro/menu/menuaction.lua
@@ -5,19 +5,19 @@
 
 local require = require
 
---local log				= require("hs.logger").new("menuaction")
+local log				= require "hs.logger".new "menuaction"
 
-local fnutils           = require("hs.fnutils")
-local image             = require("hs.image")
+local fnutils           = require "hs.fnutils"
+local image             = require "hs.image"
 
-local config            = require("cp.config")
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
-local idle              = require("cp.idle")
+local config            = require "cp.config"
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
+local idle              = require "cp.idle"
 
+local concat            = table.concat
 local imageFromPath     = image.imageFromPath
-local insert, concat    = table.insert, table.concat
-
+local insert            = table.insert
 
 local mod = {}
 
@@ -143,7 +143,7 @@ end
 --- * `true` if the action was executed successfully.
 function mod.onExecute(action)
     if action and action.path then
-        fcp:launch():menu():doSelectMenu(action.path):Now()
+        fcp:launch():menu():doSelectMenu(action.path, {plain=true}):Now()
         return true
     end
     return false
@@ -192,7 +192,6 @@ function mod.init(actionmanager)
     end
 
 end
-
 
 local plugin = {
     id              = "finalcutpro.menu.menuaction",


### PR DESCRIPTION
- Fixed a bug where triggering menu items with special characters (such
as %) would fail. `cp.app.menu` now has the option to use plain text
instead of patterns for it’s functions to get around this problem.
- Closes #1825