### PR TITLE
Changes to software updates

### DIFF
--- a/src/extensions/cp/idle/init.lua
+++ b/src/extensions/cp/idle/init.lua
@@ -4,15 +4,14 @@
 --- been idle for a specified amount of time. 'Idle' is defined as no keyboard
 --- or mouse movement.
 
-local require = require
+local require       = require
 
-local log						= require("hs.logger").new("idle")
+local log			= require "hs.logger" .new "idle"
 
-local host						= require("hs.host")
-local timer						= require("hs.timer")
+local host			= require "hs.host"
+local timer			= require "hs.timer"
 
-local insert					= table.insert
-
+local insert        = table.insert
 
 local mod = {}
 
@@ -40,7 +39,6 @@ local function checkQueue()
                 insert(newQueue, item)
             end
         end
-
         queue = newQueue
     end
 end

--- a/src/plugins/core/preferences/updates.lua
+++ b/src/plugins/core/preferences/updates.lua
@@ -6,7 +6,7 @@ local require           = require
 
 local hs                = hs
 
-local log               = require "hs.logger" .new "updates"
+--local log               = require "hs.logger" .new "updates"
 
 local timer             = require "hs.timer"
 

--- a/src/plugins/core/preferences/updates.lua
+++ b/src/plugins/core/preferences/updates.lua
@@ -2,45 +2,58 @@
 ---
 --- Updates Module.
 
-local require = require
-local hs = hs
+local require           = require
 
-local i18n = require "cp.i18n"
+local hs                = hs
+
+local log               = require "hs.logger" .new "updates"
+
+local timer             = require "hs.timer"
+
+local config            = require "cp.config"
+local i18n              = require "cp.i18n"
+local idle              = require "cp.idle"
+
+local checkForUpdates   = hs.checkForUpdates
+local doAfter           = timer.doAfter
+local doEvery           = timer.doEvery
 
 local mod = {}
 
---- plugins.core.preferences.updates.toggleCheckForUpdates() -> nil
---- Function
---- Toggles 'Check For Updates'
----
---- Parameters:
----  * None
----
---- Returns:
----  * None
-function mod.toggleCheckForUpdates()
-    local automaticallyCheckForUpdates = hs.automaticallyCheckForUpdates()
-    hs.automaticallyCheckForUpdates(not automaticallyCheckForUpdates)
-    mod.automaticallyCheckForUpdates = not automaticallyCheckForUpdates
-    if not automaticallyCheckForUpdates then
-        hs.checkForUpdates(true)
+--- plugins.core.preferences.updates.automaticallyCheckForUpdates <cp.prop: boolean>
+--- Variable
+--- Automatically check for updates?
+mod.automaticallyCheckForUpdates = config.prop("automaticallyCheckForUpdates", true):watch(function(value)
+    if value then
+        --------------------------------------------------------------------------------
+        -- Start update timer:
+        --------------------------------------------------------------------------------
+        if not mod.timer then
+            mod.timer = doEvery(3600, function() -- Check every hour
+                if not mod._alreadyInQueue then
+                    idle.queue(30, function() -- Wait until the Mac is idle for 30 seconds
+                        hs.checkForUpdates(true)
+                        if hs.updateAvailable() then
+                            doAfter(1, function()
+                                checkForUpdates()
+                            end)
+                        end
+                        mod._alreadyInQueue = false
+                    end, false)
+                    mod._alreadyInQueue = true
+                end
+            end):fire()
+        end
+    else
+        --------------------------------------------------------------------------------
+        -- Destroy update timer:
+        --------------------------------------------------------------------------------
+        if mod.timer then
+            mod.timer:stop()
+            mod.timer  = nil
+        end
     end
-end
-
---- plugins.core.preferences.updates.checkForUpdates() -> boolean
---- Function
---- Returns the 'Check for Updates' status
----
---- Parameters:
----  * None
----
---- Returns:
----  * `true` or `false`
-function mod.checkForUpdates()
-    hs.focus()
-    hs.checkForUpdates()
-end
-
+end)
 
 local plugin = {
     id              = "core.preferences.updates",
@@ -52,39 +65,63 @@ local plugin = {
 }
 
 function plugin.init(deps)
+    --------------------------------------------------------------------------------
+    -- We don't want to do it automatically with Sparkle,
+    -- we want to do it manually in Lua-land:
+    --------------------------------------------------------------------------------
+    hs.automaticallyCheckForUpdates(false)
 
-    mod.automaticallyCheckForUpdates = hs.automaticallyCheckForUpdates()
+    --------------------------------------------------------------------------------
+    -- Add update info to menubar:
+    --------------------------------------------------------------------------------
+    local top = deps.menu.top
+    top
+        :addItem(0.00000000000000000000000000001, function()
+            if hs.updateAvailable() then
+                local version, build = hs.updateAvailable()
+                return {
+                    title   = i18n("updateAvailable") .. ": " .. version .. " (" .. build .. ")",
+                    fn      = function() hs.focus(); checkForUpdates() end
+                }
+            end
+        end)
+        :addSeparator(2)
 
-    if hs.automaticallyCheckForUpdates() then
+    --------------------------------------------------------------------------------
+    -- General Preferences:
+    --------------------------------------------------------------------------------
+    local general = deps.general
+    general
+        :addCheckbox(4,
+            {
+                label       = i18n("automaticallyCheckForUpdates"),
+                onchange    = function() mod.automaticallyCheckForUpdates:toggle() end,
+                checked     = function() return mod.automaticallyCheckForUpdates() end,
+                disabled    = function() return not hs.canCheckForUpdates() end,
+            }
+        )
+        :addButton(5,
+            {
+                label   = i18n("checkForUpdatesNow"),
+                width       = 200,
+                onclick = function() checkForUpdates() end,
+            }
+        )
+
+end
+
+function plugin.postInit()
+    --------------------------------------------------------------------------------
+    -- Check for updates when CommandPost first loads:
+    --------------------------------------------------------------------------------
+    if mod.automaticallyCheckForUpdates() then
         hs.checkForUpdates(true)
     end
 
-    deps.menu.top:addItem(0.00000000000000000000000000001, function()
-        if hs.updateAvailable() and hs.automaticallyCheckForUpdates() then
-            local version, build = hs.updateAvailable()
-            return { title = i18n("updateAvailable") .. ": " .. version .. " (" .. build .. ")",    fn = mod.checkForUpdates }
-        end
-    end)
-    :addSeparator(2)
-
-    deps.general:addCheckbox(4,
-        {
-            label = i18n("automaticallyCheckForUpdates"),
-            onchange = mod.toggleCheckForUpdates,
-            checked = hs.automaticallyCheckForUpdates,
-            disabled = function() return not hs.canCheckForUpdates() end,
-        }
-    )
-
-    deps.general:addButton(5,
-        {
-            label   = i18n("checkForUpdatesNow"),
-            width       = 200,
-            onclick = function() hs.checkForUpdates() end,
-        }
-    )
-
-
+    --------------------------------------------------------------------------------
+    -- Setup update timer:
+    --------------------------------------------------------------------------------
+    mod.automaticallyCheckForUpdates:update()
 end
 
 return plugin


### PR DESCRIPTION
- We no longer rely on Sparkle to do automatic updates, and now check
manually in Lua-land using timers.
- We now check for updates when CommandPost starts, and then every hour
afterwards, but only prompt the user if the Mac has been idle for at
least 30 seconds.
- Closes #1869