### PR TITLE
Various Fixes

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/main/EffectsBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/EffectsBrowser.lua
@@ -605,7 +605,7 @@ function EffectsBrowser:sidebar()
     if not self._sidebar then
         self._sidebar = Table(self, function()
             return axutils.childFromLeft(self:mainGroupUI(), 1, ScrollArea.matches)
-        end):uncached()
+        end)
     end
     return self._sidebar
 end

--- a/src/extensions/cp/apple/finalcutpro/main/GeneratorsBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/GeneratorsBrowser.lua
@@ -173,7 +173,7 @@ function GeneratorsBrowser:sidebar()
     if not self._sidebar then
         self._sidebar = Table(self, function()
             return childWithRole(self:mainGroupUI(), "AXScrollArea")
-        end):uncached()
+        end)
     end
     return self._sidebar
 end

--- a/src/extensions/cp/apple/finalcutpro/main/LibrariesBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/LibrariesBrowser.lua
@@ -4,23 +4,24 @@
 
 local require = require
 
-local log						= require "hs.logger".new "librariesBrowser"
+local log                       = require "hs.logger".new "librariesBrowser"
 
-local axutils					= require "cp.ui.axutils"
+local axutils                   = require "cp.ui.axutils"
 local go                        = require "cp.rx.go"
 local Group                     = require "cp.ui.Group"
 local i18n                      = require "cp.i18n"
-local just						= require "cp.just"
+local just                      = require "cp.just"
 
 local AppearanceAndFiltering    = require "cp.apple.finalcutpro.browser.AppearanceAndFiltering"
-local LibrariesFilmstrip		= require "cp.apple.finalcutpro.main.LibrariesFilmstrip"
-local LibrariesList				= require "cp.apple.finalcutpro.main.LibrariesList"
+local LibrariesFilmstrip        = require "cp.apple.finalcutpro.main.LibrariesFilmstrip"
+local LibrariesList             = require "cp.apple.finalcutpro.main.LibrariesList"
+local LibrariesSidebar          = require "cp.apple.finalcutpro.main.LibrariesSidebar"
 
-local Button					= require "cp.ui.Button"
+local Button                    = require "cp.ui.Button"
 local PopUpButton               = require "cp.ui.PopUpButton"
 local SplitGroup                = require "cp.ui.SplitGroup"
-local Table						= require "cp.ui.Table"
-local TextField					= require "cp.ui.TextField"
+local Table                     = require "cp.ui.Table"
+local TextField                 = require "cp.ui.TextField"
 
 local Do                        = go.Do
 local First                     = go.First
@@ -285,34 +286,11 @@ function LibrariesBrowser.lazy.method:list()
     return LibrariesList.new(self)
 end
 
---- cp.apple.finalcutpro.main.LibrariesBrowser:sidebar() -> cp.ui.Table
+--- cp.apple.finalcutpro.main.LibrariesBrowser.sidebar <cp.apple.finalcutpro.main.LibrariesSidebar>
 --- Method
---- Get Libraries sidebar [Table](cp.ui.Table.md).
----
---- Parameters:
----  * None
----
---- Returns:
----  * The sidebar table.
-function LibrariesBrowser:sidebar()
-    return Table(self, function()
-        return childMatching(self:mainGroupUI(), LibrariesBrowser.matchesSidebar)
-    end)
-end
-
---- cp.apple.finalcutpro.main.LibrariesBrowser.matchesSidebar(element) -> boolean
---- Function
---- Checks to see if an element matches the Sidebar type.
----
---- Parameters:
----  * element - The element to check.
----
---- Returns:
----  * `true` if there's a match, otherwise `false`.
-function LibrariesBrowser.matchesSidebar(element)
-    return element and element:attributeValue("AXRole") == "AXScrollArea"
-    and element:attributeValueCount("AXChildren") >= 1
-    and element:attributeValue("AXChildren")[1]:attributeValueCount("AXChildren") ~= 0
+--- The  [LibrariesSidebar](cp.apple.finalcutpro.main.LibrariesSidebar.md) Table
+function LibrariesBrowser.lazy.value:sidebar()
+    return LibrariesSidebar(self)
 end
 
 --- cp.apple.finalcutpro.main.LibrariesBrowser:selectLibrary(...) -> Table

