### PR TITLE
Timeline & Generator actions now ignore cache if a range is selected in the timeline

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/timeline/Timeline.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Timeline.lua
@@ -145,6 +145,7 @@ function Timeline.lazy.prop:isShowing()
         return ui ~= nil and #ui > 0
     end)
 end
+
 --- cp.apple.finalcutpro.timeline.Timeline.mainUI <cp.prop: hs._asm.axuielement; read-only>
 --- Field
 --- Returns the `axuielement` representing the 'timeline', or `nil` if not available.
@@ -314,7 +315,6 @@ function Timeline:showOnSecondary()
     return self
 end
 
-
 --- cp.apple.finalcutpro.timeline.Timeline:doShowOnSecondary() -> cp.rx.go.Statement <boolean>
 --- Method
 --- Returns a `Statement` that will ensure the timeline is in the secondary window.
@@ -404,9 +404,9 @@ end
 
 -----------------------------------------------------------------------
 --
--- CONTENT:
--- The Content is the main body of the timeline, containing the
--- Timeline Index, the Content, and the Effects/Transitions panels.
+-- CONTENTS:
+-- The Contents is the main body of the timeline, containing the
+-- Timeline Index, the Contents, and the Effects/Transitions panels.
 --
 -----------------------------------------------------------------------
 
@@ -426,8 +426,8 @@ end
 
 -----------------------------------------------------------------------
 --
--- EFFECT BROWSER:
--- The (sometimes hidden) Effect Browser.
+-- EFFECTS BROWSER:
+-- The (sometimes hidden) Effects Browser.
 --
 -----------------------------------------------------------------------
 
@@ -486,7 +486,7 @@ end
 
 -----------------------------------------------------------------------
 --
--- PLAYHEAD:
+-- SKIMMING PLAYHEAD:
 -- The Playhead that tracks under the mouse while skimming.
 --
 -----------------------------------------------------------------------
@@ -535,6 +535,17 @@ end
 ---  * `StaticText` object.
 function Timeline:title()
     return self:toolbar():title()
+end
+
+--- cp.apple.finalcutpro.timeline.Timeline.rangeSelected <cp.prop: boolean; read-only>
+--- Field
+--- Checks if a range is selected in the timeline.
+function Timeline.lazy.prop:rangeSelected()
+    return self:toolbar():duration().UI:mutate(function(original)
+        local ui = original()
+        local selected = self:app():string("PEEditorSelectedItemsDurationFormat-%@"):gsub("%%@", ".*")
+        return ui and ui:attributeValue("AXValue"):find(selected) ~= nil
+    end)
 end
 
 -----------------------------------------------------------------------

--- a/src/extensions/cp/apple/finalcutpro/timeline/Toolbar.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Toolbar.lua
@@ -232,6 +232,23 @@ function Toolbar.lazy.method:title()
     end))
 end
 
+--- cp.apple.finalcutpro.timeline.Toolbar:duration() -> cp.ui.StaticText
+--- Method
+--- Returns the duration [StaticText](cp.ui.StaticText.md) from the Timeline Titlebar.
+---
+--- Parameters:
+--- * None.
+---
+--- Returns:
+--- * The [StaticText](cp.ui.StaticText.md) containing the title.
+function Toolbar.lazy.method:duration()
+    return StaticText(self, self.UI:mutate(function(original)
+        return cache(self, "_durationUI", function()
+            return childFromLeft(original(), 2, StaticText.matches)
+        end)
+    end))
+end
+
 --- cp.apple.finalcutpro.timeline.Toolbar:appearance() -> cp.apple.finalcutpro.timeline.Appearance
 --- Method
 --- The [Appearance](cp.apple.finalcutpro.timeline.Appearance.md) button/palette control.

--- a/src/plugins/finalcutpro/timeline/generators.lua
+++ b/src/plugins/finalcutpro/timeline/generators.lua
@@ -74,9 +74,10 @@ function mod.apply(action)
     if category then cacheID = cacheID .. "-" .. name end
 
     --------------------------------------------------------------------------------
-    -- Restore from Cache:
+    -- Restore from Cache, unless there's a range selected in the timeline:
     --------------------------------------------------------------------------------
-    if mod._cache()[cacheID] then
+    local rangeSelected = fcp:timeline():rangeSelected()
+    if not rangeSelected and mod._cache()[cacheID] then
 
         --------------------------------------------------------------------------------
         -- Stop Watching Pasteboard:
@@ -292,11 +293,13 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
-    -- Cache the item for faster recall next time:
+    -- Cache the item for faster recall next time, unless there's a range selected:
     --------------------------------------------------------------------------------
-    local cache = mod._cache()
-    cache[cacheID] = base64.encode(newPasteboard)
-    mod._cache(cache)
+    if not rangeSelected then
+        local cache = mod._cache()
+        cache[cacheID] = base64.encode(newPasteboard)
+        mod._cache(cache)
+    end
 
     --------------------------------------------------------------------------------
     -- Make sure Timeline has focus:

--- a/src/plugins/finalcutpro/timeline/titles.lua
+++ b/src/plugins/finalcutpro/timeline/titles.lua
@@ -76,9 +76,10 @@ function mod.apply(action)
     if category then cacheID = cacheID .. "-" .. name end
 
     --------------------------------------------------------------------------------
-    -- Restore from Cache:
+    -- Restore from Cache, unless there's a range selected in the timeline:
     --------------------------------------------------------------------------------
-    if mod._cache()[cacheID] then
+    local rangeSelected = fcp:timeline():rangeSelected()
+    if not rangeSelected and mod._cache()[cacheID] then
 
         --------------------------------------------------------------------------------
         -- Stop Watching Pasteboard:
@@ -308,11 +309,13 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
-    -- Cache the item for faster recall next time:
+    -- Cache the item for faster recall next time, unless there's a range selected:
     --------------------------------------------------------------------------------
-    local cache = mod._cache()
-    cache[cacheID] = base64.encode(newPasteboard)
-    mod._cache(cache)
+    if not rangeSelected then
+        local cache = mod._cache()
+        cache[cacheID] = base64.encode(newPasteboard)
+        mod._cache(cache)
+    end
 
     --------------------------------------------------------------------------------
     -- Make sure Timeline has focus:


### PR DESCRIPTION
- Added `cp.apple.finalcutpro.timeline.Toolbar:duration()`
- Added `cp.apple.finalcutpro.timeline.Timeline.rangeSelected()`
- Fixed some documentation in the FCPX API.
- Closes #2014