### PR TITLE
Fixed various bugs in Apple Feedback Forms

### DIFF
--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -578,7 +578,9 @@ function tools.getmacOSVersion()
     local macOSVersion = tools.macOSVersion()
     if macOSVersion then
         local result = ""
-        if v(macOSVersion) >= v("10.14") then
+        if v(macOSVersion) >= v("10.15") then
+            result = "macOS Catalina" .. " " .. tostring(macOSVersion)
+        elseif v(macOSVersion) >= v("10.14") then
             result = "macOS Mojave" .. " " .. tostring(macOSVersion)
         elseif v(macOSVersion) >= v("10.13") then
             result = "macOS High Sierra" .. " " .. tostring(macOSVersion)

--- a/src/plugins/compressor/feedback/bugreport.lua
+++ b/src/plugins/compressor/feedback/bugreport.lua
@@ -127,15 +127,15 @@ local function navigationCallback(action, webView)
             document.getElementById("customer_email").value = "]] .. mod.email .. [[";
             document.getElementById("feedback_type").value = "]] .. FEEDBACK_TYPE .. [[";
             document.getElementById("app_version").value = "]] .. mod.compressorVersion .. [[";
-            document.getElementById("osversion").value = "]] .. mod.macOSVersion .. [[";
+            document.getElementById("os_version").value = "]] .. mod.macOSVersion .. [[";
             document.getElementById("installed_ram").value = "]] .. mod.ramSize .. [[";
             document.getElementById("installed_video_ram").value = "]] .. mod.vramSize .. [[";
             document.getElementById("machine_config").value = "]] .. mod.modelName .. [[";
             document.getElementsByName("third_party")[0].value = `]] .. mod.externalDevices .. [[`;
             document.getElementById("feedback_comment").value = `]] .. defaultFeedback .. [[`;
             //document.getElementById("feedback").value = "]] .. mod.feedback .. [[";
-            document.getElementById("Compressor_usage_purpose").value = "]] .. mod.compressorUsage .. [[";
-            document.getElementById("Compressor_documentation_usage_frequency").value = "]] .. mod.documentationUsage .. [[";
+            document.getElementById("compressor_usage_purpose").value = "]] .. mod.compressorUsage .. [[";
+            document.getElementById("compressor_documentation_usage_frequency").value = "]] .. mod.documentationUsage .. [[";
             document.getElementById("documentation_context").value = "]] .. mod.documentationContext .. [[";
 
             /* CUSTOMER NAME: */
@@ -182,8 +182,8 @@ local function navigationCallback(action, webView)
             });
             */
 
-            /* FINAL CUT PRO USAGE: */
-            var compressorUsage = document.getElementById("Compressor_usage_purpose");
+            /* COMPRESSOR USAGE: */
+            var compressorUsage = document.getElementById("compressor_usage_purpose");
             compressorUsage.addEventListener('change', function()
             {
                 var result = {};
@@ -197,7 +197,7 @@ local function navigationCallback(action, webView)
             });
 
             /* DOCUMENTATION USAGE: */
