### PR TITLE
Disable Touch Bar on Catalina

### DIFF
--- a/src/plugins/core/touchbar/manager/init.lua
+++ b/src/plugins/core/touchbar/manager/init.lua
@@ -19,7 +19,7 @@ local json              = require "cp.json"
 local prop              = require "cp.prop"
 local tools             = require "cp.tools"
 
-local touchbar          = require "hs._asm.undocumented.touchbar"
+local semver            = require "semver"
 
 local widgets           = require "widgets"
 
@@ -93,12 +93,20 @@ end)
 --- Contains all the saved Touch Bar Buttons
 mod._items = json.prop(config.userConfigRootPath, mod.FOLDER_NAME, mod.FILE_NAME, {})
 
+mod.macOSVersionSupported = prop(function()
+    local osVersion = semver(tools.macOSVersion())
+    return osVersion <= semver("10.13")
+end)
+
 --- plugins.core.touchbar.manager.supported <cp.prop: boolean; read-only>
 --- Field
 --- Is `true` if the Touch Bar is supported on this version of macOS.
-mod.supported = prop(function() return touchbar.supported() end)
+mod.supported = mod.macOSVersionSupported:AND(prop(function()
+    local touchbar = mod.touchbar()
+    return touchbar and touchbar.supported()
+end))
 
---- plugins.core.touchbar.manager.touchBar() -> none
+--- plugins.core.touchbar.manager.touchbar() -> none
 --- Function
 --- Returns the `hs._asm.undocumented.touchbar` object if it exists.
 ---
@@ -107,8 +115,17 @@ mod.supported = prop(function() return touchbar.supported() end)
 ---
 --- Returns:
 ---  * `hs._asm.undocumented.touchbar`
-function mod.touchBar()
-    return mod._touchBar or nil
+function mod.touchbar()
+    if not mod._touchbar then
+        if mod.macOSVersionSupported() then
+            mod._touchbar = require "hs._asm.undocumented.touchbar"
+        else
+            mod._touchbar = {
+                supported = function() return false end,
+            }
+        end
+    end
+    return mod._touchbar
 end
 
 --- plugins.core.touchbar.manager.clear() -> none
@@ -416,7 +433,7 @@ end
 ---  * None
 function mod.start()
     if not mod._bar then
-        mod._bar = touchbar.bar.new()
+        mod._bar = mod.touchbar().bar.new()
 
         --------------------------------------------------------------------------------
         -- Resize Icon:
@@ -431,7 +448,7 @@ function mod.start()
         --------------------------------------------------------------------------------
         -- Setup System Icon:
         --------------------------------------------------------------------------------
-        mod._sysTrayIcon = touchbar.item.newButton(icon:imageFromCanvas(), "CommandPost")
+        mod._sysTrayIcon = mod.touchbar().item.newButton(icon:imageFromCanvas(), "CommandPost")
                              :callback(function()
                                 mod.incrementActiveSubGroup()
                                 mod.update()
@@ -523,9 +540,9 @@ local function addButton(icon, _, label, id)
     end
     table.insert(mod._tbItemIDs, id)
     if icon then
-        table.insert(mod._tbItems, touchbar.item.newButton(label, icon, id):callback(buttonCallback))
+        table.insert(mod._tbItems, mod.touchbar().item.newButton(label, icon, id):callback(buttonCallback))
     else
-        table.insert(mod._tbItems, touchbar.item.newButton(label, id):callback(buttonCallback))
+        table.insert(mod._tbItems, mod.touchbar().item.newButton(label, id):callback(buttonCallback))
     end
 end
 
@@ -807,7 +824,7 @@ function mod.update()
             text    = styledtext.getStyledTextFromData([[<span style="font-family: -apple-system; font-size: 10px; color: #FFFFFF; vertical-align: middle;">]] .. bankLabel .. [[</span>]]),
             frame   = { x = 0, y = 8, h = "100%", w = "100%" }
         }
-        local bankLabelCanvasItem = touchbar.item.newCanvas(bankLabelCanvas, id)
+        local bankLabelCanvasItem = mod.touchbar().item.newCanvas(bankLabelCanvas, id)
         table.insert(mod._tbItemIDs, 1, id)
         table.insert(mod._tbItems, 1, bankLabelCanvasItem)
     end

