### PR TITLE
Improved Plugin Load Times

### DIFF
--- a/src/extensions/cp/plugins/init.lua
+++ b/src/extensions/cp/plugins/init.lua
@@ -145,7 +145,7 @@
 ---
 --- These modules will not be accessible to other plugins or to the main application. They are only available to code inside the plugin.
 
-local require = require
+local require       = require
 
 local log           = require "hs.logger".new "plugins"
 
@@ -167,7 +167,7 @@ local mod = {}
 -- SLOW_PLUGIN_WARNING_THRESHOLD -> number
 -- Constant
 -- Slow Plugin Warning Threshold
-local SLOW_PLUGIN_WARNING_THRESHOLD = 0.1
+local SLOW_PLUGIN_WARNING_THRESHOLD = 1
 
 --- cp.plugins.CACHE -> table
 --- Constant

--- a/src/extensions/languages/English.json
+++ b/src/extensions/languages/English.json
@@ -1336,6 +1336,7 @@
         "removeFavouriteKeyword": "Remove Favourite Keyword",
         "renameButton": "Rename Button",
         "renameButtonQuestion": "What would you like to rename this button to?",
+        "renameClip": "Rename Clip",
         "renderComplete": "Render Complete!",
         "replace": "Replace",
         "replaceAll": "Replace All",

--- a/src/plugins/core/tangent/manager/init.lua
+++ b/src/plugins/core/tangent/manager/init.lua
@@ -8,33 +8,33 @@
 --- Download the Tangent Developer Support Pack & Tangent Hub Installer for Mac
 --- here: http://www.tangentwave.co.uk/developer-support/
 
-local require = require
+local require           = require
 
-local log                                       = require("hs.logger").new("tangentMan")
+local log               = require "hs.logger".new "tangentMan"
 
-local application                               = require("hs.application")
-local fs                                        = require("hs.fs")
-local inspect                                   = require("hs.inspect")
-local tangent                                   = require("hs.tangent")
-local timer                                     = require("hs.timer")
+local application       = require "hs.application"
+local fs                = require "hs.fs"
+local inspect           = require "hs.inspect"
+local tangent           = require "hs.tangent"
+local timer             = require "hs.timer"
 
-local config                                    = require("cp.config")
-local fcp                                       = require("cp.apple.finalcutpro")
-local is                                        = require("cp.is")
-local prop                                      = require("cp.prop")
-local tools                                     = require("cp.tools")
-local x                                         = require("cp.web.xml")
+local config            = require "cp.config"
+local fcp               = require "cp.apple.finalcutpro"
+local is                = require "cp.is"
+local prop              = require "cp.prop"
+local tools             = require "cp.tools"
+local x                 = require "cp.web.xml"
 
-local action                                    = require("action")
-local controls                                  = require("controls")
-local menu                                      = require("menu")
-local mode                                      = require("mode")
-local parameter                                 = require("parameter")
+local action            = require "action"
+local controls          = require "controls"
+local menu              = require "menu"
+local mode              = require "mode"
+local parameter         = require "parameter"
 
-local doAfter                                   = timer.doAfter
-local format                                    = string.format
-local insert, sort                              = table.insert, table.sort
-
+local doAfter           = timer.doAfter
+local format            = string.format
+local insert            = table.insert
+local sort              = table.sort
 
 local mod = {}
 
@@ -678,7 +678,6 @@ end
 function mod._test(...)
     return require("all_tests")(...)
 end
