### PR TITLE
Various Fixes

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/main/LibrariesBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/LibrariesBrowser.lua
@@ -18,6 +18,7 @@ local LibrariesList				= require "cp.apple.finalcutpro.main.LibrariesList"
 
 local Button					= require "cp.ui.Button"
 local PopUpButton               = require "cp.ui.PopUpButton"
+local SplitGroup                = require "cp.ui.SplitGroup"
 local Table						= require "cp.ui.Table"
 local TextField					= require "cp.ui.TextField"
 
@@ -68,7 +69,7 @@ function LibrariesBrowser.lazy.prop:mainGroupUI()
         return cache(self, "_mainGroup", function()
             local ui = original()
             return ui and childWithRole(ui, "AXSplitGroup")
-        end)
+        end, SplitGroup.matches)
     end)
 end
 
@@ -284,13 +285,19 @@ function LibrariesBrowser.lazy.method:list()
     return LibrariesList.new(self)
 end
 
---- cp.apple.finalcutpro.main.LibrariesBrowser.sidebar <cp.ui.Table>
---- Field
+--- cp.apple.finalcutpro.main.LibrariesBrowser:sidebar() -> cp.ui.Table
+--- Method
 --- Get Libraries sidebar [Table](cp.ui.Table.md).
-function LibrariesBrowser.lazy.value:sidebar()
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The sidebar table.
+function LibrariesBrowser:sidebar()
     return Table(self, function()
         return childMatching(self:mainGroupUI(), LibrariesBrowser.matchesSidebar)
-    end):uncached()
+    end)
 end
 
 --- cp.apple.finalcutpro.main.LibrariesBrowser.matchesSidebar(element) -> boolean
@@ -304,6 +311,8 @@ end
 ---  * `true` if there's a match, otherwise `false`.
 function LibrariesBrowser.matchesSidebar(element)
     return element and element:attributeValue("AXRole") == "AXScrollArea"
+    and element:attributeValueCount("AXChildren") >= 1
+    and element:attributeValue("AXChildren")[1]:attributeValueCount("AXChildren") ~= 0
 end
 
 --- cp.apple.finalcutpro.main.LibrariesBrowser:selectLibrary(...) -> Table

--- a/src/extensions/cp/ui/Element.lua
+++ b/src/extensions/cp/ui/Element.lua
@@ -151,6 +151,23 @@ function Element:show()
     return self
 end
 
+--- cp.ui.Element:focus() -> self
+--- Method
+--- Set the focus on an element.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * self
+function Element:focus()
+    local ui = self.UI()
+    if ui then
+        ui:setAttributeValue("AXFocused", true)
+    end
+    return self
+end
+
 --- cp.ui.Element.role <cp.prop: string; read-only>
 --- Field
 --- Returns the `AX` role name for the element.

--- a/src/extensions/cp/ui/Table.lua
+++ b/src/extensions/cp/ui/Table.lua
@@ -212,19 +212,6 @@ function Table.lazy.prop:isFocused()
     end)
 end
 
---- cp.ui.Table:uncached() -> Table
---- Method
---- Calling this will force the table to look up the `axuielement` on demand, rather than caching the result.
----
---- Parameters:
----  * None
----
----  * The same `Table`, now uncached..
-function Table:uncached()
-    self._uncached = true
-    return self
-end
-
 --- cp.ui.Table.matchesContent(element) -> boolean
 --- Function
 --- Checks if the `element` is a valid table content element.

--- a/src/plugins/finalcutpro/browser/selectlibrary.lua
+++ b/src/plugins/finalcutpro/browser/selectlibrary.lua
@@ -4,6 +4,8 @@
 
 local require       = require
 
+--local log		    = require "hs.logger".new "selectlibrary"
+
 local fcp           = require "cp.apple.finalcutpro"
 local i18n          = require "cp.i18n"
 
@@ -26,13 +28,14 @@ function plugin.init(deps)
         :whenActivated(function()
             local libraries = fcp:libraries()
             local browser = fcp:browser()
-            local sidebar = libraries:sidebar()
             browser:show()
+            local sidebar = libraries:sidebar()
             if not sidebar:isShowing() then
                 browser:showLibraries():press()
             end
             sidebar:selectRowAt(1)
             sidebar:showRowAt(1)
+            sidebar:focus()
         end)
         :titled(i18n("selectTopmostLibraryInBrowser"))
 
@@ -44,8 +47,8 @@ function plugin.init(deps)
         :whenActivated(function()
             local libraries = fcp:libraries()
             local browser = fcp:browser()
-            local sidebar = libraries:sidebar()
             browser:show()
+            local sidebar = libraries:sidebar()
             if not sidebar:isShowing() then
                 browser:showLibraries():press()
             end
@@ -63,6 +66,7 @@ function plugin.init(deps)
                         if foundSelected then
                             if child and child:attributeValue("AXDisclosureLevel") == 0 then
                                 outline:setAttributeValue("AXSelectedRows", {child})
+                                sidebar:focus()
                                 break
                             end
                         end


### PR DESCRIPTION
- Select Top/Active Library actions now put focus on the library.
- Removed `cp.ui.Table:uncached()` as it wasn’t actually hooked up to
anything.
- Added `cp.ui.Element:focus()`
- Changed `cp.apple.finalcutpro.main.LibrariesBrowser:sidebar()` to be
a method rather than a field, as it had a caching issue.
- Improved `cp.apple.finalcutpro.main.LibrariesBrowser.matchesSidebar`.
- Fixed caching issue in
`cp.apple.finalcutpro.main.LibrariesBrowser.mainGroupUI`.
- Closes #2185