### PR TITLE
Fixed bug in plugin scanner

### DIFF
--- a/src/plugins/finalcutpro/timeline/generators.lua
+++ b/src/plugins/finalcutpro/timeline/generators.lua
@@ -224,6 +224,26 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
+    -- If there's a range selected, do the old fashion way:
+    --------------------------------------------------------------------------------
+    if rangeSelected then
+        --------------------------------------------------------------------------------
+        -- Apply item:
+        --------------------------------------------------------------------------------
+        generators:applyItem(whichItem)
+
+        --------------------------------------------------------------------------------
+        -- Restore Layout:
+        --------------------------------------------------------------------------------
+        doAfter(0.1, function()
+            generators:loadLayout(generatorsLayout)
+            if browserLayout then browser:loadLayout(browserLayout) end
+        end)
+
+        return
+    end
+
+    --------------------------------------------------------------------------------
     -- Make sure the correct window has focus:
     --------------------------------------------------------------------------------
     local gridWindow = grid:attributeValue("AXWindow")
@@ -293,13 +313,11 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
-    -- Cache the item for faster recall next time, unless there's a range selected:
+    -- Cache the item for faster recall next time:
     --------------------------------------------------------------------------------
-    if not rangeSelected then
-        local cache = mod._cache()
-        cache[cacheID] = base64.encode(newPasteboard)
-        mod._cache(cache)
-    end
+    local cache = mod._cache()
+    cache[cacheID] = base64.encode(newPasteboard)
+    mod._cache(cache)
 
     --------------------------------------------------------------------------------
     -- Make sure Timeline has focus:

--- a/src/plugins/finalcutpro/timeline/titles.lua
+++ b/src/plugins/finalcutpro/timeline/titles.lua
@@ -80,7 +80,6 @@ function mod.apply(action)
     --------------------------------------------------------------------------------
     local rangeSelected = fcp:timeline():rangeSelected()
     if not rangeSelected and mod._cache()[cacheID] then
-
         --------------------------------------------------------------------------------
         -- Stop Watching Pasteboard:
         --------------------------------------------------------------------------------
@@ -240,6 +239,26 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
+    -- If there's a range selected, do the old fashion way:
+    --------------------------------------------------------------------------------
+    if rangeSelected then
+        --------------------------------------------------------------------------------
+        -- Apply item:
+        --------------------------------------------------------------------------------
+        generators:applyItem(whichItem)
+
+        --------------------------------------------------------------------------------
+        -- Restore Layout:
+        --------------------------------------------------------------------------------
+        doAfter(0.1, function()
+            generators:loadLayout(generatorsLayout)
+            if browserLayout then browser:loadLayout(browserLayout) end
+        end)
+
+        return
+    end
+
+    --------------------------------------------------------------------------------
     -- Make sure the correct window has focus:
     --------------------------------------------------------------------------------
     local gridWindow = grid:attributeValue("AXWindow")
@@ -255,7 +274,7 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
-    -- Select the chosen Generator:
+    -- Select the chosen Title:
     --------------------------------------------------------------------------------
     grid:setAttributeValue("AXSelectedChildren", {whichItem})
     whichItem:setAttributeValue("AXFocused", true)
@@ -309,13 +328,11 @@ function mod.apply(action)
     end
 
     --------------------------------------------------------------------------------
-    -- Cache the item for faster recall next time, unless there's a range selected:
+    -- Cache the item for faster recall next time:
     --------------------------------------------------------------------------------
-    if not rangeSelected then
-        local cache = mod._cache()
-        cache[cacheID] = base64.encode(newPasteboard)
-        mod._cache(cache)
-    end
+    local cache = mod._cache()
+    cache[cacheID] = base64.encode(newPasteboard)
+    mod._cache(cache)
 
     --------------------------------------------------------------------------------
     -- Make sure Timeline has focus:


### PR DESCRIPTION
- `cp.localized` now correctly reads both binary and plain text
property lists. Originally it was only reading binary property lists,
which caused the “Basic Title” to fail from the Console in German (for
instance).
- Individual Generator & Title actions now use a good old Ninja Mouse
click (as opposed to copy & paste) if a range is selected in the
timeline. This fixes #2014 properly this time.
- Closes #2012