### PR TITLE
Added Bank Labels for Loupedeck & Streamdeck Preferences

### DIFF
--- a/src/plugins/core/loupedeck/banks.lua
+++ b/src/plugins/core/loupedeck/banks.lua
@@ -56,7 +56,12 @@ function plugin.init(deps)
                 local activeGroup = manager.activeGroup()
                 local activeSubGroup = manager.activeLoupedeckSubGroup()
                 if activeGroup and activeSubGroup then
-                    displayNotification(i18n("switchingTo") .. " " .. i18n("loupedeckPlus") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    local bankLabel = manager.getLoupedeckBankLabel(activeGroup .. activeSubGroup)
+                    if bankLabel then
+                        displayNotification(i18n("switchingTo") .. " " .. i18n("loupedeckPlus") .. " " .. i18n("bank") .. ": " .. bankLabel)
+                    else
+                        displayNotification(i18n("switchingTo") .. " " .. i18n("loupedeckPlus") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    end
                 end
             end
         end)

--- a/src/plugins/core/loupedeck/prefs/css/loupedeck.css
+++ b/src/plugins/core/loupedeck/prefs/css/loupedeck.css
@@ -38,6 +38,24 @@
 	width: 190px;
 }
 
+.loupedeckLabel {
+	-webkit-appearance: none;
+	text-shadow:0 1px 0 rgba(0,0,0,0.4);
+	background-color: rgba(65,65,65,1);
+	color: #bfbfbc;
+	text-decoration: none;
+	padding: 2px 18px 2px 5px;
+	border:0.5px solid black;
+	margin: 2px 2px;
+	display: inline-block;
+	border-radius: 3px;
+	border-radius: 0px;
+	cursor: default;
+	font-family: -apple-system;
+	font-size: 13px;
+	width: 150px;
+}
+
 .loupedeckRowAction {
 	width: 240px;
 }

--- a/src/plugins/core/loupedeck/prefs/html/panel.html
+++ b/src/plugins/core/loupedeck/prefs/html/panel.html
@@ -88,6 +88,23 @@
 			alertErrorMessage(err);
 		}
 	}
+
+	function updateLoupedeckBankLabel() {
+		try {
+			var result = {
+				id: "loupedeckPanelCallback",
+				params: {
+					type: "updateBankLabel",
+					groupID: document.getElementById("loupedeckGroupSelect").value + document.getElementById("loupedeckSubGroupSelect").value,
+					bankLabel: document.getElementById("loupedeckBankLabel").value,
+				},
+			}
+			postMessage(result);
+		} catch(err) {
+			alertErrorMessage(err);
+		}
+	}
+
 </script>
 <table style="width: 100%; text-align: left; vertical-align: text-bottom; padding-top: 10px;">
 	<tr>
@@ -103,7 +120,7 @@
 				{% end %}
 			</select>
 		</span></th>
