### PR TITLE
#1843

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -41,10 +41,13 @@ local class                     = require "middleclass"
 local doAfter                   = timer.doAfter
 local format                    = string.format
 local Given                     = go.Given
+local If                        = go.If
 local insert                    = table.insert
 local printf                    = hs.printf
 local processInfo               = hs.processInfo
-local WaitUntil, Throw, If      = go.WaitUntil, go.Throw, go.If
+local tableContains             = tools.tableContains
+local Throw                     = go.Throw
+local WaitUntil                 = go.WaitUntil
 
 local app = class("app"):include(lazy)
 
@@ -496,15 +499,16 @@ function app.lazy.prop:currentLocale()
         function()
             --------------------------------------------------------------------------------
             -- If the app is not running, we next try to determine the language using
-            -- the 'AppleLanguages' preference...
+            -- the 'AppleLanguages' preference:
             --------------------------------------------------------------------------------
             local appLanguages = self.preferences.AppleLanguages
             if appLanguages then
                 for _,lang in ipairs(appLanguages) do
                     if self:isSupportedLocale(lang) then
                         local currentLocale = localeID.forCode(lang)
-                        if currentLocale then
-                            return currentLocale
+                        local bestLocale = currentLocale and self:bestSupportedLocale(currentLocale)
+                        if bestLocale then
+                            return bestLocale
                         end
                     end
                 end
@@ -539,7 +543,6 @@ function app.lazy.prop:currentLocale()
             -- If that also fails, we use the base locale, or failing that, English:
             --------------------------------------------------------------------------------
             local locale = self:baseLocale() or localeID.forCode("en")
-
             return locale
         end,
         function(value, _, theProp)

--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -45,7 +45,6 @@ local If                        = go.If
 local insert                    = table.insert
 local printf                    = hs.printf
 local processInfo               = hs.processInfo
-local tableContains             = tools.tableContains
 local Throw                     = go.Throw
 local WaitUntil                 = go.WaitUntil
 

--- a/src/plugins/finalcutpro/console/font.lua
+++ b/src/plugins/finalcutpro/console/font.lua
@@ -6,21 +6,22 @@ local require = require
 
 local hs = hs
 
-local log				= require("hs.logger").new("fontConsole")
+local log				= require "hs.logger".new "fontConsole"
 
-local image             = require("hs.image")
-local styledtext        = require("hs.styledtext")
+local image             = require "hs.image"
+local styledtext        = require "hs.styledtext"
+local timer             = require "hs.timer"
 
-local config            = require("cp.config")
-local dialog            = require("cp.dialog")
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
-local just              = require("cp.just")
-local tools             = require("cp.tools")
+local config            = require "cp.config"
+local dialog            = require "cp.dialog"
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
+local just              = require "cp.just"
+local tools             = require "cp.tools"
 
+local doAfter           = timer.doAfter
 local execute           = hs.execute
 local imageFromPath     = image.imageFromPath
-
 
 local mod = {}
 
@@ -417,7 +418,14 @@ function plugin.init(deps)
     --------------------------------------------------------------------------------
     fcp.isRunning:watch(function(running)
         if running then
-            mod._handler:reset(true)
+            --------------------------------------------------------------------------------
+            -- Give ourselves a 5 second buffer, just incase Final Cut Pro is restarting:
+            --------------------------------------------------------------------------------
+            doAfter(5, function()
+                if fcp:isRunning() then
+                    mod._handler:reset(true)
+                end
+            end)
         end
     end)
 


### PR DESCRIPTION
- Fixed a bug in `cp.app:currentLocale()` where it could potentially
pick a language that’s not supported.
- Fixed a bug where the Font Console cache could fail to reset when
Final Cut Pro is restarting (i.e. when changing languages).
- Closes #1843