--- a/src/plugins/core/touchbar/manager/init.lua
+++ b/src/plugins/core/touchbar/manager/init.lua
@@ -95,7 +95,7 @@ mod._items = json.prop(config.userConfigRootPath, mod.FOLDER_NAME, mod.FILE_NAME
 
 mod.macOSVersionSupported = prop(function()
     local osVersion = semver(tools.macOSVersion())
-    return osVersion <= semver("10.13")
+    return osVersion < semver("10.15")
 end)
 
 --- plugins.core.touchbar.manager.supported <cp.prop: boolean; read-only>

--- a/src/plugins/core/touchbar/prefs/init.lua
+++ b/src/plugins/core/touchbar/prefs/init.lua
@@ -403,10 +403,12 @@ mod.virtual.enabled = config.prop("displayVirtualTouchBar", false):watch(functio
         dialog.displayMessage(i18n("touchBarError"))
         mod.enabled(false)
     end
-    if enabled then
-        mod._virtual.start()
-    else
-        mod._virtual.stop()
+    if mod._virtual then
+        if enabled then
+            mod._virtual.start()
+        else
+            mod._virtual.stop()
+        end
     end
 end)
 

--- a/src/plugins/core/touchbar/virtual/init.lua
+++ b/src/plugins/core/touchbar/virtual/init.lua
@@ -54,7 +54,7 @@ mod.updateLocationCallback = location
 
 mod.macOSVersionSupported = prop(function()
     local osVersion = semver(tools.macOSVersion())
-    return osVersion <= semver("10.13")
+    return osVersion < semver("10.15")
 end)
 
 --- plugins.core.touchbar.virtual.supported <cp.prop: boolean; read-only>

--- a/src/plugins/core/touchbar/widgets/volume.lua
+++ b/src/plugins/core/touchbar/widgets/volume.lua
@@ -6,8 +6,6 @@ local require = require
 
 local audiodevice		= require("hs.audiodevice")
 local image				  = require("hs.image")
-local touchbar 			= require("hs._asm.undocumented.touchbar")
-
 
 local mod = {}
 
@@ -27,7 +25,7 @@ local ID = "volume"
 ---  * A `hs._asm.undocumented.touchbar.item`
 function mod.widget()
 
-    mod.item = touchbar.item.newSlider(ID)
+    mod.item = mod._manager.touchbar().item.newSlider(ID)
         :sliderMin(0)
         :sliderMax(100)
         :sliderMinImage(image.imageFromName(image.systemImageNames.TouchBarVolumeDownTemplate))
@@ -50,7 +48,8 @@ end
 ---
 --- Returns:
 ---  * None
-function mod.init(deps)
+function mod.init(manager)
+    mod._manager = manager
 
     --------------------------------------------------------------------------------
     -- Watch for volume changes:
@@ -73,12 +72,11 @@ function mod.init(deps)
         subText = "Adds a volume slider to the Touch Bar",
         item = mod.widget,
     }
-    deps.manager.widgets:new(id, params)
+    manager.widgets:new(id, params)
 
     return mod
 
 end
-
 
 local plugin = {
     id				= "core.touchbar.widgets.volume",
@@ -89,8 +87,9 @@ local plugin = {
 }
 
 function plugin.init(deps)
-    if touchbar.supported() then
-        return mod.init(deps)
+    local manager = deps.manager
+    if manager.supported() then
+        return mod.init(manager)
     end
 end
 

--- a/src/plugins/core/touchbar/widgets/windowSlide.lua
+++ b/src/plugins/core/touchbar/widgets/windowSlide.lua
@@ -4,12 +4,9 @@
 
 local require = require
 
-local canvas   			= require("hs.canvas")
-local screen   			= require("hs.screen")
-local window   			= require("hs.window")
-
-local touchbar 			= require("hs._asm.undocumented.touchbar")
-
+local canvas   			= require "hs.canvas"
+local screen   			= require "hs.screen"
+local window   			= require "hs.window"
 
 local mod = {}
 
@@ -77,7 +74,7 @@ function mod.widget()
         end
     end)
 
-    mod.item = touchbar.item.newCanvas(widgetCanvas, ID)
+    mod.item = mod._manager.touchbar().item.newCanvas(widgetCanvas, ID)
         :canvasClickColor{ alpha = 0.0 }
 
     return mod.item
