### PR TITLE
Added Caffeinate option to menubar

### DIFF
--- a/src/extensions/languages/English.json
+++ b/src/extensions/languages/English.json
@@ -155,6 +155,7 @@
         "buttonLabel": "Button Label",
         "buttonPress": "Button Press",
         "buttons": "Buttons",
+        "caffeinate": "Caffeinate",
         "cancel": "Cancel",
         "center": "Center",
         "changeBrowserClipHeightDown_title": "Browser Clip Height Decrease",

--- a/src/plugins/core/menu/manager/init.lua
+++ b/src/plugins/core/menu/manager/init.lua
@@ -217,6 +217,22 @@ function plugin.init(deps)
         end)
 
     --------------------------------------------------------------------------------
+    -- Tools Section:
+    --------------------------------------------------------------------------------
+    local tools = manager.addSection(7777777)
+    local toolsEnabled = config.prop("menubarToolsEnabled", true)
+    tools:setDisabledFn(function() return not toolsEnabled() end)
+    tools:addHeading(i18n("tools"))
+    prefs:addCheckbox(105,
+        {
+            label = i18n("show") .. " " .. i18n("tools"),
+            onchange = function(_, params) toolsEnabled(params.checked) end,
+            checked = toolsEnabled,
+        }
+    )
+    manager.tools = tools
+
+    --------------------------------------------------------------------------------
     -- Help & Support Section:
     --------------------------------------------------------------------------------
     local helpAndSupport = manager.addSection(8888888)

--- a/src/plugins/core/tools/caffeinate.lua
+++ b/src/plugins/core/tools/caffeinate.lua
@@ -1,0 +1,48 @@
+--- === plugins.core.tools.caffeinate ===
+---
+--- Prevents your Mac from going to sleep.
+
+local require           = require
+
+local caffeinate        = require "hs.caffeinate"
+
+local config            = require "cp.config"
+local i18n              = require "cp.i18n"
+
+local enabled = config.prop("caffeinate.enabled", false):watch(function(value)
+    if value then
+        caffeinate.set("displayIdle", true)
+        caffeinate.set("systemIdle", true)
+        caffeinate.set("system", true)
+    else
+        caffeinate.set("displayIdle", false)
+        caffeinate.set("systemIdle", false)
+        caffeinate.set("system", false)
+    end
+end)
+
+local plugin = {
+    id				= "core.tools.caffeinate",
+    group			= "core",
+    dependencies	= {
+        ["core.menu.manager"] = "menu",
+        ["core.watchfolders.manager"]	= "watchfolders",
+    }
+}
+
+function plugin.init(deps)
+    deps.menu.tools
+        :addItem(1, function()
+            return {
+                title = i18n("enable") .. " " .. i18n("caffeinate"),
+                fn = function()
+                    enabled:toggle()
+                end,
+                checked = enabled()
+            }
+        end)
+
+    enabled:update()
+end
+
+return plugin

--- a/src/plugins/finalcutpro/hud/manager/init.lua
+++ b/src/plugins/finalcutpro/hud/manager/init.lua
@@ -958,7 +958,7 @@ local plugin = {
     required        = true,
     dependencies    = {
         ["finalcutpro.commands"] = "fcpxCmds",
-        ["finalcutpro.menu.manager"] = "menu",
+        ["core.menu.manager"] = "menu",
     }
 }
 
@@ -969,7 +969,9 @@ function plugin.init(deps, env)
     --------------------------------------------------------------------------------
    deps.menu.tools
         :addItem(10000, function()
-            return { title = i18n("enableHUD"), fn = function() mod.enabled:toggle() end, checked = mod.enabled()}
+            if fcp:isSupported() and fcp:isFrontmost() then
+                return { title = i18n("enableHUD"), fn = function() mod.enabled:toggle() end, checked = mod.enabled()}
+            end
         end)
 
     --------------------------------------------------------------------------------

--- a/src/plugins/finalcutpro/menu/manager.lua
+++ b/src/plugins/finalcutpro/menu/manager.lua
@@ -137,24 +137,6 @@ function plugin.init(deps)
         }
     )
 
-    --------------------------------------------------------------------------------
-    -- Add "Tools" section to the menubar:
-    --------------------------------------------------------------------------------
-    local tools = menuManager.addSection(6000)
-    tools:setDisabledFn(disabledFn)
-    tools:setDisabledPreferenceKey("tools")
-    tools:addHeading(i18n("tools"))
-    mod.tools = tools
-
-    local toolsDisabled = config.prop(SECTION_DISABLED_PREFERENCES_KEY_PREFIX .. "tools", false)
-    prefs:addCheckbox(406,
-        {
-            label = i18n("show") .. " " .. i18n("tools"),
-            onchange = function(_, params) toolsDisabled(not params.checked) end,
-            checked = function() return not toolsDisabled() end,
-        }
-    )
-
     return mod
 end
 


### PR DESCRIPTION
- Removed the Final Cut Pro specific “Tools” menubar section.
- Added a core “Tools” menubar section, which now contains the Final
Cut Pro HUD.
- Closes #1985