### PR TITLE
Bug Fixes for Languages other than English

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -703,7 +703,7 @@ function app.lazy.prop:currentLocale()
                 end
             end
             if self:running() then
-                self:doRestart():TimeoutAfter(20*1000):Now()
+                self:doRestart():Now()
             end
         end
     ):monitor(self.running)

--- a/src/extensions/cp/app/menu.lua
+++ b/src/extensions/cp/app/menu.lua
@@ -709,6 +709,9 @@ function menu.mt:doFindMenuUI(path, options)
 
         return Do(Observable.fromTable(path, ipairs)):Then(
             function(step)
+
+                log.df("--------------------------> STEP: %s", step)
+
                 local menuItemUI
                 local currentMenuTitles = menuTitles
                 if type(step) == "number" then
@@ -724,23 +727,53 @@ function menu.mt:doFindMenuUI(path, options)
                     end
                 else
                     menuItemName = step
+
+                    --log.df("menuItemName: %s", menuItemName)
+
                     --------------------------------------------------------------------------------
                     -- Check with the finder functions:
                     --------------------------------------------------------------------------------
                     for _, finder in ipairs(self._itemFinders) do
                         local translatedStep = _translateTitle(menuTitles, menuItemName, appLocale, en)
+
+                        --log.df("translatedStep: %s", translatedStep)
                         menuItemUI = finder(menuUI, currentPath, translatedStep, appLocale)
+
+                        --log.df("menuItemUI: %s", menuItemUI)
+
                         if menuItemUI then
+                            --log.df("BREAKING because there's a menuItemUI")
                             break
                         end
                     end
 
+                    --log.df("menuTitles: %s", menuTitles)
+
                     if not menuItemUI and menuTitles then
+                        log.df("see if the menu is in the map...")
                         --------------------------------------------------------------------------------
                         -- See if the menu is in the map:
                         --------------------------------------------------------------------------------
+                        --log.df("menuTitles: %s", hs.inspect(menuTitles))
+
+
+                        log.df("#menuTitles: %s", #menuTitles)
+
+                        --[[
+                        if #menuTitles == 0 then
+                            menuTitles = { menuTitles }
+                        end
+                        --]]
+
                         for _, item in ipairs(menuTitles) do
                             local pathItemTitle = item[pathLocale.code]
+
+                            log.df("pathLocale.code: %s", pathLocale.code)
+                            log.df("item: %s", item)
+                            log.df("pathItemTitle: %s", pathItemTitle)
+                            log.df("step: %s", step)
+                            log.df("options.plain: %s", options.plain)
+
                             if exactMatch(pathItemTitle, step, options.plain) then
                                 menuItemUI = item.ui
                                 if not axutils.isValid(menuItemUI) then
@@ -762,6 +795,7 @@ function menu.mt:doFindMenuUI(path, options)
                                         return Throw("Unable to find '%s' in '%s' with %s.", pathItemTitle, (#currentPath > 0 and concat(currentPath, " > ") or self:app():displayName()), appLocale.code)
                                     end
                                 end
+                                --log.df("item.submenu: %s", hs.inspect(item.submenu))
                                 menuTitles = item.submenu
                                 break
                             end
@@ -770,13 +804,24 @@ function menu.mt:doFindMenuUI(path, options)
                 end
 
                 if menuItemUI then
+                    log.df("there is a menuItemUI!")
 
                     if #menuItemUI == 1 then
+                        log.df("#menuItemUI is 1 so this is a sub-menu")
                         -- the item is a sub-menu. Find the next values.
                         menuUI = menuItemUI[1]
+
+                        log.df("menuUI: %s", menuUI)
+
                         for _, item in ipairs(menuTitles) do
+                            log.df("item: %s", item)
                             local mapTitle = item[appLocale.code]
+
+                            log.df("mapTitle: %s", mapTitle)
+
                             if mapTitle and exactMatch(menuItemUI:attributeValue("AXTitle"), mapTitle:gsub("%%@", ".*"), options.plain) then
+                                log.df("MATCH!")
+                                log.df("")
                                 menuTitles = item
                                 break
                             end

--- a/src/extensions/cp/app/menu.lua
+++ b/src/extensions/cp/app/menu.lua
@@ -939,7 +939,7 @@ function menu.mt:findMenuUI(path, options)
             --------------------------------------------------------------------------------
             -- Translate the 'menuItemName' to English for use in finders:
             --------------------------------------------------------------------------------
-            local menuItemNameEn = _translateTitle(currentMenuTitles, menuItemName, pathLocale, en)
+            local menuItemNameEn = _translateTitle(menuTitles, menuItemName, pathLocale, en)
             insert(currentPath, menuItemNameEn)
 
         else

--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -1686,4 +1686,24 @@ function tools.stringToHexString(value)
     return result
 end
 
+--- cp.tools.contentsInsideBrackets(value) -> string | nil
+--- Function
+--- Gets the contents of any text inside the first bracket set.
+---
+--- Parameters:
+---  * value - The string to process
+---
+--- Returns:
+---  * The contents as a string or `nil`
+function tools.contentsInsideBrackets(a)
+    --------------------------------------------------------------------------------
+    -- Workaround for Chinese:
+    --------------------------------------------------------------------------------
+    a = a:gsub("）", ")")
+    a = a:gsub("（", "(")
+
+    local b = a and string.match(a, "%(.*%)")
+    return b and b:sub(2, -2)
+end
+
 return tools

--- a/src/plugins/core/tangent/commandpost/functions.lua
+++ b/src/plugins/core/tangent/commandpost/functions.lua
@@ -6,7 +6,6 @@ local require = require
 
 local i18n = require("cp.i18n")
 
-
 local plugin = {
     id = "core.tangent.commandpost.functions",
     group = "core",
@@ -29,49 +28,49 @@ function plugin.init(deps)
     --------------------------------------------------------------------------------
     -- Global Console:
     --------------------------------------------------------------------------------
-    group:action(id, i18n("cpGlobalConsole" .. "_title"))
+    group:action(id, i18n("cpGlobalConsole_title"))
         :onPress(deps.coreConsole.show)
     id = id + 1
 
     --------------------------------------------------------------------------------
     -- Developers Guide:
     --------------------------------------------------------------------------------
-    group:action(id, i18n("cpDeveloperGuide" .. "_title"))
+    group:action(id, i18n("cpDeveloperGuide_title"))
         :onPress(deps.developerguide.show)
     id = id + 1
 
     --------------------------------------------------------------------------------
     -- Feedback:
     --------------------------------------------------------------------------------
-    group:action(id, i18n("cpFeedback" .. "_title"))
+    group:action(id, i18n("cpFeedback_title"))
         :onPress(deps.feedback.show)
     id = id + 1
 
     --------------------------------------------------------------------------------
     -- User Guide:
     --------------------------------------------------------------------------------
-    group:action(id, i18n("cpUserGuide" .. "_title"))
+    group:action(id, i18n("cpUserGuide_title"))
         :onPress(deps.userguide.show)
     id = id + 1
 
     --------------------------------------------------------------------------------
-    -- Open Error Log:
+    -- Open Debug Console:
     --------------------------------------------------------------------------------
-     group:action(id, i18n("cpOpenErrorLog" .. "_title"))
+     group:action(id, i18n("cpOpenDebugConsole_title"))
         :onPress(function() hs.openConsole() end)
     id = id + 1
 
     --------------------------------------------------------------------------------
     -- Preferences:
     --------------------------------------------------------------------------------
-     group:action(id, i18n("cpPreferences" .. "_title"))
+     group:action(id, i18n("cpPreferences_title"))
         :onPress(deps.prefsMan.show)
     id = id + 1
 
     --------------------------------------------------------------------------------
     -- Setup Watch Folders:
     --------------------------------------------------------------------------------
-     group:action(id, i18n("cpSetupWatchFolders" .. "_title"))
+     group:action(id, i18n("cpSetupWatchFolders_title"))
         :onPress(deps.watchfolders.show)
 
 end

--- a/src/plugins/finalcutpro/menu/menuaction.lua
+++ b/src/plugins/finalcutpro/menu/menuaction.lua
@@ -211,8 +211,17 @@ local function compareLegacyVersusNew(choices) -- luacheck: ignore
     log.df("%s", result)
 end
 
+-- contentsInsideBrackets(a) -> string | nil
+-- Function
+-- Gets the contents of any text inside a bracket
+--
+-- Parameters:
+--  * a - The input
+--
+-- Returns:
+--  * The contents as a string or `nil`
 local function contentsInsideBrackets(a)
-    local b = string.match(a, "%(.*%)")
+    local b = a and string.match(a, "%(.*%)")
     return b and b:sub(2, -2)
 end
 
@@ -234,6 +243,13 @@ local function applyMenuWorkarounds(choices, currentLocaleCode)
     --------------------------------------------------------------------------------
     local en = localeID("en")
     local fcpLocaleCode = fcp:currentLocale().code
+
+    --------------------------------------------------------------------------------
+    -- Add workaround for Chinese:
+    --------------------------------------------------------------------------------
+    if fcpLocaleCode == "zh_CN" then
+        fcpLocaleCode = "zh_Hans_CN"
+    end
 
     --------------------------------------------------------------------------------
     -- Final Cut Pro > Commands

--- a/src/plugins/finalcutpro/midi/controls/timeline.lua
+++ b/src/plugins/finalcutpro/midi/controls/timeline.lua
@@ -60,7 +60,7 @@ function plugin.init(deps)
     local manager = deps.manager
     manager.controls:new("timelineScrub", {
         group = "fcpx",
-        text = i18n("scrubTimeline") .. " ()" .. i18n("relative") .. ")",
+        text = i18n("scrubTimeline") .. " (" .. i18n("relative") .. ")",
         subText = i18n("scrubTimelineDescription"),
         fn = createTimelineScrub(),
     })


### PR DESCRIPTION
- Removed unnecessary code from `doFindMenuUI()` which was breaking
Chinese & Japanese support, because they had a submenu items which
contained the same name as the submenu.
- Now translates 'menuItemName' to English for use in finders in
`findMenuUI`.
- Removed the 20sec timeout from `cp.app:currentLocale()`. It now uses
the `cp.app:doRestart()` default of 60sec.
- Added `cp.tools.contentsInsideBrackets()`.
- Added workarounds for “Edit > Captions > Duplicate Captions to New
Language > Bangla” and “Edit > Captions > Duplicate Captions to New
Language > Tagalog”.
- Added workaround for Chinese menu items. Final Cut Pro has “zh_CN” language translations, however this
language code is not available in `hs.host.locale.availableLocales()`
so we have to manually correct to "zh_Hans_CN”.
- Closes #1975