-		<th style="width: 3%;"><span class="loupedeckGroupSelect"><span style="font-weight:normal; font-size:13px;">{{ i18n("bank") }}: </span>
+		<th style="width: 5%;"><span class="loupedeckGroupSelect"><span style="font-weight:normal; font-size:13px;">{{ i18n("bank") }}: </span>
 			<select id="loupedeckSubGroupSelect" style="width: 50px;" onchange="updateLoupedeckGroup()">
 				{%
 				for i=1, numberOfSubGroups do
@@ -115,6 +132,9 @@
 				{% end %}
 			</select>
 		</span></th>
+		<th style="width: 9%;"><span style="font-weight:normal; font-size:13px; padding-left:5px;">{{ i18n("label") }}: </span>
+			<input type="text" id="loupedeckBankLabel" class="loupedeckLabel" value="{{ bankLabel }}" onchange="updateLoupedeckBankLabel()" placeholder="{{ i18n("none") }}">
+		</th>
 		<th style="width: 4%;"></th>
 	</tr>
 </table>

--- a/src/plugins/core/loupedeck/prefs/init.lua
+++ b/src/plugins/core/loupedeck/prefs/init.lua
@@ -85,6 +85,27 @@ function mod.updateAction(button, group, actionTitle, handlerID, action)
     mod.items(items)
 end
 
+-- setBankLabel(group, label) -> none
+-- Function
+-- Sets a Loupedeck Bank Label.
+--
+-- Parameters:
+--  * group - Group ID as string
+--  * label - Label as string
+--
+-- Returns:
+--  * None
+local function setBankLabel(group, label)
+    local items = mod.items()
+
+    if not items[group] then
+        items[group] = {}
+    end
+    items[group]["bankLabel"] = label
+
+    mod.items(items)
+end
+
 -- resetEverything() -> none
 -- Function
 -- Prompts to reset shortcuts to default for all groups.
@@ -210,7 +231,10 @@ local function generateContent()
     local leftValue = i18n("none")
     local rightValue = i18n("none")
 
+    local bankLabel
+
     if items[groupID] then
+        bankLabel = items[groupID]["bankLabel"]
         if items[groupID][note .. "Press"] then
             if items[groupID][note .. "Press"]["actionTitle"] then
                 pressValue = items[groupID][note .. "Press"]["actionTitle"]
@@ -237,6 +261,7 @@ local function generateContent()
         groupLabels                 = groupLabels,
         groups                      = groups,
         defaultGroup                = defaultGroup,
+        bankLabel                   = bankLabel,
         i18n                        = i18n,
 
         lastNote                    = mod.lastNote(),
@@ -414,6 +439,10 @@ local function loupedeckPanelCallback(id, params)
             mod._midi.forceLoupedeckGroupChange(params["groupID"], mod.enabled())
             mod.lastGroup(params["groupID"])
             mod._manager.refresh()
+        elseif callbackType == "updateBankLabel" then
+            local groupID = params["groupID"]
+            local bankLabel = params["bankLabel"]
+            setBankLabel(groupID, bankLabel)
         else
             --------------------------------------------------------------------------------
             -- Unknown Callback:

--- a/src/plugins/core/midi/controls/banks.lua
+++ b/src/plugins/core/midi/controls/banks.lua
@@ -2,10 +2,12 @@
 ---
 --- MIDI Control Bank Actions.
 
-local require   = require
+local require               = require
 
-local dialog    = require "cp.dialog"
-local i18n      = require "cp.i18n"
+local dialog                = require "cp.dialog"
+local i18n                  = require "cp.i18n"
+
+local displayNotification   = dialog.displayNotification
 
 local plugin = {
     id              = "core.midi.controls.banks",
@@ -54,7 +56,12 @@ function plugin.init(deps)
                 local activeGroup = manager.activeGroup()
                 local activeSubGroup = manager.activeSubGroup()
                 if activeGroup and activeSubGroup then
-                    dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("midi") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    local bankLabel = manager.getBankLabel(activeGroup .. activeSubGroup)
+                    if bankLabel then
+                        displayNotification(i18n("switchingTo") .. " " .. i18n("midi") .. " " .. i18n("bank") .. ": " .. bankLabel)
+                    else
+                        displayNotification(i18n("switchingTo") .. " " .. i18n("midi") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    end
                 end
             end
         end)

--- a/src/plugins/core/midi/manager/init.lua
+++ b/src/plugins/core/midi/manager/init.lua
@@ -372,7 +372,7 @@ end
 -- Function
 -- Updates the cachedLoupedeckActiveGroupAndSubgroup variable.
 local function updateLoupedeckCachedActiveGroupAndSubgroup()
-    cachedLoupedeckActiveGroupAndSubgroup = mod.activeGroup() .. mod.activeLoupdeckSubGroup()
+    cachedLoupedeckActiveGroupAndSubgroup = mod.activeGroup() .. mod.activeLoupedeckSubGroup()
 end
 
 --- plugins.core.midi.manager.clear() -> none
@@ -517,6 +517,24 @@ function mod.getBankLabel(group)
     end
 end
 
+--- plugins.core.midi.manager.getLoupedeckBankLabel(group) -> string
+--- Function
+--- Returns a specific Loupedeck Bank Label.
+---
+--- Parameters:
+---  * group - Group ID as string
+---
+--- Returns:
+---  * Label as string
+function mod.getLoupedeckBankLabel(group)
+    local items = mod._loupedeckItems()
+    if items[group] and items[group] and items[group]["bankLabel"] then
+        return items[group]["bankLabel"]
+    else
+        return nil
+    end
+end
+
 --- plugins.core.midi.manager.getItems() -> tables
 --- Function
 --- Gets all the MIDI items in a table.
@@ -568,16 +586,16 @@ function mod.activeSubGroup()
     return tostring(result)
 end
 
---- plugins.core.midi.manager.activeSubGroup() -> string
+--- plugins.core.midi.manager.activeLoupedeckSubGroup() -> string
 --- Function
---- Returns the active sub-group.
+--- Returns the active Loupedeck+ sub-group.
 ---
 --- Parameters:
 ---  * None
 ---
 --- Returns:
 ---  * Returns the active sub group as string
-function mod.activeLoupdeckSubGroup()
+function mod.activeLoupedeckSubGroup()
     local currentSubGroup = mod._currentLoupedeckSubGroup()
     local result = 1
     local activeGroup = mod.activeGroup()
@@ -636,7 +654,12 @@ function mod.forceLoupedeckGroupChange(combinedGroupAndSubGroupID, notify)
             mod._currentLoupedeckSubGroup(currentSubGroup)
         end
         if notify then
-            dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("loupedeckPlus") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. group) .. " " .. subGroup)
+            local bankLabel = mod.getLoupedeckBankLabel(combinedGroupAndSubGroupID)
+            if bankLabel then
+                dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("loupedeckPlus") .. " " .. i18n("bank") .. ": " .. bankLabel)
+            else
+                dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("loupedeckPlus") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. group) .. " " .. subGroup)
+            end
         end
         updateLoupedeckCachedActiveGroupAndSubgroup()
     end

