### PR TITLE
Fixed bug in cp.localized

### DIFF
--- a/src/extensions/cp/localized/init.lua
+++ b/src/extensions/cp/localized/init.lua
@@ -154,7 +154,7 @@ local function getLocalizedName(path, locale)
         end
         return result, file
     else
-        file = match(path, "^.-([^/%.]+)$")
+        file = match(path, "^.-([^/]+)$")
         return file, file
     end
 end


### PR DESCRIPTION
- This bug prevented Motion Templates with dots in the folder name from
being scanned.
- Closes #2102