-            var documentationUsage = document.getElementById("Compressor_documentation_usage_frequency");
+            var documentationUsage = document.getElementById("compressor_documentation_usage_frequency");
             documentationUsage.addEventListener('change', function()
             {
                 var result = {};

--- a/src/plugins/finalcutpro/feedback/bugreport.lua
+++ b/src/plugins/finalcutpro/feedback/bugreport.lua
@@ -126,15 +126,15 @@ local function navigationCallback(action, webView)
             document.getElementById("customer_email").value = "]] .. mod.email .. [[";
             document.getElementById("feedback_type").value = "]] .. FEEDBACK_TYPE .. [[";
             document.getElementById("app_version").value = "]] .. mod.finalCutProVersion .. [[";
-            document.getElementById("osversion").value = "]] .. mod.macOSVersion .. [[";
+            document.getElementById("os_version").value = "]] .. mod.macOSVersion .. [[";
             document.getElementById("installed_ram").value = "]] .. mod.ramSize .. [[";
             document.getElementById("installed_video_ram").value = "]] .. mod.vramSize .. [[";
             document.getElementById("machine_config").value = "]] .. mod.modelName .. [[";
             document.getElementsByName("third_party")[0].value = `]] .. mod.externalDevices .. [[`;
             document.getElementById("feedback_comment").value = `]] .. defaultFeedback .. [[`;
-            document.getElementById("feedback").value = "]] .. mod.feedback .. [[";
-            document.getElementById("FinalCutPro_usage_purpose").value = "]] .. mod.fcpUsage .. [[";
-            document.getElementById("FinalCutPro_documentation_usage_frequency").value = "]] .. mod.documentationUsage .. [[";
+            document.getElementById("finalcutpro_feedback_sent_before").value = "]] .. mod.feedback .. [[";
+            document.getElementById("finalcutpro_usage_purpose").value = "]] .. mod.fcpUsage .. [[";
+            document.getElementById("finalcutpro_documentation_usage_frequency").value = "]] .. mod.documentationUsage .. [[";
             document.getElementById("documentation_context").value = "]] .. mod.documentationContext .. [[";
             document.getElementById("video_output").value = "]] .. mod.videoOutput .. [[";
 
@@ -167,7 +167,7 @@ local function navigationCallback(action, webView)
             });
 
             /* FEEDBACK: */
-            var feedback = document.getElementById("feedback");
+            var feedback = document.getElementById("finalcutpro_feedback_sent_before");
             feedback.addEventListener('change', function()
             {
                 var result = {};
@@ -181,7 +181,7 @@ local function navigationCallback(action, webView)
             });
 
             /* FINAL CUT PRO USAGE: */
-            var fcpUsage = document.getElementById("FinalCutPro_usage_purpose");
+            var fcpUsage = document.getElementById("finalcutpro_usage_purpose");
             fcpUsage.addEventListener('change', function()
             {
                 var result = {};
@@ -195,7 +195,7 @@ local function navigationCallback(action, webView)
             });
 
             /* DOCUMENTATION USAGE: */
-            var documentationUsage = document.getElementById("FinalCutPro_documentation_usage_frequency");
+            var documentationUsage = document.getElementById("finalcutpro_documentation_usage_frequency");
             documentationUsage.addEventListener('change', function()
             {
                 var result = {};

--- a/src/plugins/motion/feedback/bugreport.lua
+++ b/src/plugins/motion/feedback/bugreport.lua
@@ -139,8 +139,8 @@ local function navigationCallback(action, webView)
             document.getElementsByName("third_party")[0].value = `]] .. mod.externalDevices .. [[`;
             document.getElementById("anonymous_element_3").value = `]] .. defaultFeedback .. [[`;
             //document.getElementById("subject").value = "]] .. mod.feedback .. [[";
-            document.getElementById("Motion_usage_purpose").value = "]] .. mod.motionUsage .. [[";
-            document.getElementById("Motion_documentation_usage_frequency").value = "]] .. mod.documentationUsage .. [[";
+            document.getElementById("motion_usage_purpose").value = "]] .. mod.motionUsage .. [[";
+            document.getElementById("motion_documentation_usage_frequency").value = "]] .. mod.documentationUsage .. [[";
             document.getElementById("documentation_context").value = "]] .. mod.documentationContext .. [[";
 
             /* CUSTOMER NAME: */
@@ -185,8 +185,8 @@ local function navigationCallback(action, webView)
                 }
             });
 
-            /* FINAL CUT PRO USAGE: */
-            var motionUsage = document.getElementById("Motion_usage_purpose");
+            /* MOTION USAGE: */
+            var motionUsage = document.getElementById("motion_usage_purpose");
             motionUsage.addEventListener('change', function()
             {
                 var result = {};
@@ -200,7 +200,7 @@ local function navigationCallback(action, webView)
             });
 
             /* DOCUMENTATION USAGE: */
-            var documentationUsage = document.getElementById("Motion_documentation_usage_frequency");
+            var documentationUsage = document.getElementById("motion_documentation_usage_frequency");
             documentationUsage.addEventListener('change', function()
             {
                 var result = {};


### PR DESCRIPTION
- Added Catalina to `cp.tools.getmacOSVersion()`
- Updated FCPX, Compressor & Motion Feedback forms so they use the
correct HTML IDs.
- Closes #2154