### PR TITLE
Issue/1880 menu action bug

### DIFF
--- a/src/extensions/cp/app/menu.lua
+++ b/src/extensions/cp/app/menu.lua
@@ -563,17 +563,20 @@ function menu.mt:doFindMenuUI(path, options)
 
     -- make sure the app is active.
     return If(self.UI):Then(function(ui)
-        local pathLocale = localeID(options.locale) or localeID("en")
+        local en = localeID("en")
+        local pathLocale = localeID(options.locale) or en
         local appLocale = self:app():currentLocale()
 
-        local menuTitles = self:getMenuTitles({pathLocale, appLocale})
+        local menuTitles = self:getMenuTitles({pathLocale, appLocale, en})
         local currentPath = {}
+
         local menuItemName
         local menuUI = ui
 
         return Do(Observable.fromTable(path, ipairs)):Then(
             function(step)
                 local menuItemUI
+                local currentMenuTitles = menuTitles
                 if type(step) == "number" then
                     menuItemUI = menuUI[step]
                     menuItemName = _translateTitle(menuTitles, menuItemUI, appLocale, pathLocale)
@@ -591,7 +594,7 @@ function menu.mt:doFindMenuUI(path, options)
                     -- Check with the finder functions:
                     --------------------------------------------------------------------------------
                     for _, finder in ipairs(self._itemFinders) do
-                        menuItemUI = finder(menuUI, currentPath, step, pathLocale)
+                        menuItemUI = finder(menuUI, currentPath, step, en)
                         if menuItemUI then
                             break
                         end
@@ -632,6 +635,7 @@ function menu.mt:doFindMenuUI(path, options)
                 end
 
                 if menuItemUI then
+
                     if #menuItemUI == 1 then
                         -- the item is a sub-menu. Find the next values.
                         menuUI = menuItemUI[1]
@@ -644,7 +648,9 @@ function menu.mt:doFindMenuUI(path, options)
                         end
                     end
 
-                    insert(currentPath, menuItemName)
+                    -- translate the item name to English for use in finders.
+                    local menuItemNameEn = _translateTitle(currentMenuTitles, menuItemName, pathLocale, en)
+                    insert(currentPath, menuItemNameEn)
 
                     return menuItemUI
                 else

--- a/src/extensions/cp/apple/finalcutpro/menu.lua
+++ b/src/extensions/cp/apple/finalcutpro/menu.lua
@@ -47,7 +47,6 @@ local missingMenuMap = {
     { path = {"Window", "Show in Workspace"},   child = "Timeline Index",           key = "PEDataList" },
     { path = {"Window"},                        child = "Extensions",               key = "FFExternalProviderMenuItemTitle" },
 }
-
 menu:addMenuFinder(function(parentItem, path, childName)
     for _,item in ipairs(missingMenuMap) do
         if isEqual(path, item.path) and childName == item.child then
@@ -63,6 +62,16 @@ end)
 ----------------------------------------------------------------------------------------
 menu:addMenuFinder(function(parentItem, path, childName)
     if isEqual(path, {"Window", "Workspaces"}) then
+        return childWith(parentItem, "AXTitle", childName)
+    end
+    return nil
+end)
+
+----------------------------------------------------------------------------------------
+-- Add a finder for Commands:
+----------------------------------------------------------------------------------------
+menu:addMenuFinder(function(parentItem, path, childName)
+    if isEqual(path, {"Final Cut Pro", "Commands"}) then
         return childWith(parentItem, "AXTitle", childName)
     end
     return nil

--- a/src/extensions/cp/apple/finalcutpro/menu.lua
+++ b/src/extensions/cp/apple/finalcutpro/menu.lua
@@ -4,18 +4,17 @@
 
 local require = require
 
--- local log                       = require("hs.logger").new("fcp_menu")
+--local log               = require "hs.logger".new "fcpMenu"
 
-local fcpApp                    = require("cp.apple.finalcutpro.app")
-local strings                   = require("cp.apple.finalcutpro.strings")
-local destinations              = require("cp.apple.finalcutpro.export.destinations")
+local axutils       = require "cp.ui.axutils"
+local destinations  = require "cp.apple.finalcutpro.export.destinations"
+local fcpApp        = require "cp.apple.finalcutpro.app"
+local strings       = require "cp.apple.finalcutpro.strings"
 
-local axutils                   = require("cp.ui.axutils")
+local moses         = require "moses"
 
-local isEqual                   = require("moses").isEqual
-
-local childWith                 = axutils.childWith
-
+local childWith     = axutils.childWith
+local isEqual       = moses.isEqual
 
 local menu = fcpApp:menu()
 

--- a/src/plugins/finalcutpro/menu/menuaction.lua
+++ b/src/plugins/finalcutpro/menu/menuaction.lua
@@ -68,6 +68,7 @@ function mod.reload()
             if path[1] ~= "Apple" then
                 local params = {}
                 params.path = fnutils.concat(fnutils.copy(path), { title })
+                params.locale = fcp:currentLocale()
 
                 insert(choices, {
                     text = title,
@@ -143,7 +144,8 @@ end
 --- * `true` if the action was executed successfully.
 function mod.onExecute(action)
     if action and action.path then
-        fcp:launch():menu():doSelectMenu(action.path, {plain=true}):Now()
+        fcp:launch():menu():doSelectMenu(action.path, {plain=true, locale=action.locale}):Now()
+        --fcp.app:hsApplication():selectMenuItem(action.path)
         return true
     end
     return false

--- a/src/plugins/finalcutpro/menu/menuaction.lua
+++ b/src/plugins/finalcutpro/menu/menuaction.lua
@@ -14,6 +14,7 @@ local config            = require "cp.config"
 local fcp               = require "cp.apple.finalcutpro"
 local i18n              = require "cp.i18n"
 local idle              = require "cp.idle"
+local localeID          = require "cp.i18n.localeID"
 
 local concat            = table.concat
 local imageFromPath     = image.imageFromPath
@@ -68,8 +69,7 @@ function mod.reload()
             if path[1] ~= "Apple" then
                 local params = {}
                 params.path = fnutils.concat(fnutils.copy(path), { title })
-                params.locale = fcp:currentLocale()
-
+                params.locale = fcp:currentLocale().code
                 insert(choices, {
                     text = title,
                     subText = i18n("menuChoiceSubText", {path = concat(path, " > ")}),
@@ -144,8 +144,7 @@ end
 --- * `true` if the action was executed successfully.
 function mod.onExecute(action)
     if action and action.path then
-        fcp:launch():menu():doSelectMenu(action.path, {plain=true, locale=fcp:currentLocale()}):Now()
-        --fcp.app:hsApplication():selectMenuItem(action.path)
+        fcp:launch():menu():doSelectMenu(action.path, {plain=true, locale=localeID(action.locale)}):Now()
         return true
     end
     return false

--- a/src/plugins/finalcutpro/menu/menuaction.lua
+++ b/src/plugins/finalcutpro/menu/menuaction.lua
@@ -144,7 +144,7 @@ end
 --- * `true` if the action was executed successfully.
 function mod.onExecute(action)
     if action and action.path then
-        fcp:launch():menu():doSelectMenu(action.path, {plain=true, locale=action.locale}):Now()
+        fcp:launch():menu():doSelectMenu(action.path, {plain=true, locale=fcp:currentLocale()}):Now()
         --fcp.app:hsApplication():selectMenuItem(action.path)
         return true
     end


### PR DESCRIPTION
- We now save the locale code for menu actions within the parameters,
allowing you to change Final Cut Pro languages without breaking any
saved actions (i.e. if you have a menu item action set to a Touch Bar
button).
- Added a finder function for the “Final Cut Pro > Commands” menu.
- Closes #1880