--- a/src/plugins/core/midi/prefs/html/panel.html
+++ b/src/plugins/core/midi/prefs/html/panel.html
@@ -272,8 +272,8 @@
 				{% end %}
 			</select>
 		</span></th>
-		<th style="width: 16%;"><span style="font-weight:normal; font-size:13px; padding-left:5px;">Label: </span>
-			<input type="text" id="midiBankLabel" class="midiLabel" value="{{ bankLabel }}" onchange="updateMIDIBankLabel()" placeholder="None">
+		<th style="width: 16%;"><span style="font-weight:normal; font-size:13px; padding-left:5px;">{{ i18nLabel }}: </span>
+			<input type="text" id="midiBankLabel" class="midiLabel" value="{{ bankLabel }}" onchange="updateMIDIBankLabel()" placeholder="{{ i18nNone }}">
 		</th>
 		<th style="width: 1%;"></th>
 	</tr>

--- a/src/plugins/core/midi/prefs/init.lua
+++ b/src/plugins/core/midi/prefs/init.lua
@@ -208,6 +208,7 @@ local function generateContent()
         i18nPitchWheelChange        = i18n("pitchWheelChange"),
         i18nAll                     = i18n("all"),
         i18nBank                    = i18n("bank"),
+        i18nLabel                   = i18n("label"),
     }
 
     return renderPanel(context)

--- a/src/plugins/core/streamdeck/banks/init.lua
+++ b/src/plugins/core/streamdeck/banks/init.lua
@@ -54,7 +54,12 @@ function mod.init()
                 local activeGroup = mod._manager.activeGroup()
                 local activeSubGroup = mod._manager.activeSubGroup()
                 if activeGroup and activeSubGroup then
-                    dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("streamDeck") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    local bankLabel = mod._manager.getBankLabel(activeGroup .. activeSubGroup)
+                    if bankLabel then
+                        dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("streamDeck") .. " " .. i18n("bank") .. ": " .. bankLabel)
+                    else
+                        dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("streamDeck") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    end
                 end
                 mod._manager.update()
             end

--- a/src/plugins/core/streamdeck/manager/init.lua
+++ b/src/plugins/core/streamdeck/manager/init.lua
@@ -49,7 +49,7 @@ mod._streamDeck = {}
 
 -- plugins.core.touchbar.manager._currentSubGroup -> table
 -- Variable
--- Current Touch Bar Sub Group Statuses.
+-- Current Stream Deck Sub Group Statuses.
 mod._currentSubGroup = config.prop("streamDeckCurrentSubGroup", {})
 
 --- plugins.core.streamdeck.manager.maxItems -> number
@@ -59,7 +59,7 @@ mod.maxItems = 15
 
 --- plugins.core.streamdeck.manager.numberOfSubGroups -> number
 --- Variable
---- The number of Sub Groups per Touch Bar Group.
+--- The number of Sub Groups per Stream Deck Group.
 mod.numberOfSubGroups = 9
 
 -- plugins.core.streamdeck.manager._items <cp.prop: table>
@@ -83,7 +83,7 @@ end
 
 --- plugins.core.streamdeck.manager.updateOrder(direction, button, group) -> none
 --- Function
