### PR TITLE
Various Fixes

### DIFF
--- a/src/extensions/cp/plist/plistParse.lua
+++ b/src/extensions/cp/plist/plistParse.lua
@@ -17,7 +17,6 @@
 --- local plistTable = plistParse(plistStr)
 --- ```
 
-
 local plp = {}
 
 function plp.nextTag(s, i)
@@ -117,7 +116,7 @@ function plp.dictionary(s, i)
 end
 
 local function plistParse(s)
-    if type(s) == "nil" then
+    if type(s) == "nil" or s == "" then
         return nil
     end
 
@@ -132,7 +131,7 @@ local function plistParse(s)
         -- BUG: Something is going funky here with complex plist's:
 
         if ni == nil then
-            print(string.format("Fatal Error: Something has gone wrong in plistParse at #%s: %s", lastIndex+1, s))
+            print(string.format("Fatal Error: Something has gone wrong in plistParse at #%s: '%s'", lastIndex+1, s))
             return nil
         else
             assert(ni)

--- a/src/extensions/cp/strings/source/plist.lua
+++ b/src/extensions/cp/strings/source/plist.lua
@@ -24,11 +24,9 @@ local moses             = require "moses"
 local extend            = moses.extend
 
 local delayed           = timer.delayed
-local escapeXML         = text.escapeXML
 local find              = string.find
 local insert            = table.insert
 local len               = string.len
-local unescapeXML       = text.unescapeXML
 
 local mod = {}
 mod.mt = {}
@@ -144,7 +142,7 @@ function mod.mt:find(key, context)
         end
     end
 
-    return unescapeXML(values[escapeXML(key)])
+    return values[key]
 end
 
 --- cp.strings.source.plist:findKeys(pattern[, context]) -> table of strings
@@ -168,11 +166,10 @@ function mod.mt:findKeys(pattern, context)
 
     local keys = {}
     for k,v in pairs(values) do
-        v = unescapeXML(v)
         -- check if the pattern matches the beginning of the key value
         local s, e = find(v, pattern)
         if s == 1 and e == len(v) then
-        insert(keys, unescapeXML(k))
+        insert(keys, k)
         end
     end
     return keys

--- a/src/plugins/core/loupedeck/prefs/init.lua
+++ b/src/plugins/core/loupedeck/prefs/init.lua
@@ -313,7 +313,7 @@ local function loupedeckPanelCallback(id, params)
                             --------------------------------------------------------------------------------
                             -- Don't include "widgets" (that are used for the Touch Bar):
                             --------------------------------------------------------------------------------
-                            if handlerTable[2] ~= "widgets" and handlerTable[2] ~= "midicontrols" then
+                            if handlerTable[2] ~= "widgets" and handlerTable[2] ~= "midicontrols" and v ~= "global_menuactions" then
                                 table.insert(allowedHandlers, v)
                             end
                         end

--- a/src/plugins/core/midi/prefs/init.lua
+++ b/src/plugins/core/midi/prefs/init.lua
@@ -610,7 +610,7 @@ local function midiPanelCallback(id, params)
                             --------------------------------------------------------------------------------
                             -- Don't include "widgets" (that are used for the Touch Bar):
                             --------------------------------------------------------------------------------
-                            if handlerTable[2] ~= "widgets" then
+                            if handlerTable[2] ~= "widgets" and v ~= "global_menuactions" then
                                 table.insert(allowedHandlers, v)
                             end
                         end

--- a/src/plugins/core/streamdeck/prefs/init.lua
+++ b/src/plugins/core/streamdeck/prefs/init.lua
@@ -159,7 +159,7 @@ local function streamDeckPanelCallback(id, params)
                     local allowedHandlers = {}
                     for _,v in pairs(handlerIds) do
                         local handlerTable = tools.split(v, "_")
-                        if handlerTable[1] == groupID or handlerTable[1] == "global" then
+                        if handlerTable[1] == groupID or handlerTable[1] == "global" and v ~= "global_menuactions" then
                             table.insert(allowedHandlers, v)
                         end
                     end

--- a/src/plugins/core/touchbar/prefs/init.lua
+++ b/src/plugins/core/touchbar/prefs/init.lua
@@ -162,7 +162,7 @@ local function touchBarPanelCallback(id, params)
                     local allowedHandlers = {}
                     for _,v in pairs(handlerIds) do
                         local handlerTable = tools.split(v, "_")
-                        if handlerTable[1] == groupID or handlerTable[1] == "global" then
+                        if handlerTable[1] == groupID or handlerTable[1] == "global" and v ~= "global_menuactions" then
                             table.insert(allowedHandlers, v)
                         end
                     end

--- a/src/plugins/finalcutpro/actions/custom.lua
+++ b/src/plugins/finalcutpro/actions/custom.lua
@@ -3,15 +3,17 @@
 --- Creates a bunch of commands that can be used to assign actions to.
 --- This allows you to assign any action to a shortcut key in CommandPost.
 
-local require       = require
+local require           = require
 
-local log           = require "hs.logger".new "customAction"
+local log               = require "hs.logger".new "customAction"
 
-local fcp           = require "cp.apple.finalcutpro"
-local config        = require "cp.config"
-local prop          = require "cp.prop"
-local tools         = require "cp.tools"
-local i18n          = require "cp.i18n"
+local config            = require "cp.config"
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
+local prop              = require "cp.prop"
+local tools             = require "cp.tools"
+
+local removeFromTable   = tools.removeFromTable
 
 local mod           = {}
 
@@ -103,10 +105,12 @@ function mod.assign(id, completionFn)
         end)
 
     --------------------------------------------------------------------------------
-    -- Remove Final Cut Pro Commands from Activator:
+    -- Remove Final Cut Pro Commands & Global Menu Actions from Activator:
     --------------------------------------------------------------------------------
     local handlerIds = mod._actionmanager.handlerIds()
-    activator:allowHandlers(table.unpack(tools.removeFromTable(handlerIds, "fcpx_cmds")))
+    local allowedHandlers = removeFromTable(handlerIds, "fcpx_cmds")
+    allowedHandlers = removeFromTable(allowedHandlers, "global_menuactions")
+    activator:allowHandlers(table.unpack(allowedHandlers))
 
     --------------------------------------------------------------------------------
     -- Don't bother remembering the last query:

--- a/src/plugins/finalcutpro/console/console.lua
+++ b/src/plugins/finalcutpro/console/console.lua
@@ -37,7 +37,7 @@ function plugin.init(deps)
             local handlerIds = actionmanager.handlerIds()
             for _,id in pairs(handlerIds) do
                 local handlerTable = tools.split(id, "_")
-                if handlerTable[2]~= "widgets" then
+                if handlerTable[2]~= "widgets" and id ~= "global_menuactions" then
                     table.insert(allowedHandlers, id)
                 end
             end


### PR DESCRIPTION
- `cp.plist.plistParse` no longer generates an error if given a blank
(“”) string.
- Removed escape/unescape code from `cp.strings.source.plist`, as this
is no longer required by `hs.plist`.
- Removed “Active Application Menu Items” from various Search Consoles
where it made no sense to have these items.
- Closes #2077