### PR TITLE
Batch Export Improvements

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/app.lua
+++ b/src/extensions/cp/apple/finalcutpro/app.lua
@@ -9,7 +9,6 @@ local application = require("hs.application")
 
 local app = require("cp.app")
 
-
 local fcpID = "com.apple.FinalCut"
 local trialID = "com.apple.FinalCutTrial"
 

--- a/src/extensions/cp/apple/finalcutpro/export/ExportDialog.lua
+++ b/src/extensions/cp/apple/finalcutpro/export/ExportDialog.lua
@@ -8,96 +8,60 @@ local require               = require
 
 local axutils               = require "cp.ui.axutils"
 local dialog                = require "cp.dialog"
+local Dialog                = require "cp.ui.Dialog"
 local i18n                  = require "cp.i18n"
 local just                  = require "cp.just"
 local prop                  = require "cp.prop"
 local SaveSheet             = require "cp.apple.finalcutpro.export.SaveSheet"
+local StaticText            = require "cp.ui.StaticText"
 
 local v                     = require "semver"
 
+local cache                 = axutils.cache
+local childFromRight        = axutils.childFromRight
+local childMatching         = axutils.childMatching
+local childWithDescription  = axutils.childWithDescription
+
 local displayMessage        = dialog.displayMessage
+
 local doUntil               = just.doUntil
 local wait                  = just.wait
 
-local ExportDialog = {}
+local ExportDialog = Dialog:subclass("cp.apple.finalcutpro.export.ExportDialog")
 
---- cp.apple.finalcutpro.export.ExportDialog.matches(element) -> boolean
---- Function
---- Checks to see if an element matches what we think it should be.
----
---- Parameters:
----  * element - An `axuielementObject` to check.
----
---- Returns:
----  * `true` if matches otherwise `false`
-function ExportDialog.matches(element)
-    if element then
-        return element:attributeValue("AXSubrole") == "AXDialog"
-           and element:attributeValue("AXModal")
-           and axutils.childWithDescription(element, "PE Share WindowBackground") ~= nil
-    end
-    return false
+function ExportDialog.static.matches(element)
+    return element:attributeValue("AXSubrole") == "AXDialog"
+        and element:attributeValue("AXModal")
+        and childWithDescription(element, "PE Share WindowBackground") ~= nil
 end
 
---- cp.apple.finalcutpro.export.ExportDialog.new(app) -> ExportDialog
+--- cp.apple.finalcutpro.export.ExportDialogTitleText(parent)
 --- Constructor
---- Creates a new Export Dialog object.
----
---- Parameters:
----  * app - The `cp.apple.finalcutpro` object.
----
---- Returns:
----  * A new ExportDialog object.
-function ExportDialog.new(app)
-    local o = prop.extend({_app = app}, ExportDialog)
-
-    local UI = app.windowsUI:mutate(function(original, self)
-        return axutils.cache(self, "_ui", function()
-            return axutils.childMatching(original(), ExportDialog.matches)
-        end,
-        ExportDialog.matches)
-    end)
-
-    prop.bind(o) {
---- cp.apple.finalcutpro.export.ExportDialog.UI <cp.prop: hs._asm.axuielement: read-only; live>
---- Field
---- Returns the Export Dialog `axuielement`.
-        UI = UI,
-
---- cp.apple.finalcutpro.export.ExportDialog.isShowing <cp.prop: boolean; read-only; live>
---- Field
---- Is the window showing?
-        isShowing = UI:ISNOT(nil),
-
---- cp.apple.finalcutpro.export.ExportDialog.title <cp.prop: string; read-only; live>
---- Field
---- The window title, or `nil` if not available.
-        title = UI:mutate(function(original)
-            local ui = original()
-            return ui and ui:attributeValue("AXTitle")
-        end),
-    }
-
-    return o
+--- Creates a new Export [Dialog](cp.ui.Dialog.md)
+function ExportDialog:initialize(parent)
+    Dialog.initialize(self, parent, parent.windowsUI:mutate(function(original)
+        return cache(self, "_window", function()
+            return childMatching(original(), ExportDialog.matches)
+        end, ExportDialog.matches)
+    end))
 end
 
---- cp.apple.finalcutpro.export.ExportDialog:app() -> App
---- Method
---- Returns the app instance representing Final Cut Pro.
----
---- Parameters:
----  * None
----
---- Returns:
----  * App
-function ExportDialog:app()
-    return self._app
+-- isDefaultItem(menuItem) -> boolean
+-- Function
+-- Is an element the default item?
+--
+-- Parameters
+--  * element - The UI of the AXMenuItem to check.
+--
+-- Returns:
+--  * `true` if the element is the default item, otherwise `false`
+local function isDefaultItem(element)
+    return element and element:attributeValue("AXMenuItemCmdChar") ~= nil
 end
 
