### PR TITLE
Fixed bug in Stream Deck Manager

### DIFF
--- a/src/plugins/core/streamdeck/manager/init.lua
+++ b/src/plugins/core/streamdeck/manager/init.lua
@@ -727,7 +727,7 @@ function mod.discoveryCallback(connected, object)
             mod._streamDeck[serialNumber] = object:buttonCallback(mod.buttonCallback)
             mod.update()
         else
-            if mod._streamDeck[serialNumber] then
+            if mod._streamDeck and mod._streamDeck[serialNumber] then
                 --log.df("Disconnected Stream Deck: %s", serialNumber)
                 mod._streamDeck[serialNumber] = nil
             else


### PR DESCRIPTION
- If a Stream Deck is connected then quickly disconnected before the
device as had a chance to establish, you can get a rare `nil` error.
- Closes #2108