---- Shifts a Touch Bar button either up or down.
+--- Shifts a Stream Deck button either up or down.
 ---
 --- Parameters:
 ---  * direction - Either "up" or "down"
@@ -124,7 +124,7 @@ end
 
 --- plugins.core.streamdeck.manager.updateIcon(button, group, icon) -> none
 --- Function
---- Updates a Touch Bar icon.
+--- Updates a Stream Deck icon.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -150,9 +150,49 @@ function mod.updateIcon(button, group, icon)
     mod.update()
 end
 
+--- plugins.core.streamdeck.manager.setBankLabel(group, label) -> none
+--- Function
+--- Sets a Stream Deck Bank Label.
+---
+--- Parameters:
+---  * group - Group ID as string
+---  * label - Label as string
+---
+--- Returns:
+---  * None
+function mod.setBankLabel(group, label)
+    local items = mod._items()
+
+    if not items[group] then
+        items[group] = {}
+    end
+    items[group]["bankLabel"] = label
+
+    mod._items(items)
+    mod.update()
+end
+
+--- plugins.core.streamdeck.manager.getBankLabel(group) -> string
+--- Function
+--- Returns a specific Stream Deck Bank Label.
+---
+--- Parameters:
+---  * group - Group ID as string
+---
+--- Returns:
+---  * Label as string
+function mod.getBankLabel(group)
+    local items = mod._items()
+    if items[group] and items[group] and items[group]["bankLabel"] then
+        return items[group]["bankLabel"]
+    else
+        return nil
+    end
+end
+
 --- plugins.core.streamdeck.manager.updateAction(button, group, action) -> boolean
 --- Function
---- Updates a Touch Bar action.
+--- Updates a Stream Deck action.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -200,7 +240,7 @@ end
 
 --- plugins.core.streamdeck.manager.updateLabel(button, group, label) -> none
 --- Function
---- Updates a Touch Bar label.
+--- Updates a Stream Deck label.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -226,31 +266,9 @@ function mod.updateLabel(button, group, label)
     mod.update()
 end
 
---- plugins.core.streamdeck.manager.updateBankLabel(group, label) -> none
---- Function
---- Updates a Touch Bar Bank Label.
----
---- Parameters:
----  * group - Group ID as string
----  * label - Label as string
----
---- Returns:
----  * None
-function mod.updateBankLabel(group, label)
-    local items = mod._items()
-
-    if not items[group] then
-        items[group] = {}
-    end
-    items[group]["bankLabel"] = label
-
-    mod._items(items)
-    mod.update()
-end
-
 --- plugins.core.streamdeck.manager.getIcon(button, group) -> string
 --- Function
---- Returns a specific Touch Bar Icon.
+--- Returns a specific Stream Deck Icon.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -269,7 +287,7 @@ end
 
 --- plugins.core.streamdeck.manager.getActionTitle(button, group) -> string
 --- Function
---- Returns a specific Touch Bar Action Title.
+--- Returns a specific Stream Deck Action Title.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -288,7 +306,7 @@ end
 
 --- plugins.core.streamdeck.manager.getActionHandlerID(button, group) -> string
 --- Function
---- Returns a specific Touch Bar Action Handler ID.
+--- Returns a specific Stream Deck Action Handler ID.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -307,7 +325,7 @@ end
 
 --- plugins.core.streamdeck.manager.getAction(button, group) -> string
 --- Function
---- Returns a specific Touch Bar Action.
+--- Returns a specific Stream Deck Action.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -326,7 +344,7 @@ end
 
 --- plugins.core.streamdeck.manager.getLabel(button, group) -> string
 --- Function
---- Returns a specific Touch Bar Label.
+--- Returns a specific Stream Deck Label.
 ---
 --- Parameters:
 ---  * button - Button ID as string
@@ -345,7 +363,7 @@ end
 
 --- plugins.core.streamdeck.manager.getBankLabel(group) -> string
 --- Function
---- Returns a specific Touch Bar Bank Label.
+--- Returns a specific Stream Deck Bank Label.
 ---
 --- Parameters:
 ---  * group - Group ID as string
@@ -434,7 +452,12 @@ function mod.forceGroupChange(combinedGroupAndSubGroupID, notify)
             mod._currentSubGroup(currentSubGroup)
         end
         if notify then