-local function isDefaultItem(menuItem)
-    return menuItem:attributeValue("AXMenuItemCmdChar") ~= nil
-end
-
+-- destinationFormat -> string
+-- Constant
+-- Destination Format.
 local destinationFormat = "(.+)…"
 
 --- cp.apple.finalcutpro.export.ExportDialog:show(destinationSelect, ignoreProxyWarning, ignoreMissingMedia, ignoreInvalidCaptions, quiet) -> cp.apple.finalcutpro.export.ExportDialog, string
@@ -314,6 +278,17 @@ function ExportDialog:pressNext()
         end
     end
     return self
+end
+
+--- cp.apple.finalcutpro.export.ExportDialog:fileExtension() -> cp.ui.StaticText
+--- Method
+--- The "File Extension" [StaticText](cp.ui.StaticText.md).
+function ExportDialog.lazy.method:fileExtension()
+    return StaticText(self, self.UI:mutate(function(original)
+        return cache(self, "_next", function()
+            return childFromRight(original(), 2, StaticText.matches)
+        end, StaticText.matches)
+    end))
 end
 
 --- cp.apple.finalcutpro.export.ExportDialog:saveSheet() -> SaveSheet

--- a/src/extensions/cp/apple/finalcutpro/init.lua
+++ b/src/extensions/cp/apple/finalcutpro/init.lua
@@ -846,7 +846,7 @@ end
 --- Returns:
 ---  * The Final Cut Pro Export Dialog Box
 function fcp.lazy.method:exportDialog()
-    return ExportDialog.new(self)
+    return ExportDialog(self)
 end
 
 --- cp.apple.finalcutpro:findAndReplaceTitleText() -> FindAndReplaceTitleText

--- a/src/extensions/cp/apple/finalcutpro/main/FindAndReplaceTitleText.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/FindAndReplaceTitleText.lua
@@ -15,12 +15,18 @@ local TextField	        = require "cp.ui.TextField"
 
 local strings           = require "cp.apple.finalcutpro.strings"
 
-local If, Given, Do     = go.If, go.Given, go.Do
+local Do                = go.Do
+local Given             = go.Given
+local If                = go.If
+
 local ninjaMouseClick	= tools.ninjaMouseClick
 
-local childFromTop, childFromLeft, childFromRight   = axutils.childFromTop, axutils.childFromLeft, axutils.childFromRight
-local childrenBelow	                        = axutils.childrenBelow
-local childMatching, cache	                = axutils.childMatching, axutils.cache
+local cache             = axutils.cache
+local childFromLeft     = axutils.childFromLeft
+local childFromRight    = axutils.childFromRight
+local childFromTop      = axutils.childFromTop
+local childMatching	    = axutils.childMatching
+local childrenBelow	    = axutils.childrenBelow
 
 local FindAndReplace = Dialog:subclass("cp.apple.finalcutpro.main.FindAndReplaceTitleText")
 

--- a/src/extensions/cp/ui/Window.lua
+++ b/src/extensions/cp/ui/Window.lua
@@ -4,22 +4,20 @@
 
 local require = require
 
-local hswindow                      = require("hs.window")
-local class                         = require("middleclass")
+local hswindow          = require "hs.window"
+local class             = require "middleclass"
 
-local lazy                          = require("cp.lazy")
-local prop                          = require("cp.prop")
-local axutils                       = require("cp.ui.axutils")
-local notifier                      = require("cp.ui.notifier")
-local Alert                         = require("cp.ui.Alert")
-local Button                        = require("cp.ui.Button")
+local lazy              = require "cp.lazy"
+local prop              = require "cp.prop"
+local axutils           = require "cp.ui.axutils"
+local notifier          = require "cp.ui.notifier"
+local Alert             = require "cp.ui.Alert"
+local Button            = require "cp.ui.Button"
 
-local If                            = require("cp.rx.go.If")
-local WaitUntil                     = require("cp.rx.go.WaitUntil")
+local If                = require "cp.rx.go.If"
+local WaitUntil         = require "cp.rx.go.WaitUntil"
 
-
-local format                        = string.format
-
+local format            = string.format
 
 local Window = class("cp.ui.Window"):include(lazy)
 


### PR DESCRIPTION
- `cp.apple.finalcutpro.export.ExportDialog` now uses middleclass.
- Added `cp.apple.finalcutpro.export.ExportDialog:fileExtension()`.
- Improved file incrementing during timeline batch export.
- Batch Export now triggers if you press “Return” with the Batch Export
window open.
- Closes #2050