@@ -93,7 +90,8 @@ end
 ---
 --- Returns:
 ---  * None
-function mod.init(deps)
+function mod.init(manager)
+    mod._manager = manager
 
     local id = ID
     local params = {
@@ -102,7 +100,7 @@ function mod.init(deps)
         subText = "Allows you to slide window positions.",
         item = mod.widget,
     }
-    deps.manager.widgets:new(id, params)
+    manager.widgets:new(id, params)
 
     return mod
 
@@ -118,8 +116,9 @@ local plugin = {
 }
 
 function plugin.init(deps)
-    if touchbar.supported() then
-        return mod.init(deps)
+    local manager = deps.manager
+    if manager.supported() then
+        return mod.init(manager)
     end
 end
 

--- a/src/plugins/finalcutpro/touchbar/virtual/init.lua
+++ b/src/plugins/finalcutpro/touchbar/virtual/init.lua
@@ -43,12 +43,12 @@ mod.visibility = config.prop("virtualTouchBarVisibility", mod.VISIBILITY_FCP)
 --  * None
 function mod._checkVisibility(active)
     if mod.visibility() == mod.VISIBILITY_ALWAYS then
-        mod._manager.show()
+        mod._virtual.show()
     else
         if active then
-            mod._manager.show()
+            mod._virtual.show()
         else
-            mod._manager.hide()
+            mod._virtual.hide()
         end
     end
 end