-            dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("streamDeck") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. group) .. " " .. subGroup)
+            local bankLabel = mod.getBankLabel(combinedGroupAndSubGroupID)
+            if bankLabel then
+                dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("streamDeck") .. " " .. i18n("bank") .. ": " .. bankLabel)
+            else
+                dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("streamDeck") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. group) .. " " .. subGroup)
+            end
         end
     end
 end

--- a/src/plugins/core/streamdeck/prefs/css/streamdeck.css
+++ b/src/plugins/core/streamdeck/prefs/css/streamdeck.css
@@ -100,6 +100,24 @@
 	overflow-y: scroll;
 }
 
+.streamDeckLabel {
+	-webkit-appearance: none;
+	text-shadow:0 1px 0 rgba(0,0,0,0.4);
+	background-color: rgba(65,65,65,1);
+	color: #bfbfbc;
+	text-decoration: none;
+	padding: 2px 18px 2px 5px;
+	border:0.5px solid black;
+	margin: 2px 2px;
+	display: inline-block;
+	border-radius: 3px;
+	border-radius: 0px;
+	cursor: default;
+	font-family: -apple-system;
+	font-size: 13px;
+	width: 150px;
+}
+
 .streamDeck tbody tr:hover {
 	background-color: #006dd4;
 	color: white;

--- a/src/plugins/core/streamdeck/prefs/html/panel.html
+++ b/src/plugins/core/streamdeck/prefs/html/panel.html
@@ -269,7 +269,7 @@
 				{% end %}
 			</select>
 		</span></th>
-		<th style="width: 8%;"><span class="touchBarGroupSelect"><span style="font-weight:normal; font-size:13px;">{{ i18n("bank") }}: </span>
+		<th style="width: 8%;"><span class="streamDeckGroupSelect"><span style="font-weight:normal; font-size:13px;">{{ i18n("bank") }}: </span>
 			<select id="streamDeckSubGroupSelect" style="width: 50px;" onchange="updateStreamDeckGroup()">
 				{%
 				for i=1, numberOfSubGroups do

--- a/src/plugins/core/streamdeck/prefs/html/panel.html
+++ b/src/plugins/core/streamdeck/prefs/html/panel.html
@@ -237,10 +237,26 @@
 		}
 	}
 
+	function updateStreamDeckBankLabel() {
+		try {
+			var result = {
+				id: "streamDeckPanelCallback",
+				params: {
+					type: "updateBankLabel",
+					groupID: document.getElementById("streamDeckGroupSelect").value + document.getElementById("streamDeckSubGroupSelect").value,
+					bankLabel: document.getElementById("streamDeckBankLabel").value,
+				},
+			}
+			postMessage(result);
+		} catch(err) {
+			alertErrorMessage(err);
+		}
+	}
+
 </script>
 <table style="width: 100%; text-align: left; vertical-align: text-bottom; padding-top: 10px;">
 	<tr>
