### PR TITLE
You can now use multiple settings for a single Compressor watch folder

### DIFF
--- a/src/extensions/cp/apple/compressor/init.lua
+++ b/src/extensions/cp/apple/compressor/init.lua
@@ -2,15 +2,14 @@
 ---
 --- Represents the Compressor application, providing functions that allow different tasks to be accomplished.
 
-local require                 = require
+local require       = require
 
-local fnutils									= require("hs.fnutils")
+local fnutils       = require "hs.fnutils"
 
-local app                     = require("cp.apple.compressor.app")
-local prop										= require("cp.prop")
+local app           = require "cp.apple.compressor.app"
+local prop			= require "cp.prop"
 
-local v                       = require("semver")
-
+local v             = require "semver"
 
 local compressor = {
     app = app,

--- a/src/extensions/cp/battery.lua
+++ b/src/extensions/cp/battery.lua
@@ -113,12 +113,11 @@
 
 local require = require
 
-local log           = require("hs.logger").new("cpBattery")
+local log           = require "hs.logger".new "cpBattery"
 
-local battery       = require("hs.battery")
+local battery       = require "hs.battery"
 
-local prop          = require("cp.prop")
-
+local prop          = require "cp.prop"
 
 local mod = {}
 

--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -1292,6 +1292,22 @@ function tools.getFilenameFromPath(input, removeExtension)
     end
 end
 
+--- cp.tools.getFileExtensionFromPath(input) -> string
+--- Function
+--- Gets the file extension from a path.
+---
+--- Parameters:
+---  * input - The path
+---
+--- Returns:
+---  * A string of the file extension.
+function tools.getFileExtensionFromPath(path)
+    local extension = path and string.match(path, "^.+(%..+)$")
+    if extension and extension:sub(1, 1) == "." then
+        return extension:sub(2)
+    end
+end
+
 --- cp.tools.removeFilenameFromPath(string) -> string
 --- Function
 --- Removes the filename from a path.
@@ -1368,15 +1384,39 @@ end
 --- Returns:
 ---  * A string
 function tools.incrementFilename(value)
-    if value == nil then return nil end
-    if type(value) ~= "string" then return nil end
-
-    local name, counter = string.match(value, '^(.*)%s(%d+)$')
-    if name == nil or counter == nil then
-        return value .. " 1"
+    if type(value) == "string" then
+        local name, counter = string.match(value, '^(.*)%s(%d+)$')
+        if name == nil or counter == nil then
+            return value .. " 1"
+        end
+        return name .. " " .. tostring(tonumber(counter) + 1)
     end
+end
 
-    return name .. " " .. tostring(tonumber(counter) + 1)
+--- cp.tools.incrementFilenameInPath(path) -> string
+--- Function
+--- Increments the filename as it appears in a path.
+---
+--- Parameters:
+---  * path - A path to a file.
+---
+--- Returns:
+---  * A string
+function tools.incrementFilenameInPath(value)
+    if type(value) == "string" then
+        local path = tools.removeFilenameFromPath(value)
+        local extension = tools.getFileExtensionFromPath(value)
+        local filename
+        if extension then
+            filename = tools.getFilenameFromPath(value, true)
+            extension = "." .. extension
+        else
+            extension = ""
+            filename = tools.getFilenameFromPath(value)
+        end
+        local newFilename = tools.incrementFilename(filename)
+        return path .. newFilename .. extension
+    end
 end
 
 --- cp.tools.dirFiles(path) -> table

--- a/src/plugins/compressor/watchfolders/panels/media/init.lua
+++ b/src/plugins/compressor/watchfolders/panels/media/init.lua
@@ -27,11 +27,9 @@ local xml                       = require "hs._asm.xml"
 
 local doesFileExist             = tools.doesFileExist
 local doEvery                   = timer.doEvery
-local getFileExtensionFromPath  = tools.getFileExtensionFromPath
+
 local getFilenameFromPath       = tools.getFilenameFromPath
-local incrementFilename         = tools.incrementFilename
 local incrementFilenameInPath   = tools.incrementFilenameInPath
-local removeFilenameFromPath    = tools.removeFilenameFromPath
 local tableContains             = tools.tableContains
 local unescape                  = tools.unescape
 local uuid                      = host.uuid
@@ -508,7 +506,7 @@ function mod.addFilesToCompressor(files)
         local filename = getFilenameFromPath(file, true)
 
         local usedFiles = {}
-        for i, item in pairs(presets) do
+        for _, item in pairs(presets) do
 
             local exportFile = item.destinationPath .. filename
 

--- a/src/plugins/core/watchfolders/manager/init.lua
+++ b/src/plugins/core/watchfolders/manager/init.lua
@@ -208,14 +208,10 @@ local function windowCallback(action, wv, frame)
             for _, v in ipairs(mod._panels) do
                 if v.id == id then
                     --------------------------------------------------------------------------------
-                    -- Wait until the Webview has loaded before triggering individual panels
-                    -- functions:
+                    -- Previously we waited until the webview loaded before trigging individual
+                    -- panels functions, but this was causing issues, so have removed:
                     --------------------------------------------------------------------------------
-                    if just.doUntil(function() return not wv:loading() end) then
-                        v.loadFn()
-                    else
-                        log.ef("Failed to trigger Watch Folder Load Function via manager.windowCallback.")
-                    end
+                    v.loadFn()
                 end
             end
         end

--- a/src/plugins/core/watchfolders/menuitem.lua
+++ b/src/plugins/core/watchfolders/menuitem.lua
@@ -2,10 +2,9 @@
 ---
 --- Adds the "Setup Watch Folders" to the menu bar.
 
-local require = require
+local require   = require
 
-local i18n = require("cp.i18n")
-
+local i18n      = require "cp.i18n"
 
 local plugin = {
     id				= "core.watchfolders.menuitem",

--- a/src/plugins/finalcutpro/watchfolders/media/init.lua
+++ b/src/plugins/finalcutpro/watchfolders/media/init.lua
@@ -4,14 +4,13 @@
 
 local require = require
 
-local config            = require("cp.config")
-local fcp               = require("cp.apple.finalcutpro")
+local config            = require "cp.config"
+local fcp               = require "cp.apple.finalcutpro"
 
-local MediaFolder       = require("MediaFolder")
-local panel             = require("panel")
+local MediaFolder       = require "MediaFolder"
+local panel             = require "panel"
 
 local insert            = table.insert
-
 
 local mod = {}
 
@@ -142,7 +141,6 @@ function mod.init(deps)
 
     return mod
 end
-
 
 local plugin = {
     id = "finalcutpro.watchfolders.media",


### PR DESCRIPTION
- Added `cp.tools.getFileExtensionFromPath()`
- Added `cp.tools.incrementFilenameInPath()`
- We now get the Compressor Setting name from the XML, as opposed to
the filename.
- Various cleanup of other code.
- Closes #1900