@@ -73,7 +73,7 @@ mod.enabled = config.prop("displayVirtualTouchBar", false):watch(function(enable
     --------------------------------------------------------------------------------
     -- Check for compatibility:
     --------------------------------------------------------------------------------
-    if enabled and not mod._manager.supported() then
+    if enabled and not mod._virtual.supported() then
         dialog.displayMessage(i18n("touchBarError"))
         mod.enabled(false)
     end
@@ -82,9 +82,9 @@ mod.enabled = config.prop("displayVirtualTouchBar", false):watch(function(enable
         --------------------------------------------------------------------------------
         -- Add Callbacks to Control Location:
         --------------------------------------------------------------------------------
-        mod.updateLocationCallback = mod._manager.updateLocationCallback:new("fcp", function()
+        mod.updateLocationCallback = mod._virtual.updateLocationCallback:new("fcp", function()
 
-            local displayVirtualTouchBarLocation = mod._manager.location()
+            local displayVirtualTouchBarLocation = mod._virtual.location()
 
             --------------------------------------------------------------------------------
             -- Show Touch Bar at Top Centre of Timeline:
@@ -96,18 +96,18 @@ mod.enabled = config.prop("displayVirtualTouchBar", false):watch(function(enable
                 --------------------------------------------------------------------------------
                 local viewFrame = timeline:contents():viewFrame()
                 if viewFrame then
-                    if mod._manager._touchBar then
-                        local topLeft = {x = viewFrame.x + viewFrame.w/2 - mod._manager._touchBar:getFrame().w/2, y = viewFrame.y + 20}
-                        mod._manager._touchBar:topLeft(topLeft)
+                    if mod._virtual._touchBar then
+                        local topLeft = {x = viewFrame.x + viewFrame.w/2 - mod._virtual._touchBar:getFrame().w/2, y = viewFrame.y + 20}
+                        mod._virtual._touchBar:topLeft(topLeft)
                     end
                 end
-            elseif displayVirtualTouchBarLocation == mod._manager.LOCATION_MOUSE then
+            elseif displayVirtualTouchBarLocation == mod._virtual.LOCATION_MOUSE then
 
                 --------------------------------------------------------------------------------
                 -- Position Touch Bar to Mouse Pointer Location:
                 --------------------------------------------------------------------------------
-                if mod._manager._touchBar then
-                    mod._manager._touchBar:atMousePosition()
+                if mod._virtual._touchBar then
+                    mod._virtual._touchBar:atMousePosition()
                 end
 
             end
@@ -129,24 +129,24 @@ mod.enabled = config.prop("displayVirtualTouchBar", false):watch(function(enable
         --------------------------------------------------------------------------------
         -- Update the Virtual Touch Bar position if either of the main windows move:
         --------------------------------------------------------------------------------
-        fcp:primaryWindow().frame:watch(mod._manager.updateLocation)
-        fcp:secondaryWindow().frame:watch(mod._manager.updateLocation)
+        fcp:primaryWindow().frame:watch(mod._virtual.updateLocation)
+        fcp:secondaryWindow().frame:watch(mod._virtual.updateLocation)
 
         --------------------------------------------------------------------------------
         -- Start the Virtual Touch Bar:
         --------------------------------------------------------------------------------
-        mod._manager.start()
+        mod._virtual.start()
 
         --------------------------------------------------------------------------------
         -- Update the visibility:
         --------------------------------------------------------------------------------
         if mod.visibility() == mod.VISIBILITY_ALWAYS then
-            mod._manager.show()
+            mod._virtual.show()
         else
             if fcp.isFrontmost() then
-                mod._manager.show()
+                mod._virtual.show()
             else
-                mod._manager.hide()
+                mod._virtual.hide()
             end
         end
 
@@ -162,11 +162,11 @@ mod.enabled = config.prop("displayVirtualTouchBar", false):watch(function(enable
             mod.isActive = nil
         end
         if mod._fcpPrimaryWindowWatcher then
-            mod._fcpPrimaryWindowWatcher:unwatch(mod._manager.updateLocation)
+            mod._fcpPrimaryWindowWatcher:unwatch(mod._virtual.updateLocation)
             mod._fcpPrimaryWindowWatcher = nil
         end
         if mod._fcpSecondaryWindowWatcher then
-            fcp:secondaryWindow().frame:unwatch(mod._manager.updateLocation)
+            fcp:secondaryWindow().frame:unwatch(mod._virtual.updateLocation)
             mod._fcpSecondaryWindowWatcher = nil
         end
         if mod.updateLocationCallback then
@@ -177,7 +177,7 @@ mod.enabled = config.prop("displayVirtualTouchBar", false):watch(function(enable
         --------------------------------------------------------------------------------
         -- Stop the Virtual Touch Bar:
         --------------------------------------------------------------------------------
-        mod._manager.stop()
+        mod._virtual.stop()
     end
 end)
 
@@ -197,13 +197,13 @@ function plugin.init(deps)
     --------------------------------------------------------------------------------
     -- Connect to Manager:
     --------------------------------------------------------------------------------
-    mod._manager = deps.manager
+    mod._virtual = deps.manager
     mod._tbManager = deps.tbManager
 
     --------------------------------------------------------------------------------
     -- Add Commands if Supported:
     --------------------------------------------------------------------------------
-    if mod._manager.supported() then
+    if mod._virtual.supported() then
         --------------------------------------------------------------------------------
         -- Final Cut Pro Command:
         --------------------------------------------------------------------------------

--- a/src/plugins/finalcutpro/touchbar/widgets/colorboard.lua
+++ b/src/plugins/finalcutpro/touchbar/widgets/colorboard.lua
@@ -4,16 +4,14 @@
 
 local require = require
 
-local canvas            = require("hs.canvas")
-local eventtap          = require("hs.eventtap")
-local styledtext        = require("hs.styledtext")
-local timer             = require("hs.timer")
+local canvas            = require "hs.canvas"
+local eventtap          = require "hs.eventtap"
+local styledtext        = require "hs.styledtext"
+local timer             = require "hs.timer"
 
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
-local prop              = require("cp.prop")
-
-local touchbar          = require("hs._asm.undocumented.touchbar")
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
+local prop              = require "cp.prop"
 
 local abs               = math.abs
 local doAfter           = timer.doAfter
@@ -431,7 +429,7 @@ local function puckWidget(id, puck)
     --------------------------------------------------------------------------------
     -- Create new Touch Bar Item from Canvas:
     --------------------------------------------------------------------------------
-    local item = touchbar.item.newCanvas(widgetCanvas, id):canvasClickColor{ alpha = 0.0 }
+    local item = mod._manager.touchbar().item.newCanvas(widgetCanvas, id):canvasClickColor{ alpha = 0.0 }
 
     --------------------------------------------------------------------------------
     -- Add update callback to timer:
@@ -491,8 +489,8 @@ local function groupPuck(id)
     --------------------------------------------------------------------------------
     -- Setup Group:
     --------------------------------------------------------------------------------
-    local group = touchbar.item.newGroup(id):groupItems({
-        touchbar.item.newCanvas(widgetCanvas):canvasClickColor{ alpha = 0.0 },
+    local group = mod._manager.touchbar().item.newGroup(id):groupItems({
+        mod._manager.touchbar().item.newCanvas(widgetCanvas):canvasClickColor{ alpha = 0.0 },
         puckWidget("colorBoardGroup1", function() return colorBoard:current():master() end),
         puckWidget("colorBoardGroup2", function() return colorBoard:current():shadows() end),
         puckWidget("colorBoardGroup3", function() return colorBoard:current():midtones() end),
@@ -511,7 +509,9 @@ end
 ---
 --- Returns:
 ---  * None
-function mod.init(deps)
+function mod.init(manager)
+    mod._manager = manager
+
     --------------------------------------------------------------------------------
     -- Color Board Group:
     --------------------------------------------------------------------------------
@@ -522,7 +522,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardGroupedDescription"),
         item = function() return groupPuck("colorBoardGroup") end,
     }
-    deps.manager.widgets:new("colorBoardGroup", params)
+    manager.widgets:new("colorBoardGroup", params)
 
     local colorBoard = fcp:colorBoard()
 
@@ -535,7 +535,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardPuckDescription", {puck=i18n("one")}),
         item = function() return puckWidget("colorBoardPuck1", function() return colorBoard:current():master() end) end,
     }
-    deps.manager.widgets:new("colorBoardPuck1", params)
+    manager.widgets:new("colorBoardPuck1", params)
 
     params = {
         group = "fcpx",
@@ -543,7 +543,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardPuckDescription", {puck=i18n("two")}),
         item = function() return puckWidget("colorBoardPuck2", function() return colorBoard:current():shadows() end) end,
     }
-    deps.manager.widgets:new("colorBoardPuck2", params)
+    manager.widgets:new("colorBoardPuck2", params)
 
     params = {
         group = "fcpx",
@@ -551,7 +551,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardPuckDescription", {puck=i18n("three")}),
         item = function() return puckWidget("colorBoardPuck3", function() return colorBoard:current():midtones() end) end,
     }
-    deps.manager.widgets:new("colorBoardPuck3", params)
+    manager.widgets:new("colorBoardPuck3", params)
 
     params = {
         group = "fcpx",
@@ -559,7 +559,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardPuckDescription", {puck=i18n("four")}),
         item = function() return puckWidget("colorBoardPuck4", function() return colorBoard:current():highlights() end) end,
     }
-    deps.manager.widgets:new("colorBoardPuck4", params)
+    manager.widgets:new("colorBoardPuck4", params)
 
     --------------------------------------------------------------------------------
     -- Color Panel:
@@ -570,7 +570,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("color")}),
         item = function() return puckWidget("colorBoardColorPuck1", function() return colorBoard:color():master() end) end,
     }
-    deps.manager.widgets:new("colorBoardColorPuck1", params)
+    manager.widgets:new("colorBoardColorPuck1", params)
 
     params = {
         group = "fcpx",
@@ -578,7 +578,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("color")}),
         item = function() return puckWidget("colorBoardColorPuck2", function() return colorBoard:color():shadows() end) end,
     }
-    deps.manager.widgets:new("colorBoardColorPuck2", params)
+    manager.widgets:new("colorBoardColorPuck2", params)
 
     params = {
         group = "fcpx",
@@ -586,7 +586,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("color")}),
         item = function() return puckWidget("colorBoardColorPuck3", function() return colorBoard:color():midtones() end) end,
     }
-    deps.manager.widgets:new("colorBoardColorPuck3", params)
+    manager.widgets:new("colorBoardColorPuck3", params)
 
     params = {
         group = "fcpx",
@@ -594,7 +594,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("color")}),
         item = function() return puckWidget("colorBoardColorPuck4", function() return colorBoard:color():highlights() end) end,
     }
-    deps.manager.widgets:new("colorBoardColorPuck4", params)
+    manager.widgets:new("colorBoardColorPuck4", params)
 
     --------------------------------------------------------------------------------
     -- Saturation Panel:
@@ -605,7 +605,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("saturation")}),
         item = function() return puckWidget("colorBoardSaturationPuck1", function() return colorBoard:saturation():master() end) end,
     }
-    deps.manager.widgets:new("colorBoardSaturationPuck1", params)
+    manager.widgets:new("colorBoardSaturationPuck1", params)
 
     params = {
         group = "fcpx",
@@ -613,7 +613,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("saturation")}),
         item = function() return puckWidget("colorBoardSaturationPuck2", function() return colorBoard:saturation():shadows() end) end,
     }
-    deps.manager.widgets:new("colorBoardSaturationPuck2", params)
+    manager.widgets:new("colorBoardSaturationPuck2", params)
 
     params = {
         group = "fcpx",
@@ -621,7 +621,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("saturation")}),
         item = function() return puckWidget("colorBoardSaturationPuck3", function() return colorBoard:saturation():midtones() end) end,
     }