-		<th style="width: 40%;"><span style="font-weight:bold; font-size:1.17em; padding-left: 20px;">{{ i18n("layoutEditor") }}</span></th>
+		<th style="width: 20%;"><span style="font-weight:bold; font-size:1.17em; padding-left: 20px;">{{ i18n("layoutEditor") }}</span></th>
 		<th style="width: 30%; text-align: right;"><span class="midiGroupSelect"><span style="font-weight:normal; font-size:13px;">{{ i18n("application") }}: </span>
 			<select id="streamDeckGroupSelect" style="width: 150px;" onchange="updateStreamDeckGroup()">
 				{%
@@ -265,7 +281,10 @@
 				{% end %}
 			</select>
 		</span></th>
-		<th style="width: 1.2%;"></th>
+		<th style="width: 16%;"><span style="font-weight:normal; font-size:13px; padding-left:5px;">{{ i18n("label") }}: </span>
+			<input type="text" id="streamDeckBankLabel" class="streamDeckLabel" value="{{ bankLabel }}" onchange="updateStreamDeckBankLabel()" placeholder="{{ i18n("none") }}">
+		</th>
+		<th style="width: 1%;"></th>
 	</tr>
 </table>
 {(html/controls.html, context)}

--- a/src/plugins/core/streamdeck/prefs/init.lua
+++ b/src/plugins/core/streamdeck/prefs/init.lua
@@ -104,6 +104,7 @@ local function generateContent()
         groupLabels             = groupLabels,
         groups                  = groups,
         defaultGroup            = defaultGroup,
+        bankLabel               = mod._sd.getBankLabel(defaultGroup),
         scrollBarPosition       = mod.scrollBarPosition(),
         groupEditor             = mod.getGroupEditor,
         i18n                    = i18n,
@@ -234,11 +235,6 @@ local function streamDeckPanelCallback(id, params)
             -- Update Label:
             --------------------------------------------------------------------------------
             mod._sd.updateLabel(params["buttonID"], params["groupID"], params["label"])
-        elseif params["type"] == "updateBankLabel" then
-            --------------------------------------------------------------------------------
-            -- Update Bank Label:
-            --------------------------------------------------------------------------------
-            mod._sd.updateBankLabel(params["groupID"], params["label"])
         elseif params["type"] == "iconClicked" then
             --------------------------------------------------------------------------------
             -- Icon Clicked:
@@ -250,7 +246,7 @@ local function streamDeckPanelCallback(id, params)
                 local icon = image.imageFromPath(path)
                 if icon then
                     local genericPath = mod.defaultIconPath .. "Generic"
-                    local touchBarPath = mod.defaultIconPath .. "Touch Bar"
+                    local touchBarPath = mod.defaultIconPath .. "Stream Deck"
                     if string.sub(path, 1, string.len(genericPath)) == genericPath or string.sub(path, 1, string.len(touchBarPath)) == touchBarPath then
                         --------------------------------------------------------------------------------
                         -- One of our pre-supplied images:
@@ -346,11 +342,15 @@ local function streamDeckPanelCallback(id, params)
                 scrollBarPosition[groupID] = value
                 mod.scrollBarPosition(scrollBarPosition)
             end
+        elseif params["type"] == "updateBankLabel" then
+            local groupID = params["groupID"]
+            local bankLabel = params["bankLabel"]
+            mod._sd.setBankLabel(groupID, bankLabel)
         else
             --------------------------------------------------------------------------------
             -- Unknown Callback:
             --------------------------------------------------------------------------------
-            log.df("Unknown Callback in Touch Bar Preferences Panel:")
+            log.df("Unknown Callback in Stream Deck Preferences Panel:")
             log.df("id: %s", hs.inspect(id))
             log.df("params: %s", hs.inspect(params))
         end
@@ -389,7 +389,7 @@ end
 
 -- resetAll() -> none
 -- Function
--- Prompts to reset all Touch Bar Preferences to their defaults.
+-- Prompts to reset all Stream Deck Preferences to their defaults.
 --
 -- Parameters:
 --  * None

--- a/src/plugins/core/touchbar/banks/init.lua
+++ b/src/plugins/core/touchbar/banks/init.lua
@@ -2,11 +2,12 @@
 ---
 --- Touch Bar Bank Actions.
 
-local require = require
+local require               = require
 
-local dialog      = require("cp.dialog")
-local i18n        = require("cp.i18n")
+local dialog                = require("cp.dialog")
+local i18n                  = require("cp.i18n")
 
+local displayNotification   = dialog.displayNotification
 
 local mod = {}
 
@@ -55,7 +56,12 @@ function mod.init()
                 local activeGroup = mod._manager.activeGroup()
                 local activeSubGroup = mod._manager.activeSubGroup()
                 if activeGroup and activeSubGroup then
-                    dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("touchBar") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    local bankLabel = mod._manager.getBankLabel(activeGroup .. activeSubGroup)
+                    if bankLabel then
+                        displayNotification(i18n("switchingTo") .. " " .. i18n("midi") .. " " .. i18n("bank") .. ": " .. bankLabel)
+                    else
+                        displayNotification(i18n("switchingTo") .. " " .. i18n("touchBar") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. activeGroup) .. " " .. activeSubGroup)
+                    end
                 end
                 mod._manager.update()
             end
@@ -63,7 +69,6 @@ function mod.init()
         :onActionId(function(action) return "touchbarBank" .. action.id end)
     return mod
 end
-
 
 local plugin = {
     id              = "core.touchbar.banks",

--- a/src/plugins/core/touchbar/manager/init.lua
+++ b/src/plugins/core/touchbar/manager/init.lua
@@ -635,7 +635,12 @@ function mod.forceGroupChange(combinedGroupAndSubGroupID, notify)
             mod._currentSubGroup(currentSubGroup)
         end
         if notify then
-            dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("touchBar") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. group) .. " " .. subGroup)
+            local bankLabel = mod.getBankLabel(combinedGroupAndSubGroupID)
+            if bankLabel then
+                dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("touchBar") .. " " .. i18n("bank") .. ": " .. bankLabel)
+            else
+                dialog.displayNotification(i18n("switchingTo") .. " " .. i18n("touchBar") .. " " .. i18n("bank") .. ": " .. i18n("shortcut_group_" .. group) .. " " .. subGroup)
+            end
         end
     end
 end

