### PR TITLE
Fixes #2135 by excluding the psuSerialString value.

### DIFF
--- a/src/extensions/cp/battery.lua
+++ b/src/extensions/cp/battery.lua
@@ -127,6 +127,7 @@ local mod = {}
 local EXCLUDED = {
     ["privateBluetoothBatteryInfo"] = true,
     ["getAll"] = true,
+    ["psuSerialString"] = true,
 }
 
 --- cp.battery._watcher -> hs.battery.watcher object


### PR DESCRIPTION
Fixes #2135 