-    deps.manager.widgets:new("colorBoardSaturationPuck3", params)
+    manager.widgets:new("colorBoardSaturationPuck3", params)
 
     params = {
         group = "fcpx",
@@ -629,7 +629,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("saturation")}),
         item = function() return puckWidget("colorBoardSaturationPuck4", function() return colorBoard:saturation():highlights() end) end,
     }
-    deps.manager.widgets:new("colorBoardSaturationPuck4", params)
+    manager.widgets:new("colorBoardSaturationPuck4", params)
 
     --------------------------------------------------------------------------------
     -- Exposure Panel:
@@ -640,7 +640,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("exposure")}),
         item = function() return puckWidget("colorBoardExposurePuck1", function() return colorBoard:exposure():master() end) end,
     }
-    deps.manager.widgets:new("colorBoardExposurePuck1", params)
+    manager.widgets:new("colorBoardExposurePuck1", params)
 
     params = {
         group = "fcpx",
@@ -648,7 +648,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("exposure")}),
         item = function() return puckWidget("colorBoardExposurePuck2", function() return colorBoard:exposure():shadows() end) end,
     }
-    deps.manager.widgets:new("colorBoardExposurePuck2", params)
+    manager.widgets:new("colorBoardExposurePuck2", params)
 
     params = {
         group = "fcpx",
@@ -656,7 +656,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("exposure")}),
         item = function() return puckWidget("colorBoardExposurePuck3", function() return colorBoard:exposure():midtones() end) end,
     }