--- a/src/plugins/core/touchbar/prefs/css/touchbar.css
+++ b/src/plugins/core/touchbar/prefs/css/touchbar.css
@@ -46,6 +46,24 @@
 	width: 290px;
 }
 
+.tbLabel {
+	-webkit-appearance: none;
+	text-shadow:0 1px 0 rgba(0,0,0,0.4);
+	background-color: rgba(65,65,65,1);
+	color: #bfbfbc;
+	text-decoration: none;
+	padding: 2px 18px 2px 5px;
+	border:0.5px solid black;
+	margin: 2px 2px;
+	display: inline-block;
+	border-radius: 3px;
+	border-radius: 0px;
+	cursor: default;
+	font-family: -apple-system;
+	font-size: 13px;
+	width: 150px;
+}
+
 .tbRowIcon {
 	width: 10%;
 }

--- a/src/plugins/core/touchbar/prefs/html/controls.html
+++ b/src/plugins/core/touchbar/prefs/html/controls.html
@@ -20,15 +20,6 @@
 				</tr>
 			</thead>
 			<tbody onscroll="saveScrollbarPosition('{{ groupID }}', this);">
-			<tr>
-				<td class="tbRowIcon"></td>
-				<td class="tbRowAction"></td>
-				<td class="tbRowActionButton"></td>
-				<td class="tbRowLabel">
-					<input type="text" id="touchbar_{{ groupID }}_bankLabel" class="tbButtonLabel" value="{{ tb.getBankLabel(groupID) or i18n("none") }}" onchange="changeTouchBarBankLabel('{{ groupID }}', this.value)">
-				</td>
-				<td class="tbRowOrder"></td>
-			</tr>
 			{(html/rows.html, _.extend({groupID = groupID}, context))}
 			</tbody>
 		</table>

--- a/src/plugins/core/touchbar/prefs/html/panel.html
+++ b/src/plugins/core/touchbar/prefs/html/panel.html
@@ -188,14 +188,14 @@
 		}
 	}
 
-	function changeTouchBarBankLabel(groupID, label) {
+	function changeTouchBarBankLabel() {
 		try {
 			var result = {
 				id: "touchBarPanelCallback",
 				params: {
 					type: "updateBankLabel",
-					groupID: groupID,
-					label: label,
+					groupID: document.getElementById("touchBarGroupSelect").value + document.getElementById("touchBarSubGroupSelect").value,
+					label: document.getElementById("touchbarBankLabel").value,
 				},
 			}
 			postMessage(result);
@@ -240,7 +240,7 @@
 </script>
 <table style="width: 100%; text-align: left; vertical-align: text-bottom; padding-top: 10px;">
 	<tr>
-		<th style="width: 40%;"><span style="font-weight:bold; font-size:1.17em; padding-left: 20px;">{{ i18n("layoutEditor") }}</span></th>
+		<th style="width: 20%;"><span style="font-weight:bold; font-size:1.17em; padding-left: 20px;">{{ i18n("layoutEditor") }}</span></th>
 		<th style="width: 30%; text-align: right;"><span class="midiGroupSelect"><span style="font-weight:normal; font-size:13px;">{{ i18n("application") }}: </span>
 			<select id="touchBarGroupSelect" style="width: 150px;" onchange="updateTouchBarGroup()">
 				{%
@@ -265,7 +265,12 @@
 				{% end %}
 			</select>
 		</span></th>
-		<th style="width: 1.2%;"></th>
+		<th style="width: 16%;"><span style="font-weight:normal; font-size:13px; padding-left:5px;">{{ i18n("label") }}: </span>
+			<input type="text" id="touchbarBankLabel" class="tbLabel" value="{{ tb.getBankLabel(defaultGroup) }}" placeholder="{{ i18n("none") }}" onchange="changeTouchBarBankLabel()">
+		</th>
+		<th style="width: 1%;"></th>
 	</tr>
 </table>
 {(html/controls.html, context)}
+
+


### PR DESCRIPTION
- Moved Touch Bar Bank Label so that it matches the other preferences
panels.
- Popup now displays correct custom bank label when changing MIDI banks
via an action.
- Closes #1930