--- a/src/extensions/cp/apple/finalcutpro/main/LibrariesSidebar.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/LibrariesSidebar.lua
@@ -1,0 +1,89 @@
+--- === cp.apple.finalcutpro.main.LibrariesSidebar ===
+---
+--- Libraries Sidebar Browser Module.
+
+local require = require
+
+--local log						= require "hs.logger".new "LibrariesSidebar"
+
+local axutils                   = require "cp.ui.axutils"
+local Table						= require "cp.ui.Table"
+
+local childMatching             = axutils.childMatching
+
+local LibrariesSidebar = Table:subclass("cp.apple.finalcutpro.main.LibrariesSidebar")
+
+function LibrariesSidebar.static.matches(element)
+    return element and element:attributeValue("AXRole") == "AXScrollArea"
+    and element:attributeValueCount("AXChildren") >= 1
+    and element:attributeValue("AXChildren")[1]:attributeValueCount("AXChildren") ~= 0
+end
+
+--- cp.apple.finalcutpro.main.LibrariesSidebar(parent) -> LibrariesSidebar
+--- Constructor
+--- Creates a new `LibrariesSidebar` instance.
+---
+--- Parameters:
+---  * parent - The parent object.
+---
+--- Returns:
+---  * A new `LibrariesSidebar` object.
+function LibrariesSidebar:initialize(parent)
+    local UI = parent.mainGroupUI:mutate(function(original)
+        local mainGroupUI = original()
+        return mainGroupUI and childMatching(mainGroupUI, LibrariesSidebar.matches)
+    end)
+    Table.initialize(self, parent, UI)
+end
+
+--- cp.apple.finalcutpro.main.LibrariesSidebar:show() -> LibrariesSidebar
+--- Method
+--- Show the Libraries Sidebar.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The `LibrariesSidebar` object.
+function LibrariesSidebar:show()
+    self:parent():show()
+    if not self:isShowing() then
+        self:parent():parent():showLibraries():press()
+    end
+    return self
+end
+
+--- cp.apple.finalcutpro.main.LibrariesSidebar:selectActiveLibrary() -> LibrariesSidebar
+--- Method
+--- Selects the active library.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The `LibrariesSidebar` object.
+function LibrariesSidebar:selectActiveLibrary()
+    local scrollArea = self:UI()
+    local outline = scrollArea and scrollArea[1]
+    if outline and outline:attributeValue("AXRole") == "AXOutline" then
+        local children = outline:attributeValue("AXChildren")
+        if children then
+            local foundSelected = false
+            for i=#children, 1, -1 do
+                local child = children[i]
+                if child and child:attributeValue("AXSelected") then
+                    foundSelected = true
+                end
+                if foundSelected then
+                    if child and child:attributeValue("AXDisclosureLevel") == 0 then
+                        outline:setAttributeValue("AXSelectedRows", {child})
+                        break
+                    end
+                end
+            end
+        end
+    end
+    return self
+end
+
+return LibrariesSidebar

--- a/src/plugins/finalcutpro/browser/selectlibrary.lua
+++ b/src/plugins/finalcutpro/browser/selectlibrary.lua
@@ -26,16 +26,10 @@ function plugin.init(deps)
     fcpxCmds
         :add("selectTopmostLibraryInBrowser")
         :whenActivated(function()
-            local libraries = fcp:libraries()
-            local browser = fcp:browser()
-            browser:show()
-            local sidebar = libraries:sidebar()
-            if not sidebar:isShowing() then
-                browser:showLibraries():press()
-            end
-            sidebar:selectRowAt(1)
-            sidebar:showRowAt(1)
-            sidebar:focus()
+            fcp.libraries.sidebar:show()
+            fcp.libraries.sidebar:selectRowAt(1)
+            fcp.libraries.sidebar:showRowAt(1)
+            fcp.libraries.sidebar:focus()
         end)
         :titled(i18n("selectTopmostLibraryInBrowser"))
 
@@ -45,37 +39,11 @@ function plugin.init(deps)
     fcpxCmds
         :add("selectActiveLibraryInBrowser")
         :whenActivated(function()
-            local libraries = fcp:libraries()
-            local browser = fcp:browser()
-            browser:show()
-            local sidebar = libraries:sidebar()
-            if not sidebar:isShowing() then
-                browser:showLibraries():press()
-            end
-            local scrollArea = sidebar:UI()
-            local outline = scrollArea and scrollArea[1]
-            if outline and outline:attributeValue("AXRole") == "AXOutline" then
-                local children = outline:attributeValue("AXChildren")
-                if children then
-                    local foundSelected = false
-                    for i=#children, 1, -1 do
-                        local child = children[i]
-                        if child and child:attributeValue("AXSelected") then
-                            foundSelected = true
-                        end
-                        if foundSelected then
-                            if child and child:attributeValue("AXDisclosureLevel") == 0 then
-                                outline:setAttributeValue("AXSelectedRows", {child})
-                                sidebar:focus()
-                                break
-                            end
-                        end
-                    end
-                end
-            end
+            fcp.libraries.sidebar:show()
+            fcp.libraries.sidebar:selectActiveLibrary()
+            fcp.libraries.sidebar:focus()
         end)
         :titled(i18n("selectActiveLibraryInBrowser"))
-
 end
 
 return plugin


### PR DESCRIPTION
- Fixes issues introduced in #2185
- Removed the `uncached()` value from `EffectsBrowser` &
`GeneratorsBrowser` as they’re no longer used (they were accidentally
dropped when things were swapped to using `middleclass`, however they
don’t seem necessary anymore from testing).
- Moved `cp.apple.finalcutpro.main.LibrariesBrowser.sidebar` into it’s
own module.
- Updated `finalcutpro.browser.selectlibrary` plugin to make use of
`cp.apple.finalcutpro.main.LibrariesBrowser.sidebar`.
- Closes #2191