-    deps.manager.widgets:new("colorBoardExposurePuck3", params)
+    manager.widgets:new("colorBoardExposurePuck3", params)
 
     params = {
         group = "fcpx",
@@ -664,7 +664,7 @@ function mod.init(deps)
         subText = i18n("touchBarColorBoardDescription", {panel=i18n("exposure")}),
         item = function() return puckWidget("colorBoardExposurePuck4", function() return colorBoard:exposure():highlights() end) end,
     }
-    deps.manager.widgets:new("colorBoardExposurePuck4", params)
+    manager.widgets:new("colorBoardExposurePuck4", params)
 
     return mod
 
@@ -696,11 +696,12 @@ local plugin = {
 }
 
 function plugin.init(deps)
+    local manager = deps.manager
     --------------------------------------------------------------------------------
     -- Only load this plugin if the Touch Bar is supported:
     --------------------------------------------------------------------------------
-    if touchbar.supported() then
-        return mod.init(deps)
+    if manager.supported() then
+        return mod.init(manager)
     end
 end
 

--- a/src/plugins/finalcutpro/touchbar/widgets/duration.lua
+++ b/src/plugins/finalcutpro/touchbar/widgets/duration.lua
@@ -4,15 +4,12 @@
 
 local require           = require
 
---local log               = require("hs.logger").new("duration")
+--local log               = require "hs.logger" .new "duration"
 
-local canvas            = require("hs.canvas")
+local canvas            = require "hs.canvas"
 
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
-
-local touchbar          = require("hs._asm.undocumented.touchbar")
-
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
 
 local mod = {}
 
@@ -99,7 +96,7 @@ function mod.widget()
             end
     end)
 
-    mod.item = touchbar.item.newCanvas(widgetCanvas, "browserDurationSlider")
+    mod.item = mod._manager.touchbar().item.newCanvas(widgetCanvas, "browserDurationSlider")
         :canvasClickColor{ alpha = 0.0 }
 
     return mod.item
@@ -115,7 +112,8 @@ end
 ---
 --- Returns:
 ---  * None