-
 
 local plugin = {
     id          = "core.tangent.manager",

--- a/src/plugins/finalcutpro/inspector/show.lua
+++ b/src/plugins/finalcutpro/inspector/show.lua
@@ -23,50 +23,52 @@ local plugin = {
 function plugin.init(deps)
     deps.fcpxCmds
         :add("goToAudioInspector")
-        :whenActivated(fcp:inspector():audio():doShow())
+        :whenActivated(function() fcp:inspector():audio():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("audio") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToInfoInspector")
-        :whenActivated(fcp:inspector():info():doShow())
+        :whenActivated(function() fcp:inspector():info():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("info") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToTitleInspector")
-        :whenActivated(fcp:inspector():title():doShow())
+        :whenActivated(function() fcp:inspector():title():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("title") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToTextInspector")
-        :whenActivated(fcp:inspector():text():doShow())
+        :whenActivated(function() fcp:inspector():text():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("text") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToVideoInspector")
-        :whenActivated(fcp:inspector():video():doShow())
+        :whenActivated(function() fcp:inspector():video():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("video") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToGeneratorInspector")
-        :whenActivated(fcp:inspector():generator():doShow())
+        :whenActivated(function() fcp:inspector():generator():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("generator") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToShareInspector")
-        :whenActivated(fcp:inspector():share():doShow())
+        :whenActivated(function() fcp:inspector():share():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("share") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("goToTransitionInspector")
-        :whenActivated(fcp:inspector():transition():doShow())
+        :whenActivated(function() fcp:inspector():transition():doShow():Now() end)
         :titled(i18n("goTo") .. " " .. i18n("transition") .. " " .. i18n("inspector"))
 
     deps.fcpxCmds
         :add("modifyProject")
-        :whenActivated(Do(fcp:inspector():projectInfo():doShow())
-            :Then(fcp:inspector():projectInfo():modify():doPress())
-            :Label("plugins.finalcutpro.inspector.show.modifyProject")
-        )
+        :whenActivated(function()
+            Do(fcp:inspector():projectInfo():doShow())
+                :Then(fcp:inspector():projectInfo():modify():doPress())
+                :Label("plugins.finalcutpro.inspector.show.modifyProject")
+                :Now()
+        end)
         :titled(i18n("modifyProject"))
 end
 

--- a/src/plugins/finalcutpro/inspector/video.lua
+++ b/src/plugins/finalcutpro/inspector/video.lua
@@ -314,28 +314,28 @@ function plugin.init(deps)
     local fcpxCmds = deps.fcpxCmds
     fcpxCmds
         :add("cpStabilizationEnable")
-        :whenActivated(doStabilization(true))
+        :whenActivated(function() doStabilization(true):Now() end)
 
     fcpxCmds
         :add("cpStabilizationDisable")
-        :whenActivated(doStabilization(false))
+        :whenActivated(function() doStabilization(false):Now() end)
 
     --------------------------------------------------------------------------------
     -- Stabilization Method:
     --------------------------------------------------------------------------------
     fcpxCmds
         :add("stabilizationMethodAutomatic")
-        :whenActivated(doStabilizationMethod("FFStabilizationDynamic"))
+        :whenActivated(function() doStabilizationMethod("FFStabilizationDynamic"):Now() end)
         :titled(i18n("stabilizationMethod") .. ": " .. i18n("automatic"))
 
     fcpxCmds
         :add("stabilizationMethodInertiaCam")
-        :whenActivated(doStabilizationMethod("FFStabilizationUseInertiaCam"))
+        :whenActivated(function() doStabilizationMethod("FFStabilizationUseInertiaCam"):Now() end)
         :titled(i18n("stabilizationMethod") .. ": " .. i18n("inertiaCam"))
 
     fcpxCmds
         :add("stabilizationMethodSmoothCam")
-        :whenActivated(doStabilizationMethod("FFStabilizationUseSmoothCam"))
+        :whenActivated(function() doStabilizationMethod("FFStabilizationUseSmoothCam"):Now() end)
         :titled(i18n("stabilizationMethod") .. ": " .. i18n("smoothCam"))
 
     --------------------------------------------------------------------------------
@@ -343,11 +343,11 @@ function plugin.init(deps)
     --------------------------------------------------------------------------------
     fcpxCmds
         :add("cpRollingShutterEnable")
-        :whenActivated(doRollingShutter(true))
+        :whenActivated(function() doRollingShutter(true):Now() end)
 
     fcpxCmds
         :add("cpRollingShutterDisable")
-        :whenActivated(doRollingShutter(false))
+        :whenActivated(function() doRollingShutter(false):Now() end)
 
     --------------------------------------------------------------------------------
     -- Rolling Shutter Amount:
@@ -358,7 +358,7 @@ function plugin.init(deps)
     for _, v in pairs(rollingShutterAmounts) do
         fcpxCmds
             :add(v.flexoID)
-            :whenActivated(doRollingShutterAmount(v.flexoID))
+            :whenActivated(function() doRollingShutterAmount(v.flexoID):Now() end)
             :titled(rollingShutterTitle .. " " .. rollingShutterAmount .. ": " .. i18n(v.i18n))
     end
 
@@ -367,15 +367,15 @@ function plugin.init(deps)
     --------------------------------------------------------------------------------
     fcpxCmds
         :add("cpSetSpatialConformTypeToFit")
-        :whenActivated(doSpatialConformType("FFConformTypeFit"))
+        :whenActivated(function() doSpatialConformType("FFConformTypeFit"):Now() end)
 
     fcpxCmds
         :add("cpSetSpatialConformTypeToFill")
-        :whenActivated(doSpatialConformType("FFConformTypeFill"))
+        :whenActivated(function() doSpatialConformType("FFConformTypeFill"):Now() end)
 
     fcpxCmds
         :add("cpSetSpatialConformTypeToNone")
-        :whenActivated(doSpatialConformType("FFConformTypeNone"))
+        :whenActivated(function() doSpatialConformType("FFConformTypeNone"):Now() end)
 
     --------------------------------------------------------------------------------
     -- Blend Modes:
@@ -385,7 +385,7 @@ function plugin.init(deps)
         if v.flexoID ~= nil then
             fcpxCmds
                 :add(v.flexoID)
-                :whenActivated(doBlendMode(v.flexoID))
+                :whenActivated(function() doBlendMode(v.flexoID):Now() end)
                 :titled(i18n("blendMode") .. ": " .. i18n(v.i18n))
         end
     end

--- a/src/plugins/finalcutpro/tangent/audio.lua
+++ b/src/plugins/finalcutpro/tangent/audio.lua
@@ -2,12 +2,12 @@
 ---
 --- Final Cut Pro Audio Inspector for Tangent
 
-local require = require
+local require       = require
 
---local log                   = require("hs.logger").new("tangentVideo")
+--local log           = require("hs.logger").new("tangentVideo")
 
-local fcp                   = require("cp.apple.finalcutpro")
-local i18n                  = require("cp.i18n")
+local fcp           = require "cp.apple.finalcutpro"
+local i18n          = require "cp.i18n"
 
 local plugin = {
     id = "finalcutpro.tangent.audio",

--- a/src/plugins/finalcutpro/tangent/common.lua
+++ b/src/plugins/finalcutpro/tangent/common.lua
@@ -16,7 +16,7 @@ local dialog                = require "cp.dialog"
 local Do                    = require "cp.rx.go.Do"
 local fcp                   = require "cp.apple.finalcutpro"
 local i18n                  = require "cp.i18n"
-local If                    = require('cp.rx.go.If')
+local If                    = require "cp.rx.go.If"
 local tools                 = require "cp.tools"
 
 local childrenMatching      = axutils.childrenMatching
@@ -55,11 +55,12 @@ local DELAY = 0.2
 function mod.popupParameter(group, param, id, value, label)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(
-            Do(param:doShow())
+        :onPress(function()
+            return Do(param:doShow())
                 :Then(param:doSelectValue(value))
                 :Label("plugins.finalcutpro.tangent.common.popupParameter")
-        )
+                :Now()
+        end)
     return id + 1
 end
 
@@ -139,8 +140,8 @@ function mod.dynamicPopupSliderParameter(group, param, id, label, defaultValue)
                 updateUI:start()
             end
         end)
-        :onReset(
-            Do(function()
+        :onReset(function()
+            return Do(function()
                 popupSliderCache = type(defaultValue) == "number" and defaultValue or 1
             end)
                 :Then(
@@ -154,7 +155,8 @@ function mod.dynamicPopupSliderParameter(group, param, id, label, defaultValue)
                 popupSliderCache = nil
             end)
             :Label("plugins.finalcutpro.tangent.common.dynamicPopupSliderParameter.reset")
-        )
+            :Now()
+        end)
     return id + 1
 
 end
@@ -268,8 +270,8 @@ function mod.popupSliderParameter(group, param, id, label, options, resetIndex)
             popupSliderCache = newID
             updateUI:start()
         end)
-        :onReset(
-            Do(function()
+        :onReset(function()
+            return Do(function()
                 popupSliderCache = resetIndex
             end)
                 :Then(param:doShow())
@@ -278,7 +280,8 @@ function mod.popupSliderParameter(group, param, id, label, options, resetIndex)
                     popupSliderCache = nil
                 end)
                 :Label("plugins.finalcutpro.tangent.common.popupSliderParameter.reset")
-        )
+                :Now()
+        end)
     return id + 1
 
 end
@@ -323,13 +326,15 @@ end
 function mod.checkboxParameter(group, param, id, label)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(
-            Do(param:doShow()):Then(
+        :onPress(function()
+            return Do(param:doShow()):Then(
                 If(param):Is(nil):Then():Otherwise(
                     param:doPress()
                 )
-            ):Label("plugins.finalcutpro.tangent.common.checkboxParameter")
-        )
+            )
+            :Label("plugins.finalcutpro.tangent.common.checkboxParameter")
+            :Now()
+        end)
     return id + 1
 end
 
@@ -406,8 +411,8 @@ function mod.checkboxSliderParameter(group, id, label, options, resetIndex)
                 updateUI:start()
             end
         end)
-        :onReset(
-            Do(function()
+        :onReset(function()
+            return Do(function()
                 cachedValue = 1
             end)
                 :Then(options[1].param:doShow())
@@ -416,7 +421,8 @@ function mod.checkboxSliderParameter(group, id, label, options, resetIndex)
                     cachedValue = nil
                 end)
                 :Label("plugins.finalcutpro.tangent.common.checkboxSliderParameter.reset")
-        )
+                :Now()
+        end)
     return id + 1
 
 end
@@ -453,11 +459,12 @@ end
 function mod.radioButtonParameter(group, param, id, label)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(
-            Do(param:doShow())
+        :onPress(function()
+            return Do(param:doShow())
                 :Then(param:doPress())
                 :Label("plugins.finalcutpro.tangent.common.radioButtonParameter")
-        )
+                :Now()
+        end)
     return id + 1
 end
 
@@ -477,11 +484,14 @@ end
 function mod.buttonParameter(group, param, id, label)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(
-            Do(param:doShow()):Then(
-                param:doPress()
-            ):Label("plugins.finalcutpro.tangent.common.buttonParameter")
-        )
+        :onPress(function()
+            return Do(param:doShow())
+                :Then(
+                    param:doPress()
+                )
+                :Label("plugins.finalcutpro.tangent.common.buttonParameter")
+                :Now()
+        end)
     return id + 1
 end
 
@@ -501,10 +511,11 @@ end
 function mod.doShowParameter(group, param, id, label)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(
-            Do(param:doShow())
-            :Label("plugins.finalcutpro.tangent.common.buttonParameter")
-        )
+        :onPress(function()
+            return Do(param:doShow())
+                :Label("plugins.finalcutpro.tangent.common.buttonParameter")
+                :Now()
+        end)
     return id + 1
 end
 
@@ -545,7 +556,9 @@ end
 function mod.shortcutParameter(group, id, label, shortcut)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(fcp:doShortcut(shortcut))
+        :onPress(function()
+            return fcp:doShortcut(shortcut):Now()
+        end)
     return id + 1
 end
 
@@ -565,7 +578,9 @@ end
 function mod.menuParameter(group, id, label, path)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(fcp:doSelectMenu(path))
+        :onPress(function()
+            return fcp:doSelectMenu(path):Now()
+        end)
     return id + 1
 end
 
@@ -585,7 +600,7 @@ end
 function mod.functionParameter(group, id, label, fn)
     group
         :action(id + 1, i18n(label, {default=label}))
-        :onPress(fn)
+        :onPress(function() fn() end)
     return id + 1
 end
 
@@ -689,8 +704,8 @@ function mod.xyParameter(group, param, id, minValue, maxValue, stepSize)
     local x, y = 0, 0
     local updateUI = deferred.new(DEFER)
     local updating = false
-    updateUI:action(
-        If(function() return not updating and (x ~= 0 or y ~= 0) end)
+    updateUI:action(function()
+        return If(function() return not updating and (x ~= 0 or y ~= 0) end)
         :Then(
             Do(param:doShow())
             :Then(function()
@@ -712,8 +727,10 @@ function mod.xyParameter(group, param, id, minValue, maxValue, stepSize)
                 mod._manager.controls:findByID(id + 1):update() -- Force the Tangent display to update.
                 updating = false
             end)
-        ):Label("plugins.finalcutpro.tangent.common.xyParameter.updateUI")
-    )
+        )
+        :Label("plugins.finalcutpro.tangent.common.xyParameter.updateUI")
+        :Now()
+    end)
 
     local label = param:label()
     local xParam = group:parameter(id + 1)
@@ -772,8 +789,8 @@ function mod.sliderParameter(group, param, id, minValue, maxValue, stepSize, def
     local value = 0
     local updateUI = deferred.new(DEFER)
     local updating = false
-    updateUI:action(
-        If(function() return not updating and value ~= 0 end)
+    updateUI:action(function()
+        return If(function() return not updating and value ~= 0 end)
         :Then(
             Do(param:doShow())
             :Then(function()
@@ -792,8 +809,10 @@ function mod.sliderParameter(group, param, id, minValue, maxValue, stepSize, def
                 mod._manager.controls:findByID(id + 1):update() -- Force the Tangent display to update.
                 updating = false
             end)
-        ):Label("plugins.finalcutpro.tangent.common.sliderParameter.updateUI")
-    )
+        )
+        :Label("plugins.finalcutpro.tangent.common.sliderParameter.updateUI")
+        :Now()
+    end)
 
     default = default or 0
     label = (label and i18n(label, {default=label})) or param:label()
@@ -842,8 +861,8 @@ function mod.volumeSliderParameter(group, param, id, minValue, maxValue, stepSiz
     local updateUI = deferred.new(DEFER)
     local updating = false
     local wasPlaying = false
-    updateUI:action(
-        If(function() return not updating and value ~= 0 end)
+    updateUI:action(function()
+        return If(function() return not updating and value ~= 0 end)
         :Then(
             Do(param:doShow())
             :Then(function()
@@ -873,8 +892,10 @@ function mod.volumeSliderParameter(group, param, id, minValue, maxValue, stepSiz
             :Then(function()
                 updating = false
                 end)
-        ):Label("plugins.finalcutpro.tangent.common.volumeSliderParameter.updateUI")
-    )
+        )
+        :Label("plugins.finalcutpro.tangent.common.volumeSliderParameter.updateUI")
+        :Now()
+    end)
 
     default = default or 0
     label = (label and i18n(label, {default=label})) or param:label()

--- a/src/plugins/finalcutpro/tangent/group.lua
+++ b/src/plugins/finalcutpro/tangent/group.lua
@@ -2,10 +2,10 @@
 ---
 --- Final Cut Pro Tangent Timeline Group/Management
 
-local require = require
+local require       = require
 
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
+local fcp           = require "cp.apple.finalcutpro"
+local i18n          = require "cp.i18n"
 
 local plugin = {
     id = "finalcutpro.tangent.group",

--- a/src/plugins/finalcutpro/tangent/video.lua
+++ b/src/plugins/finalcutpro/tangent/video.lua
@@ -2,13 +2,13 @@
 ---
 --- Final Cut Pro Video Inspector for Tangent
 
-local require = require
+local require               = require
 
---local log                   = require("hs.logger").new("tangentVideo")
+local log                   = require "hs.logger".new "tangentVideo"
 
-local fcp                   = require("cp.apple.finalcutpro")
-local i18n                  = require("cp.i18n")
-local tools                 = require("cp.tools")
+local fcp                   = require "cp.apple.finalcutpro"
+local i18n                  = require "cp.i18n"
+local tools                 = require "cp.tools"
 
 local tableCount            = tools.tableCount
 

--- a/src/plugins/finalcutpro/tangent/video.lua
+++ b/src/plugins/finalcutpro/tangent/video.lua
@@ -4,7 +4,7 @@
 
 local require               = require
 
-local log                   = require "hs.logger".new "tangentVideo"
+--local log                   = require "hs.logger".new "tangentVideo"
 
 local fcp                   = require "cp.apple.finalcutpro"
 local i18n                  = require "cp.i18n"

--- a/src/plugins/finalcutpro/timeline/renameclip.lua
+++ b/src/plugins/finalcutpro/timeline/renameclip.lua
@@ -4,11 +4,12 @@
 
 local require = require
 
-local axutils       = require("cp.ui.axutils")
-local fcp           = require("cp.apple.finalcutpro")
-local tools         = require("cp.tools")
+local axutils       = require "cp.ui.axutils"
+local fcp           = require "cp.apple.finalcutpro"
+local i18n          = require "cp.i18n"
+local tools         = require "cp.tools"
 
-local geometry      = require("hs.geometry")
+local geometry      = require "hs.geometry"
 
 local plugin = {
     id = "finalcutpro.timeline.renameclip",
@@ -19,11 +20,6 @@ local plugin = {
 }
 
 function plugin.init(deps)
-
-    --------------------------------------------------------------------------------
-    -- Add Commands:
-    --------------------------------------------------------------------------------
-    local renameClip = fcp:string("FFRename Bin Object")
     deps.fcpxCmds:add("renameClip")
         :whenActivated(function()
             local selectedClip
@@ -56,6 +52,7 @@ function plugin.init(deps)
                         tools.ninjaRightMouseClick(point)
                         local parent = selectedClip:attributeValue("AXParent")
                         local menu = parent and axutils.childWithRole(parent, "AXMenu")
+                        local renameClip = fcp:string("FFRename Bin Object")
                         local item = menu and axutils.childWith(menu, "AXTitle", renameClip)
                         if item and item:attributeValue("AXEnabled") == true then
                             item:performAction("AXPress")
@@ -77,8 +74,7 @@ function plugin.init(deps)
             --------------------------------------------------------------------------------
             tools.playErrorSound()
         end)
-        :titled(renameClip)
-
+        :titled(i18n("renameClip"))
 end
 
 return plugin


### PR DESCRIPTION
- Increased the slow plugin warning threshold from 0.1 to 1.
- The Rename Clip plugin now uses CommandPost’s i18n for the title
rather than FCPX’s strings table.
- Wrapped a lot of actions in functions to improve boot time.
- Closes #2074