-function mod.init(deps)
+function mod.init(manager)
+    mod._manager = manager
 
     local params = {
         group = "fcpx",
@@ -123,7 +121,7 @@ function mod.init(deps)
         subText = i18n("browserDurationSliderDescription"),
         item = mod.widget,
     }
-    deps.manager.widgets:new("browserDurationSlider", params)
+    manager.widgets:new("browserDurationSlider", params)
 
     return mod
 
@@ -139,8 +137,9 @@ local plugin = {
 }
 
 function plugin.init(deps)
-    if touchbar.supported() then
-        return mod.init(deps)
+    local manager = deps.manager
+    if manager.supported() then
+        return mod.init(manager)
     end
 end
 

--- a/src/plugins/finalcutpro/touchbar/widgets/height.lua
+++ b/src/plugins/finalcutpro/touchbar/widgets/height.lua
@@ -4,15 +4,12 @@
 
 local require           = require
 
---local log               = require("hs.logger").new("heightWidget")
+--local log               = require "hs.logger" .new "heightWidget"
 
-local canvas            = require("hs.canvas")
+local canvas            = require "hs.canvas"
 
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
-
-local touchbar          = require("hs._asm.undocumented.touchbar")
-
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
 
 local mod = {}
 
@@ -104,7 +101,7 @@ function mod.widget()
             end
     end)
 
-    mod.item = touchbar.item.newCanvas(widgetCanvas, "browserHeightSlider")
+    mod.item = mod._manager.touchbar().item.newCanvas(widgetCanvas, "browserHeightSlider")
         :canvasClickColor{ alpha = 0.0 }
 
     return mod.item
@@ -120,7 +117,8 @@ end
 ---
 --- Returns:
 ---  * None
-function mod.init(deps)
+function mod.init(manager)
+    mod._manager = manager
 
     local params = {
         group = "fcpx",
@@ -128,7 +126,7 @@ function mod.init(deps)
         subText = i18n("browserHeightSliderDescription"),
         item = mod.widget,
     }
-    deps.manager.widgets:new("browserHeightSlider", params)
+    manager.widgets:new("browserHeightSlider", params)
 
     return mod
 
@@ -144,8 +142,9 @@ local plugin = {
 }
 
 function plugin.init(deps)
-    if touchbar.supported() then
-        return mod.init(deps)
+    local manager = deps.manager
+    if manager.supported() then
+        return mod.init(manager)
     end
 end
 

--- a/src/plugins/finalcutpro/touchbar/widgets/zoom.lua
+++ b/src/plugins/finalcutpro/touchbar/widgets/zoom.lua
@@ -4,13 +4,10 @@
 
 local require = require
 
-local canvas            = require("hs.canvas")
+local canvas            = require "hs.canvas"
 
-local fcp               = require("cp.apple.finalcutpro")
-local i18n              = require("cp.i18n")
-
-local touchbar          = require("hs._asm.undocumented.touchbar")
-
+local fcp               = require "cp.apple.finalcutpro"
+local i18n              = require "cp.i18n"
 
 local mod = {}
 
@@ -103,7 +100,7 @@ function mod.widget()
             end
     end)
 
-    mod.item = touchbar.item.newCanvas(widgetCanvas, "zoomSlider")
+    mod.item = mod._manager.touchbar().item.newCanvas(widgetCanvas, "zoomSlider")
         :canvasClickColor{ alpha = 0.0 }
 
     return mod.item
@@ -119,7 +116,8 @@ end
 ---
 --- Returns:
 ---  * None
-function mod.init(deps)
+function mod.init(manager)
+    mod._manager = manager
 
     local params = {
         group = "fcpx",
@@ -127,7 +125,7 @@ function mod.init(deps)
         subText = i18n("zoomSliderDescription"),
         item = mod.widget,
     }
-    deps.manager.widgets:new("zoomSlider", params)
+    manager.widgets:new("zoomSlider", params)
 
     return mod
 
@@ -143,8 +141,9 @@ local plugin = {
 }
 
 function plugin.init(deps)
-    if touchbar.supported() then
-        return mod.init(deps)
+    local manager = deps.manager
+    if manager.supported() then
+        return mod.init(manager)
     end
 end
 


### PR DESCRIPTION
* Quick hack to disable Touch Bar support in Catalina completely, to work around bug where CP blanks out the Touch Bar when running.