### PR TITLE
Tweaks to Viewer Overlays

### DIFF
--- a/src/extensions/languages/English.json
+++ b/src/extensions/languages/English.json
@@ -615,6 +615,7 @@
         "enableShortcutsDuringFullscreen": "Enable Shortcuts During Fullscreen Playback",
         "enableStreamDeck": "Enable Stream Deck",
         "enableTangentPanelSupport": "Enable Tangent Panel Support",
+        "enableViewerContextualMenu": "Enable Viewer Contextual Menu",
         "enableVirtualTouchBar": "Enable Virtual Touch Bar",
         "enableWaveformDrawing": "Enable Waveform Drawing",
         "end": "End",

--- a/src/plugins/finalcutpro/viewer/overlays.lua
+++ b/src/plugins/finalcutpro/viewer/overlays.lua
@@ -83,6 +83,11 @@ mod.NUMBER_OF_MEMORIES = 5
 -- Number of Draggable Guides Available.
 mod.NUMBER_OF_DRAGGABLE_GUIDES = 5
 
+--- plugins.finalcutpro.viewer.overlays.enableViewerRightClick <cp.prop: boolean>
+--- Variable
+--- Allow the user to right click on the top of the viewer to access the menu?
+mod.enableViewerRightClick = config.prop("fcpx.ViewerOverlay.EnableViewerRightClick", false)
+
 --- plugins.finalcutpro.viewer.overlays.disabled <cp.prop: boolean>
 --- Variable
 --- Are all the Viewer Overlay's disabled?
@@ -182,14 +187,7 @@ mod.customCrossHairColor = config.prop("fcpx.ViewerOverlay.CrossHair.CustomColor
 --- Variable
 --- Toggle Viewer Overlays with Caps Lock.
 mod.capslock = config.prop("fcpx.ViewerOverlay.CapsLock", false):watch(function(enabled)
-    if enabled then
-        mod._capslockEventTap = eventtap.new({events.flagsChanged}, function(event)
-            local keycode = event:getKeyCode()
-            if keycode == 57 then
-                mod.update()
-            end
-        end):start()
-    else
+    if not enabled then
         if mod._capslockEventTap then
             mod._capslockEventTap:stop()
             mod._capslockEventTap = nil
@@ -632,6 +630,329 @@ local function areAnyOverlaysEnabled()
     or false
 end
 
+-- generateMenu -> table
+-- Function
+-- Returns a table with the Overlay menu.
+--
+-- Parameters:
+--  * None
+--
+-- Returns:
+--  * A table containing the overlay menu.
+local function generateMenu()
+    return {
+        --------------------------------------------------------------------------------
+        --
+        -- ENABLE OVERLAYS:
+        --
+        --------------------------------------------------------------------------------
+        { title = i18n("enable") .. " " .. i18n("overlays"), checked = not mod.capslock() and not mod.disabled(), fn = function() mod.disabled:toggle(); mod.update() end, disabled = mod.capslock()  },
+        { title = i18n("toggleOverlaysWithCapsLock"), checked = mod.capslock(), fn = function() mod.capslock:toggle(); mod.update() end },
+        { title = "-", disabled = true },
+        --------------------------------------------------------------------------------
+        --
+        -- DRAGGABLE GUIDES:
+        --
+        --------------------------------------------------------------------------------
+        { title = string.upper(i18n("guides")) .. ":", disabled = true },
+        { title = "  " .. i18n("draggableGuides"), menu = {
+            { title = i18n("guide") .. " 1", menu = {
+                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(1), fn = function() mod.toggleDraggableGuide(1); mod.update(); end },
+                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(1) end },
+                { title = i18n("appearance"), menu = {
+                    { title = "  " .. i18n("color"), menu = {
+                        { title = i18n("black"),    checked = mod.getGuideColor(1) == "#000000", fn = function() mod.setGuideColor(1, "#000000") end },
+                        { title = i18n("white"),    checked = mod.getGuideColor(1) == "#FFFFFF", fn = function() mod.setGuideColor(1, "#FFFFFF") end },
+                        { title = i18n("yellow"),   checked = mod.getGuideColor(1) == "#F4D03F", fn = function() mod.setGuideColor(1, "#F4D03F") end },
+                        { title = i18n("red"),      checked = mod.getGuideColor(1) == "#FF5733", fn = function() mod.setGuideColor(1, "#FF5733") end },
+                        { title = "-", disabled = true },
+                        { title = i18n("custom"),   checked = mod.getGuideColor(1) == "CUSTOM", fn = function() mod.setCustomGuideColor(1) end},
+                    }},
+                    { title = "  " .. i18n("opacity"), menu = {
+                        { title = "10%",  checked = mod.getGuideAlpha(1) == 10,  fn = function() mod.setGuideAlpha(1, 10) end },
+                        { title = "20%",  checked = mod.getGuideAlpha(1) == 20,  fn = function() mod.setGuideAlpha(1, 20) end },
+                        { title = "30%",  checked = mod.getGuideAlpha(1) == 30,  fn = function() mod.setGuideAlpha(1, 30) end },
+                        { title = "40%",  checked = mod.getGuideAlpha(1) == 40,  fn = function() mod.setGuideAlpha(1, 40) end },
+                        { title = "50%",  checked = mod.getGuideAlpha(1) == 50,  fn = function() mod.setGuideAlpha(1, 50) end },
+                        { title = "60%",  checked = mod.getGuideAlpha(1) == 60,  fn = function() mod.setGuideAlpha(1, 60) end },
+                        { title = "70%",  checked = mod.getGuideAlpha(1) == 70,  fn = function() mod.setGuideAlpha(1, 70) end },
+                        { title = "80%",  checked = mod.getGuideAlpha(1) == 80,  fn = function() mod.setGuideAlpha(1, 80) end },
+                        { title = "90%",  checked = mod.getGuideAlpha(1) == 90,  fn = function() mod.setGuideAlpha(1, 90) end },
+                        { title = "100%", checked = mod.getGuideAlpha(1) == 100, fn = function() mod.setGuideAlpha(1, 100) end },
+                    }},
+                }},
+            }},
+            { title = i18n("guide") .. " 2", menu = {
+                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(2), fn = function() mod.toggleDraggableGuide(2); mod.update(); end },
+                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(2) end },
+                { title = i18n("appearance"), menu = {
+                    { title = "  " .. i18n("color"), menu = {
+                        { title = i18n("black"),    checked = mod.getGuideColor(2) == "#000000", fn = function() mod.setGuideColor(2, "#000000") end },
+                        { title = i18n("white"),    checked = mod.getGuideColor(2) == "#FFFFFF", fn = function() mod.setGuideColor(2, "#FFFFFF") end },
+                        { title = i18n("yellow"),   checked = mod.getGuideColor(2) == "#F4D03F", fn = function() mod.setGuideColor(2, "#F4D03F") end },
+                        { title = i18n("red"),      checked = mod.getGuideColor(2) == "#FF5733", fn = function() mod.setGuideColor(2, "#FF5733") end },
+                        { title = "-", disabled = true },
+                        { title = i18n("custom"),   checked = mod.getGuideColor(2) == "CUSTOM", fn = function() mod.setCustomGuideColor(2) end},
+                    }},
+                    { title = "  " .. i18n("opacity"), menu = {
+                        { title = "10%",  checked = mod.getGuideAlpha(2) == 10,  fn = function() mod.setGuideAlpha(2, 10) end },
+                        { title = "20%",  checked = mod.getGuideAlpha(2) == 20,  fn = function() mod.setGuideAlpha(2, 20) end },
+                        { title = "30%",  checked = mod.getGuideAlpha(2) == 30,  fn = function() mod.setGuideAlpha(2, 30) end },
+                        { title = "40%",  checked = mod.getGuideAlpha(2) == 40,  fn = function() mod.setGuideAlpha(2, 40) end },
+                        { title = "50%",  checked = mod.getGuideAlpha(2) == 50,  fn = function() mod.setGuideAlpha(2, 50) end },
+                        { title = "60%",  checked = mod.getGuideAlpha(2) == 60,  fn = function() mod.setGuideAlpha(2, 60) end },
+                        { title = "70%",  checked = mod.getGuideAlpha(2) == 70,  fn = function() mod.setGuideAlpha(2, 70) end },
+                        { title = "80%",  checked = mod.getGuideAlpha(2) == 80,  fn = function() mod.setGuideAlpha(2, 80) end },
+                        { title = "90%",  checked = mod.getGuideAlpha(2) == 90,  fn = function() mod.setGuideAlpha(2, 90) end },
+                        { title = "100%", checked = mod.getGuideAlpha(2) == 100, fn = function() mod.setGuideAlpha(2, 100) end },
+                    }},
+                }},
+            }},
+            { title = i18n("guide") .. " 3", menu = {
+                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(3), fn = function() mod.toggleDraggableGuide(3); mod.update(); end },
+                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(3) end },
+                { title = i18n("appearance"), menu = {
+                    { title = "  " .. i18n("color"), menu = {
+                        { title = i18n("black"),    checked = mod.getGuideColor(3) == "#000000", fn = function() mod.setGuideColor(3, "#000000") end },
+                        { title = i18n("white"),    checked = mod.getGuideColor(3) == "#FFFFFF", fn = function() mod.setGuideColor(3, "#FFFFFF") end },
+                        { title = i18n("yellow"),   checked = mod.getGuideColor(3) == "#F4D03F", fn = function() mod.setGuideColor(3, "#F4D03F") end },
+                        { title = i18n("red"),      checked = mod.getGuideColor(3) == "#FF5733", fn = function() mod.setGuideColor(3, "#FF5733") end },
+                        { title = "-", disabled = true },
+                        { title = i18n("custom"),   checked = mod.getGuideColor(3) == "CUSTOM", fn = function() mod.setCustomGuideColor(3) end},
+                    }},
+                    { title = "  " .. i18n("opacity"), menu = {
+                        { title = "10%",  checked = mod.getGuideAlpha(3) == 10,  fn = function() mod.setGuideAlpha(3, 10) end },
+                        { title = "20%",  checked = mod.getGuideAlpha(3) == 20,  fn = function() mod.setGuideAlpha(3, 20) end },
+                        { title = "30%",  checked = mod.getGuideAlpha(3) == 30,  fn = function() mod.setGuideAlpha(3, 30) end },
+                        { title = "40%",  checked = mod.getGuideAlpha(3) == 40,  fn = function() mod.setGuideAlpha(3, 40) end },
+                        { title = "50%",  checked = mod.getGuideAlpha(3) == 50,  fn = function() mod.setGuideAlpha(3, 50) end },
+                        { title = "60%",  checked = mod.getGuideAlpha(3) == 60,  fn = function() mod.setGuideAlpha(3, 60) end },
+                        { title = "70%",  checked = mod.getGuideAlpha(3) == 70,  fn = function() mod.setGuideAlpha(3, 70) end },
+                        { title = "80%",  checked = mod.getGuideAlpha(3) == 80,  fn = function() mod.setGuideAlpha(3, 80) end },
+                        { title = "90%",  checked = mod.getGuideAlpha(3) == 90,  fn = function() mod.setGuideAlpha(3, 90) end },
+                        { title = "100%", checked = mod.getGuideAlpha(3) == 100, fn = function() mod.setGuideAlpha(3, 100) end },
+                    }},
+                }},
+            }},
+            { title = i18n("guide") .. " 4", menu = {
+                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(4), fn = function() mod.toggleDraggableGuide(4); mod.update(); end },
+                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(4) end },
+                { title = i18n("appearance"), menu = {
+                    { title = "  " .. i18n("color"), menu = {
+                        { title = i18n("black"),    checked = mod.getGuideColor(4) == "#000000", fn = function() mod.setGuideColor(4, "#000000") end },
+                        { title = i18n("white"),    checked = mod.getGuideColor(4) == "#FFFFFF", fn = function() mod.setGuideColor(4, "#FFFFFF") end },
+                        { title = i18n("yellow"),   checked = mod.getGuideColor(4) == "#F4D03F", fn = function() mod.setGuideColor(4, "#F4D03F") end },
+                        { title = i18n("red"),      checked = mod.getGuideColor(4) == "#FF5733", fn = function() mod.setGuideColor(4, "#FF5733") end },
+                        { title = "-", disabled = true },
+                        { title = i18n("custom"),   checked = mod.getGuideColor(4) == "CUSTOM", fn = function() mod.setCustomGuideColor(4) end},
+                    }},
+                    { title = "  " .. i18n("opacity"), menu = {
+                        { title = "10%",  checked = mod.getGuideAlpha(4) == 10,  fn = function() mod.setGuideAlpha(4, 10) end },
+                        { title = "20%",  checked = mod.getGuideAlpha(4) == 20,  fn = function() mod.setGuideAlpha(4, 20) end },
+                        { title = "30%",  checked = mod.getGuideAlpha(4) == 30,  fn = function() mod.setGuideAlpha(4, 30) end },
+                        { title = "40%",  checked = mod.getGuideAlpha(4) == 40,  fn = function() mod.setGuideAlpha(4, 40) end },
+                        { title = "50%",  checked = mod.getGuideAlpha(4) == 50,  fn = function() mod.setGuideAlpha(4, 50) end },
+                        { title = "60%",  checked = mod.getGuideAlpha(4) == 60,  fn = function() mod.setGuideAlpha(4, 60) end },
+                        { title = "70%",  checked = mod.getGuideAlpha(4) == 70,  fn = function() mod.setGuideAlpha(4, 70) end },
+                        { title = "80%",  checked = mod.getGuideAlpha(4) == 80,  fn = function() mod.setGuideAlpha(4, 80) end },
+                        { title = "90%",  checked = mod.getGuideAlpha(4) == 90,  fn = function() mod.setGuideAlpha(4, 90) end },
+                        { title = "100%", checked = mod.getGuideAlpha(4) == 100, fn = function() mod.setGuideAlpha(4, 100) end },
+                    }},
+                }},
+            }},
+            { title = i18n("guide") .. " 5", menu = {
+                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(5), fn = function() mod.toggleDraggableGuide(5); mod.update(); end },
+                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(5) end },
+                { title = i18n("appearance"), menu = {
+                    { title = "  " .. i18n("color"), menu = {
+                        { title = i18n("black"),    checked = mod.getGuideColor(5) == "#000000", fn = function() mod.setGuideColor(5, "#000000") end },
+                        { title = i18n("white"),    checked = mod.getGuideColor(5) == "#FFFFFF", fn = function() mod.setGuideColor(5, "#FFFFFF") end },
+                        { title = i18n("yellow"),   checked = mod.getGuideColor(5) == "#F4D03F", fn = function() mod.setGuideColor(5, "#F4D03F") end },
+                        { title = i18n("red"),      checked = mod.getGuideColor(5) == "#FF5733", fn = function() mod.setGuideColor(5, "#FF5733") end },
+                        { title = "-", disabled = true },
+                        { title = i18n("custom"),   checked = mod.getGuideColor(5) == "CUSTOM", fn = function() mod.setCustomGuideColor(5) end},
+                    }},
+                    { title = "  " .. i18n("opacity"), menu = {
+                        { title = "10%",  checked = mod.getGuideAlpha(5) == 10,  fn = function() mod.setGuideAlpha(5, 10) end },
+                        { title = "20%",  checked = mod.getGuideAlpha(5) == 20,  fn = function() mod.setGuideAlpha(5, 20) end },
+                        { title = "30%",  checked = mod.getGuideAlpha(5) == 30,  fn = function() mod.setGuideAlpha(5, 30) end },
+                        { title = "40%",  checked = mod.getGuideAlpha(5) == 40,  fn = function() mod.setGuideAlpha(5, 40) end },
+                        { title = "50%",  checked = mod.getGuideAlpha(5) == 50,  fn = function() mod.setGuideAlpha(5, 50) end },
+                        { title = "60%",  checked = mod.getGuideAlpha(5) == 60,  fn = function() mod.setGuideAlpha(5, 60) end },
+                        { title = "70%",  checked = mod.getGuideAlpha(5) == 70,  fn = function() mod.setGuideAlpha(5, 70) end },
+                        { title = "80%",  checked = mod.getGuideAlpha(5) == 80,  fn = function() mod.setGuideAlpha(5, 80) end },
+                        { title = "90%",  checked = mod.getGuideAlpha(5) == 90,  fn = function() mod.setGuideAlpha(5, 90) end },
+                        { title = "100%", checked = mod.getGuideAlpha(5) == 100, fn = function() mod.setGuideAlpha(5, 100) end },
+                    }},
+                }},
+            }},
+        }},
+        --------------------------------------------------------------------------------
+        --
+        -- CROSS HAIR:
+        --
+        --------------------------------------------------------------------------------
+        { title = "  " .. i18n("crossHair"), menu = {
+            { title = i18n("enable"),   checked = mod.crossHairEnabled(), fn = function() mod.crossHairEnabled:toggle(); mod.update(); end },
+            { title = i18n("appearance"), menu = {
+                { title = "  " .. i18n("color"), menu = {
+                    { title = i18n("black"),    checked = mod.crossHairColor() == "#000000", fn = function() mod.crossHairColor("#000000"); mod.update() end },
+                    { title = i18n("white"),    checked = mod.crossHairColor() == "#FFFFFF", fn = function() mod.crossHairColor("#FFFFFF"); mod.update() end },
+                    { title = i18n("yellow"),   checked = mod.crossHairColor() == "#F4D03F", fn = function() mod.crossHairColor("#F4D03F"); mod.update() end },
+                    { title = i18n("red"),      checked = mod.crossHairColor() == "#FF5733", fn = function() mod.crossHairColor("#FF5733"); mod.update() end },
+                    { title = "-", disabled = true },
+                    { title = i18n("custom"),   checked = mod.crossHairColor() == "CUSTOM", fn = function() mod.setCustomCrossHairColor(); mod.update() end},
+                }},
+                { title = "  " .. i18n("opacity"), menu = {
+                    { title = "10%",  checked = mod.crossHairAlpha() == 10,  fn = function() mod.crossHairAlpha(10); mod.update() end },
+                    { title = "20%",  checked = mod.crossHairAlpha() == 20,  fn = function() mod.crossHairAlpha(20); mod.update() end },
+                    { title = "30%",  checked = mod.crossHairAlpha() == 30,  fn = function() mod.crossHairAlpha(30); mod.update() end },
+                    { title = "40%",  checked = mod.crossHairAlpha() == 40,  fn = function() mod.crossHairAlpha(40); mod.update() end },
+                    { title = "50%",  checked = mod.crossHairAlpha() == 50,  fn = function() mod.crossHairAlpha(50); mod.update() end },
+                    { title = "60%",  checked = mod.crossHairAlpha() == 60,  fn = function() mod.crossHairAlpha(60); mod.update() end },
+                    { title = "70%",  checked = mod.crossHairAlpha() == 70,  fn = function() mod.crossHairAlpha(70); mod.update() end },
+                    { title = "80%",  checked = mod.crossHairAlpha() == 80,  fn = function() mod.crossHairAlpha(80); mod.update() end },
+                    { title = "90%",  checked = mod.crossHairAlpha() == 90,  fn = function() mod.crossHairAlpha(90); mod.update() end },
+                    { title = "100%", checked = mod.crossHairAlpha() == 100, fn = function() mod.crossHairAlpha(100); mod.update() end },
+                }},
+            }},
+        }},
+        { title = "-", disabled = true },
+        { title = string.upper(i18n("mattes")) .. ":", disabled = true },
+        { title = "  " .. i18n("letterbox"), menu = {
+            { title = i18n("enable"),   checked = mod.letterboxEnabled(), fn = function() mod.letterboxEnabled:toggle(); mod.update(); end },
+        }},
+        { title = "-", disabled = true },
+        --------------------------------------------------------------------------------
+        --
+        -- STILL FRAMES:
+        --
+        --------------------------------------------------------------------------------
+        { title = string.upper(i18n("stillFrames")) .. ":", disabled = true },
+        { title = "  " .. i18n("view"), menu = {
+            { title = i18n("memory") .. " 1", checked = mod.activeMemory() == 1, fn = function() mod.viewMemory(1) end, disabled = not mod.getMemory(1) },
+            { title = i18n("memory") .. " 2", checked = mod.activeMemory() == 2, fn = function() mod.viewMemory(2) end, disabled = not mod.getMemory(2) },
+            { title = i18n("memory") .. " 3", checked = mod.activeMemory() == 3, fn = function() mod.viewMemory(3) end, disabled = not mod.getMemory(3) },
+            { title = i18n("memory") .. " 4", checked = mod.activeMemory() == 4, fn = function() mod.viewMemory(4) end, disabled = not mod.getMemory(4) },
+            { title = i18n("memory") .. " 5", checked = mod.activeMemory() == 5, fn = function() mod.viewMemory(5) end, disabled = not mod.getMemory(5) },
+        }},
+        { title = "  " .. i18n("save"), menu = {
+            { title = i18n("memory") .. " 1", fn = function() mod.saveMemory(1) end },
+            { title = i18n("memory") .. " 2", fn = function() mod.saveMemory(2) end },
+            { title = i18n("memory") .. " 3", fn = function() mod.saveMemory(3) end },
+            { title = i18n("memory") .. " 4", fn = function() mod.saveMemory(4) end },
+            { title = i18n("memory") .. " 5", fn = function() mod.saveMemory(5) end },
+        }},
+        { title = "  " .. i18n("import"), menu = {
+            { title = i18n("memory") .. " 1", fn = function() mod.importMemory(1) end },
+            { title = i18n("memory") .. " 2", fn = function() mod.importMemory(2) end },
+            { title = i18n("memory") .. " 3", fn = function() mod.importMemory(3) end },
+            { title = i18n("memory") .. " 4", fn = function() mod.importMemory(4) end },
+            { title = i18n("memory") .. " 5", fn = function() mod.importMemory(5) end },
+        }},
+        { title = "  " .. i18n("delete"), menu = {
+            { title = i18n("memory") .. " 1", fn = function() mod.deleteMemory(1) end, disabled = not mod.getMemory(1) },
+            { title = i18n("memory") .. " 2", fn = function() mod.deleteMemory(2) end, disabled = not mod.getMemory(2) },
+            { title = i18n("memory") .. " 3", fn = function() mod.deleteMemory(3) end, disabled = not mod.getMemory(3) },
+            { title = i18n("memory") .. " 4", fn = function() mod.deleteMemory(4) end, disabled = not mod.getMemory(4) },
+            { title = i18n("memory") .. " 5", fn = function() mod.deleteMemory(5) end, disabled = not mod.getMemory(5) },
+        }},
+        { title = "  " .. i18n("appearance"), menu = {
+            { title = i18n("fullFrame"),  checked = mod.stillsLayout() == "Full Frame", fn = function() mod.stillsLayout("Full Frame"); mod.update() end },
+            { title = "-", disabled = true },
+            { title = i18n("leftVertical"),  checked = mod.stillsLayout() == "Left Vertical", fn = function() mod.stillsLayout("Left Vertical"); mod.update() end },
+            { title = i18n("rightVertical"), checked = mod.stillsLayout() == "Right Vertical", fn = function() mod.stillsLayout("Right Vertical"); mod.update() end },
+            { title = "-", disabled = true },
+            { title = i18n("topHorizontal"), checked = mod.stillsLayout() == "Top Horizontal", fn = function() mod.stillsLayout("Top Horizontal"); mod.update() end },
+            { title = i18n("bottomHorizontal"), checked = mod.stillsLayout() == "Bottom Horizontal", fn = function() mod.stillsLayout("Bottom Horizontal"); mod.update() end },
+        }},
+        { title = "-", disabled = true },
+        --------------------------------------------------------------------------------
+        --
+        -- GRID OVERLAY:
+        --
+        --------------------------------------------------------------------------------
+        { title = string.upper(i18n("gridOverlay")) .. ":", disabled = true },
+        { title = "  " .. i18n("enable"), checked = mod.basicGridEnabled(), fn = function() mod.basicGridEnabled:toggle(); mod.update(); end },
+        { title = "  " .. i18n("appearance"), menu = {
+            { title = "  " .. i18n("color"), menu = {
+                { title = i18n("black"),    checked = mod.gridColor() == "#000000", fn = function() mod.setGridColor("#000000") end },
+                { title = i18n("white"),    checked = mod.gridColor() == "#FFFFFF", fn = function() mod.setGridColor("#FFFFFF") end },
+                { title = i18n("yellow"),   checked = mod.gridColor() == "#F4D03F", fn = function() mod.setGridColor("#F4D03F") end },
+                { title = i18n("red"),      checked = mod.gridColor() == "#FF5733", fn = function() mod.setGridColor("#FF5733") end },
+                { title = "-", disabled = true },
+                { title = i18n("custom"),   checked = mod.gridColor() == "CUSTOM" and mod.customGridColor(), fn = mod.setCustomGridColor },
+            }},
+            { title = "  " .. i18n("opacity"), menu = {
+                { title = "10%",  checked = mod.gridAlpha() == 10,  fn = function() mod.setGridAlpha(10) end },
+                { title = "20%",  checked = mod.gridAlpha() == 20,  fn = function() mod.setGridAlpha(20) end },
+                { title = "30%",  checked = mod.gridAlpha() == 30,  fn = function() mod.setGridAlpha(30) end },
+                { title = "40%",  checked = mod.gridAlpha() == 40,  fn = function() mod.setGridAlpha(40) end },
+                { title = "50%",  checked = mod.gridAlpha() == 50,  fn = function() mod.setGridAlpha(50) end },
+                { title = "60%",  checked = mod.gridAlpha() == 60,  fn = function() mod.setGridAlpha(60) end },
+                { title = "70%",  checked = mod.gridAlpha() == 70,  fn = function() mod.setGridAlpha(70) end },
+                { title = "80%",  checked = mod.gridAlpha() == 80,  fn = function() mod.setGridAlpha(80) end },
+                { title = "90%",  checked = mod.gridAlpha() == 90,  fn = function() mod.setGridAlpha(90) end },
+                { title = "100%", checked = mod.gridAlpha() == 100, fn = function() mod.setGridAlpha(100) end },
+            }},
+            { title = "  " .. i18n("segments"), menu = {
+                { title = "5",      checked = mod.gridSpacing() == 5,  fn = function() mod.setGridSpacing(5) end },
+                { title = "10",     checked = mod.gridSpacing() == 10, fn = function() mod.setGridSpacing(10) end },
+                { title = "15",     checked = mod.gridSpacing() == 15, fn = function() mod.setGridSpacing(15) end },
+                { title = "20",     checked = mod.gridSpacing() == 20, fn = function() mod.setGridSpacing(20) end },
+                { title = "25",     checked = mod.gridSpacing() == 25, fn = function() mod.setGridSpacing(25) end },
+                { title = "30",     checked = mod.gridSpacing() == 30, fn = function() mod.setGridSpacing(30) end },
+                { title = "35",     checked = mod.gridSpacing() == 35, fn = function() mod.setGridSpacing(35) end },
+                { title = "40",     checked = mod.gridSpacing() == 40, fn = function() mod.setGridSpacing(40) end },
+                { title = "45",     checked = mod.gridSpacing() == 45, fn = function() mod.setGridSpacing(45) end },
+                { title = "50",     checked = mod.gridSpacing() == 50, fn = function() mod.setGridSpacing(50) end },
+                { title = "55",     checked = mod.gridSpacing() == 55, fn = function() mod.setGridSpacing(55) end },
+                { title = "60",     checked = mod.gridSpacing() == 60, fn = function() mod.setGridSpacing(60) end },
+                { title = "65",     checked = mod.gridSpacing() == 65, fn = function() mod.setGridSpacing(65) end },
+                { title = "70",     checked = mod.gridSpacing() == 70, fn = function() mod.setGridSpacing(70) end },
+                { title = "75",     checked = mod.gridSpacing() == 75, fn = function() mod.setGridSpacing(70) end },
+                { title = "80",     checked = mod.gridSpacing() == 80, fn = function() mod.setGridSpacing(80) end },
+                { title = "85",     checked = mod.gridSpacing() == 85, fn = function() mod.setGridSpacing(85) end },
+                { title = "90",     checked = mod.gridSpacing() == 90, fn = function() mod.setGridSpacing(90) end },
+                { title = "95",     checked = mod.gridSpacing() == 95, fn = function() mod.setGridSpacing(95) end },
+                { title = "100",    checked = mod.gridSpacing() == 100, fn = function() mod.setGridSpacing(100) end },
+            }},
+        }},
+        { title = "-", disabled = true },
+        { title = i18n("reset") .. " " .. i18n("overlays"), fn = function() mod.resetOverlays() end },
+    }
+end
+
+-- contextualMenu(event) -> none
+-- Function
+-- Builds the Final Cut Pro Overlay contextual menu.
+--
+-- Parameters:
+--  * event - The `hs.eventtap` event
+--
+-- Returns:
+--  * None
+local function contextualMenu(event)
+    local ui = fcp:viewer():UI()
+    local topBar = ui and axutils.childFromTop(ui, 1)
+    if topBar then
+        local barFrame = topBar:attributeValue("AXFrame")
+        local location = event:location() and geometry.point(event:location())
+        if barFrame and location and location:inside(geometry.rect(barFrame)) then
+            if mod._menu then
+                mod._menu:delete()
+                mod._menu = nil
+            end
+            mod._menu = menubar.new()
+            mod._menu:setMenu(generateMenu())
+            mod._menu:removeFromMenuBar()
+            mod._menu:popupMenu(location, true)
+        end
+    end
+end
+
+mod._lastValue = false
+
 --- plugins.finalcutpro.viewer.overlays.update() -> none
 --- Function
 --- Updates the Viewer Grid.
@@ -643,62 +964,132 @@ end
 ---  * None
 function mod.update()
     --------------------------------------------------------------------------------
-    -- If Final Cut Pro is Front Most & Viewer is Showing:
+    -- Wrap this in a timer to (maybe?) avoid notification lockups:
     --------------------------------------------------------------------------------
-    local viewer = fcp:viewer()
-
-    if fcp.isFrontmost()
-        and viewer:isShowing()
-        and not fcp.isModalDialogOpen()
-        and not fcp:fullScreenWindow():isShowing()
-        and not fcp:commandEditor():isShowing()
-        and not fcp:preferencesWindow():isShowing()
-    then
+    doAfter(0, function()
         --------------------------------------------------------------------------------
-        -- Start the Keyboard Watcher:
+        -- If Final Cut Pro is Front Most & Viewer is Showing:
         --------------------------------------------------------------------------------
-        if mod._eventtap then
-            mod._eventtap:start()
-        end
-
-        --------------------------------------------------------------------------------
-        -- Toggle Overall Visibility:
-        --------------------------------------------------------------------------------
-        if areAnyOverlaysEnabled() == true then
-            if mod.capslock() == true then
-                --------------------------------------------------------------------------------
-                -- Caps Lock Mode:
-                --------------------------------------------------------------------------------
-                if capslock.get() == true then
-                    mod.show()
+        if fcp.isFrontmost()
+            and fcp.viewer:isShowing()
+            and not fcp.isModalDialogOpen()
+            and not fcp:fullScreenWindow():isShowing()
+            and not fcp:commandEditor():isShowing()
+            and not fcp:preferencesWindow():isShowing()
+        then
+            --------------------------------------------------------------------------------
+            -- Start the Mouse Watcher:
+            --------------------------------------------------------------------------------
+            if mod.enableViewerRightClick() then
+                if mod._eventtap then
+                    if not mod._eventtap:isEnabled() then
+                        mod._eventtap:start()
+                    end
                 else
-                    mod.hide()
+                    mod._eventtap = eventtap.new({events.rightMouseUp}, contextualMenu)
+                    mod._eventtap:start()
+                end
+            else
+                if mod._eventtap then
+                    mod._eventtap:stop()
+                    mod._eventtap = nil
+                end
+            end
+
+            --------------------------------------------------------------------------------
+            -- Start the Caps Lock Watcher:
+            --------------------------------------------------------------------------------
+            if mod.capslock() then
+                if mod._capslockEventTap then
+                    if not mod._capslockEventTap:isEnabled() then
+                        mod._capslockEventTap:start()
+                    end
+                else
+                    mod._capslockEventTap = eventtap.new({events.flagsChanged}, function(event)
+                        local keycode = event:getKeyCode()
+                        if keycode == 57 then
+                            mod.update()
+                        end
+                    end)
+                    mod._capslockEventTap:start()
+                end
+            else
+                if mod._capslockEventTap then
+                    mod._capslockEventTap:stop()
+                    mod._capslockEventTap = nil
+                end
+            end
+
+            --------------------------------------------------------------------------------
+            -- Toggle Overall Visibility:
+            --------------------------------------------------------------------------------
+            if areAnyOverlaysEnabled() == true then
+                if mod.capslock() == true then
+                    --------------------------------------------------------------------------------
+                    -- Caps Lock Mode:
+                    --------------------------------------------------------------------------------
+                    if capslock.get() == true then
+                        mod.show()
+                    else
+                        mod.hide()
+                    end
+                else
+                    --------------------------------------------------------------------------------
+                    -- "Enable Overlays" Toggle:
+                    --------------------------------------------------------------------------------
+                    if mod.disabled() == true then
+                        mod.hide()
+                    else
+                        mod.show()
+                    end
                 end
             else
                 --------------------------------------------------------------------------------
-                -- "Enable Overlays" Toggle:
+                -- No Overlays Enabled:
                 --------------------------------------------------------------------------------
-                if mod.disabled() == true then
-                    mod.hide()
-                else
-                    mod.show()
-                end
+                mod.hide()
             end
         else
             --------------------------------------------------------------------------------
-            -- No Overlays Enabled:
+            -- Otherwise hide the grid:
             --------------------------------------------------------------------------------
             mod.hide()
+
+            --------------------------------------------------------------------------------
+            -- Destroy the Mouse Watcher:
+            --------------------------------------------------------------------------------
+            if mod._eventtap then
+                mod._eventtap:stop()
+                mod._eventtap = nil
+            end
+
+            --------------------------------------------------------------------------------
+            -- Destroy the Caps Lock Watcher:
+            --------------------------------------------------------------------------------
+            if mod._capslockEventTap then
+                mod._capslockEventTap:stop()
+                mod._capslockEventTap = nil
+            end
+
+            --------------------------------------------------------------------------------
+            -- Destroy the Mouse Move Letterbox Tracker:
+            --------------------------------------------------------------------------------
+            if mod._mouseMoveLetterboxTracker then
+                mod._mouseMoveLetterboxTracker:stop()
+                mod._mouseMoveLetterboxTracker = nil
+            end
+
+            --------------------------------------------------------------------------------
+            -- Destroy any Mouse Move Trackers:
+            --------------------------------------------------------------------------------
+            if mod._mouseMoveTracker then
+                for _, v in pairs(mod._mouseMoveTracker) do
+                    v:stop()
+                    v = nil
+                end
+            end
         end
-    else
-        --------------------------------------------------------------------------------
-        -- Otherwise hide the grid and disable the Keyboard Watcher:
-        --------------------------------------------------------------------------------
-        mod.hide()
-        if mod._eventtap then
-            mod._eventtap:stop()
-        end
-    end
+    end)
 end
 
 --- plugins.finalcutpro.viewer.overlays.getStillsFolderPath() -> string | nil
@@ -770,10 +1161,10 @@ function mod.saveMemory(id)
                 result = true
             end
         else
-            log.df("Could not create Cache Folder.")
+            log.ef("Could not create Cache Folder.")
         end
     else
-        log.df("Could not find Viewer.")
+        log.ef("Could not find Viewer.")
     end
     if not result then
         dialog.displayErrorMessage("Could not save still frame.")
@@ -1190,327 +1581,6 @@ function mod.resetOverlays()
     mod.update()
 end
 
--- generateMenu -> table
--- Function
--- Returns a table with the Overlay menu.
---
--- Parameters:
---  * None
---
--- Returns:
---  * A table containing the overlay menu.
-local function generateMenu()
-    return {
-        --------------------------------------------------------------------------------
-        --
-        -- ENABLE OVERLAYS:
-        --
-        --------------------------------------------------------------------------------
-        { title = i18n("enable") .. " " .. i18n("overlays"), checked = not mod.capslock() and not mod.disabled(), fn = function() mod.disabled:toggle(); mod.update() end, disabled = mod.capslock()  },
-        { title = i18n("toggleOverlaysWithCapsLock"), checked = mod.capslock(), fn = function() mod.capslock:toggle(); mod.update() end },
-        { title = "-", disabled = true },
-        --------------------------------------------------------------------------------
-        --
-        -- DRAGGABLE GUIDES:
-        --
-        --------------------------------------------------------------------------------
-        { title = string.upper(i18n("guides")) .. ":", disabled = true },
-        { title = "  " .. i18n("draggableGuides"), menu = {
-            { title = i18n("guide") .. " 1", menu = {
-                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(1), fn = function() mod.toggleDraggableGuide(1); mod.update(); end },
-                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(1) end },
-                { title = i18n("appearance"), menu = {
-                    { title = "  " .. i18n("color"), menu = {
-                        { title = i18n("black"),    checked = mod.getGuideColor(1) == "#000000", fn = function() mod.setGuideColor(1, "#000000") end },
-                        { title = i18n("white"),    checked = mod.getGuideColor(1) == "#FFFFFF", fn = function() mod.setGuideColor(1, "#FFFFFF") end },
-                        { title = i18n("yellow"),   checked = mod.getGuideColor(1) == "#F4D03F", fn = function() mod.setGuideColor(1, "#F4D03F") end },
-                        { title = i18n("red"),      checked = mod.getGuideColor(1) == "#FF5733", fn = function() mod.setGuideColor(1, "#FF5733") end },
-                        { title = "-", disabled = true },
-                        { title = i18n("custom"),   checked = mod.getGuideColor(1) == "CUSTOM", fn = function() mod.setCustomGuideColor(1) end},
-                    }},
-                    { title = "  " .. i18n("opacity"), menu = {
-                        { title = "10%",  checked = mod.getGuideAlpha(1) == 10,  fn = function() mod.setGuideAlpha(1, 10) end },
-                        { title = "20%",  checked = mod.getGuideAlpha(1) == 20,  fn = function() mod.setGuideAlpha(1, 20) end },
-                        { title = "30%",  checked = mod.getGuideAlpha(1) == 30,  fn = function() mod.setGuideAlpha(1, 30) end },
-                        { title = "40%",  checked = mod.getGuideAlpha(1) == 40,  fn = function() mod.setGuideAlpha(1, 40) end },
-                        { title = "50%",  checked = mod.getGuideAlpha(1) == 50,  fn = function() mod.setGuideAlpha(1, 50) end },
-                        { title = "60%",  checked = mod.getGuideAlpha(1) == 60,  fn = function() mod.setGuideAlpha(1, 60) end },
-                        { title = "70%",  checked = mod.getGuideAlpha(1) == 70,  fn = function() mod.setGuideAlpha(1, 70) end },
-                        { title = "80%",  checked = mod.getGuideAlpha(1) == 80,  fn = function() mod.setGuideAlpha(1, 80) end },
-                        { title = "90%",  checked = mod.getGuideAlpha(1) == 90,  fn = function() mod.setGuideAlpha(1, 90) end },
-                        { title = "100%", checked = mod.getGuideAlpha(1) == 100, fn = function() mod.setGuideAlpha(1, 100) end },
-                    }},
-                }},
-            }},
-            { title = i18n("guide") .. " 2", menu = {
-                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(2), fn = function() mod.toggleDraggableGuide(2); mod.update(); end },
-                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(2) end },
-                { title = i18n("appearance"), menu = {
-                    { title = "  " .. i18n("color"), menu = {
-                        { title = i18n("black"),    checked = mod.getGuideColor(2) == "#000000", fn = function() mod.setGuideColor(2, "#000000") end },
-                        { title = i18n("white"),    checked = mod.getGuideColor(2) == "#FFFFFF", fn = function() mod.setGuideColor(2, "#FFFFFF") end },
-                        { title = i18n("yellow"),   checked = mod.getGuideColor(2) == "#F4D03F", fn = function() mod.setGuideColor(2, "#F4D03F") end },
-                        { title = i18n("red"),      checked = mod.getGuideColor(2) == "#FF5733", fn = function() mod.setGuideColor(2, "#FF5733") end },
-                        { title = "-", disabled = true },
-                        { title = i18n("custom"),   checked = mod.getGuideColor(2) == "CUSTOM", fn = function() mod.setCustomGuideColor(2) end},
-                    }},
-                    { title = "  " .. i18n("opacity"), menu = {
-                        { title = "10%",  checked = mod.getGuideAlpha(2) == 10,  fn = function() mod.setGuideAlpha(2, 10) end },
-                        { title = "20%",  checked = mod.getGuideAlpha(2) == 20,  fn = function() mod.setGuideAlpha(2, 20) end },
-                        { title = "30%",  checked = mod.getGuideAlpha(2) == 30,  fn = function() mod.setGuideAlpha(2, 30) end },
-                        { title = "40%",  checked = mod.getGuideAlpha(2) == 40,  fn = function() mod.setGuideAlpha(2, 40) end },
-                        { title = "50%",  checked = mod.getGuideAlpha(2) == 50,  fn = function() mod.setGuideAlpha(2, 50) end },
-                        { title = "60%",  checked = mod.getGuideAlpha(2) == 60,  fn = function() mod.setGuideAlpha(2, 60) end },
-                        { title = "70%",  checked = mod.getGuideAlpha(2) == 70,  fn = function() mod.setGuideAlpha(2, 70) end },
-                        { title = "80%",  checked = mod.getGuideAlpha(2) == 80,  fn = function() mod.setGuideAlpha(2, 80) end },
-                        { title = "90%",  checked = mod.getGuideAlpha(2) == 90,  fn = function() mod.setGuideAlpha(2, 90) end },
-                        { title = "100%", checked = mod.getGuideAlpha(2) == 100, fn = function() mod.setGuideAlpha(2, 100) end },
-                    }},
-                }},
-            }},
-            { title = i18n("guide") .. " 3", menu = {
-                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(3), fn = function() mod.toggleDraggableGuide(3); mod.update(); end },
-                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(3) end },
-                { title = i18n("appearance"), menu = {
-                    { title = "  " .. i18n("color"), menu = {
-                        { title = i18n("black"),    checked = mod.getGuideColor(3) == "#000000", fn = function() mod.setGuideColor(3, "#000000") end },
-                        { title = i18n("white"),    checked = mod.getGuideColor(3) == "#FFFFFF", fn = function() mod.setGuideColor(3, "#FFFFFF") end },
-                        { title = i18n("yellow"),   checked = mod.getGuideColor(3) == "#F4D03F", fn = function() mod.setGuideColor(3, "#F4D03F") end },
-                        { title = i18n("red"),      checked = mod.getGuideColor(3) == "#FF5733", fn = function() mod.setGuideColor(3, "#FF5733") end },
-                        { title = "-", disabled = true },
-                        { title = i18n("custom"),   checked = mod.getGuideColor(3) == "CUSTOM", fn = function() mod.setCustomGuideColor(3) end},
-                    }},
-                    { title = "  " .. i18n("opacity"), menu = {
-                        { title = "10%",  checked = mod.getGuideAlpha(3) == 10,  fn = function() mod.setGuideAlpha(3, 10) end },
-                        { title = "20%",  checked = mod.getGuideAlpha(3) == 20,  fn = function() mod.setGuideAlpha(3, 20) end },
-                        { title = "30%",  checked = mod.getGuideAlpha(3) == 30,  fn = function() mod.setGuideAlpha(3, 30) end },
-                        { title = "40%",  checked = mod.getGuideAlpha(3) == 40,  fn = function() mod.setGuideAlpha(3, 40) end },
-                        { title = "50%",  checked = mod.getGuideAlpha(3) == 50,  fn = function() mod.setGuideAlpha(3, 50) end },
-                        { title = "60%",  checked = mod.getGuideAlpha(3) == 60,  fn = function() mod.setGuideAlpha(3, 60) end },
-                        { title = "70%",  checked = mod.getGuideAlpha(3) == 70,  fn = function() mod.setGuideAlpha(3, 70) end },
-                        { title = "80%",  checked = mod.getGuideAlpha(3) == 80,  fn = function() mod.setGuideAlpha(3, 80) end },
-                        { title = "90%",  checked = mod.getGuideAlpha(3) == 90,  fn = function() mod.setGuideAlpha(3, 90) end },
-                        { title = "100%", checked = mod.getGuideAlpha(3) == 100, fn = function() mod.setGuideAlpha(3, 100) end },
-                    }},
-                }},
-            }},
-            { title = i18n("guide") .. " 4", menu = {
-                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(4), fn = function() mod.toggleDraggableGuide(4); mod.update(); end },
-                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(4) end },
-                { title = i18n("appearance"), menu = {
-                    { title = "  " .. i18n("color"), menu = {
-                        { title = i18n("black"),    checked = mod.getGuideColor(4) == "#000000", fn = function() mod.setGuideColor(4, "#000000") end },
-                        { title = i18n("white"),    checked = mod.getGuideColor(4) == "#FFFFFF", fn = function() mod.setGuideColor(4, "#FFFFFF") end },
-                        { title = i18n("yellow"),   checked = mod.getGuideColor(4) == "#F4D03F", fn = function() mod.setGuideColor(4, "#F4D03F") end },
-                        { title = i18n("red"),      checked = mod.getGuideColor(4) == "#FF5733", fn = function() mod.setGuideColor(4, "#FF5733") end },
-                        { title = "-", disabled = true },
-                        { title = i18n("custom"),   checked = mod.getGuideColor(4) == "CUSTOM", fn = function() mod.setCustomGuideColor(4) end},
-                    }},
-                    { title = "  " .. i18n("opacity"), menu = {
-                        { title = "10%",  checked = mod.getGuideAlpha(4) == 10,  fn = function() mod.setGuideAlpha(4, 10) end },
-                        { title = "20%",  checked = mod.getGuideAlpha(4) == 20,  fn = function() mod.setGuideAlpha(4, 20) end },
-                        { title = "30%",  checked = mod.getGuideAlpha(4) == 30,  fn = function() mod.setGuideAlpha(4, 30) end },
-                        { title = "40%",  checked = mod.getGuideAlpha(4) == 40,  fn = function() mod.setGuideAlpha(4, 40) end },
-                        { title = "50%",  checked = mod.getGuideAlpha(4) == 50,  fn = function() mod.setGuideAlpha(4, 50) end },
-                        { title = "60%",  checked = mod.getGuideAlpha(4) == 60,  fn = function() mod.setGuideAlpha(4, 60) end },
-                        { title = "70%",  checked = mod.getGuideAlpha(4) == 70,  fn = function() mod.setGuideAlpha(4, 70) end },
-                        { title = "80%",  checked = mod.getGuideAlpha(4) == 80,  fn = function() mod.setGuideAlpha(4, 80) end },
-                        { title = "90%",  checked = mod.getGuideAlpha(4) == 90,  fn = function() mod.setGuideAlpha(4, 90) end },
-                        { title = "100%", checked = mod.getGuideAlpha(4) == 100, fn = function() mod.setGuideAlpha(4, 100) end },
-                    }},
-                }},
-            }},
-            { title = i18n("guide") .. " 5", menu = {
-                { title = i18n("enable"),   checked = mod.getDraggableGuideEnabled(5), fn = function() mod.toggleDraggableGuide(5); mod.update(); end },
-                { title = i18n("reset"), fn = function() mod.resetDraggableGuide(5) end },
-                { title = i18n("appearance"), menu = {
-                    { title = "  " .. i18n("color"), menu = {
-                        { title = i18n("black"),    checked = mod.getGuideColor(5) == "#000000", fn = function() mod.setGuideColor(5, "#000000") end },
-                        { title = i18n("white"),    checked = mod.getGuideColor(5) == "#FFFFFF", fn = function() mod.setGuideColor(5, "#FFFFFF") end },
-                        { title = i18n("yellow"),   checked = mod.getGuideColor(5) == "#F4D03F", fn = function() mod.setGuideColor(5, "#F4D03F") end },
-                        { title = i18n("red"),      checked = mod.getGuideColor(5) == "#FF5733", fn = function() mod.setGuideColor(5, "#FF5733") end },
-                        { title = "-", disabled = true },
-                        { title = i18n("custom"),   checked = mod.getGuideColor(5) == "CUSTOM", fn = function() mod.setCustomGuideColor(5) end},
-                    }},
-                    { title = "  " .. i18n("opacity"), menu = {
-                        { title = "10%",  checked = mod.getGuideAlpha(5) == 10,  fn = function() mod.setGuideAlpha(5, 10) end },
-                        { title = "20%",  checked = mod.getGuideAlpha(5) == 20,  fn = function() mod.setGuideAlpha(5, 20) end },
-                        { title = "30%",  checked = mod.getGuideAlpha(5) == 30,  fn = function() mod.setGuideAlpha(5, 30) end },
-                        { title = "40%",  checked = mod.getGuideAlpha(5) == 40,  fn = function() mod.setGuideAlpha(5, 40) end },
-                        { title = "50%",  checked = mod.getGuideAlpha(5) == 50,  fn = function() mod.setGuideAlpha(5, 50) end },
-                        { title = "60%",  checked = mod.getGuideAlpha(5) == 60,  fn = function() mod.setGuideAlpha(5, 60) end },
-                        { title = "70%",  checked = mod.getGuideAlpha(5) == 70,  fn = function() mod.setGuideAlpha(5, 70) end },
-                        { title = "80%",  checked = mod.getGuideAlpha(5) == 80,  fn = function() mod.setGuideAlpha(5, 80) end },
-                        { title = "90%",  checked = mod.getGuideAlpha(5) == 90,  fn = function() mod.setGuideAlpha(5, 90) end },
-                        { title = "100%", checked = mod.getGuideAlpha(5) == 100, fn = function() mod.setGuideAlpha(5, 100) end },
-                    }},
-                }},
-            }},
-        }},
-        --------------------------------------------------------------------------------
-        --
-        -- CROSS HAIR:
-        --
-        --------------------------------------------------------------------------------
-        { title = "  " .. i18n("crossHair"), menu = {
-            { title = i18n("enable"),   checked = mod.crossHairEnabled(), fn = function() mod.crossHairEnabled:toggle(); mod.update(); end },
-            { title = i18n("appearance"), menu = {
-                { title = "  " .. i18n("color"), menu = {
-                    { title = i18n("black"),    checked = mod.crossHairColor() == "#000000", fn = function() mod.crossHairColor("#000000"); mod.update() end },
-                    { title = i18n("white"),    checked = mod.crossHairColor() == "#FFFFFF", fn = function() mod.crossHairColor("#FFFFFF"); mod.update() end },
-                    { title = i18n("yellow"),   checked = mod.crossHairColor() == "#F4D03F", fn = function() mod.crossHairColor("#F4D03F"); mod.update() end },
-                    { title = i18n("red"),      checked = mod.crossHairColor() == "#FF5733", fn = function() mod.crossHairColor("#FF5733"); mod.update() end },
-                    { title = "-", disabled = true },
-                    { title = i18n("custom"),   checked = mod.crossHairColor() == "CUSTOM", fn = function() mod.setCustomCrossHairColor(); mod.update() end},
-                }},
-                { title = "  " .. i18n("opacity"), menu = {
-                    { title = "10%",  checked = mod.crossHairAlpha() == 10,  fn = function() mod.crossHairAlpha(10); mod.update() end },
-                    { title = "20%",  checked = mod.crossHairAlpha() == 20,  fn = function() mod.crossHairAlpha(20); mod.update() end },
-                    { title = "30%",  checked = mod.crossHairAlpha() == 30,  fn = function() mod.crossHairAlpha(30); mod.update() end },
-                    { title = "40%",  checked = mod.crossHairAlpha() == 40,  fn = function() mod.crossHairAlpha(40); mod.update() end },
-                    { title = "50%",  checked = mod.crossHairAlpha() == 50,  fn = function() mod.crossHairAlpha(50); mod.update() end },
-                    { title = "60%",  checked = mod.crossHairAlpha() == 60,  fn = function() mod.crossHairAlpha(60); mod.update() end },
-                    { title = "70%",  checked = mod.crossHairAlpha() == 70,  fn = function() mod.crossHairAlpha(70); mod.update() end },
-                    { title = "80%",  checked = mod.crossHairAlpha() == 80,  fn = function() mod.crossHairAlpha(80); mod.update() end },
-                    { title = "90%",  checked = mod.crossHairAlpha() == 90,  fn = function() mod.crossHairAlpha(90); mod.update() end },
-                    { title = "100%", checked = mod.crossHairAlpha() == 100, fn = function() mod.crossHairAlpha(100); mod.update() end },
-                }},
-            }},
-        }},
-        { title = "-", disabled = true },
-        { title = string.upper(i18n("mattes")) .. ":", disabled = true },
-        { title = "  " .. i18n("letterbox"), menu = {
-            { title = i18n("enable"),   checked = mod.letterboxEnabled(), fn = function() mod.letterboxEnabled:toggle(); mod.update(); end },
-        }},
-        { title = "-", disabled = true },
-        --------------------------------------------------------------------------------
-        --
-        -- STILL FRAMES:
-        --
-        --------------------------------------------------------------------------------
-        { title = string.upper(i18n("stillFrames")) .. ":", disabled = true },
-        { title = "  " .. i18n("view"), menu = {
-            { title = i18n("memory") .. " 1", checked = mod.activeMemory() == 1, fn = function() mod.viewMemory(1) end, disabled = not mod.getMemory(1) },
-            { title = i18n("memory") .. " 2", checked = mod.activeMemory() == 2, fn = function() mod.viewMemory(2) end, disabled = not mod.getMemory(2) },
-            { title = i18n("memory") .. " 3", checked = mod.activeMemory() == 3, fn = function() mod.viewMemory(3) end, disabled = not mod.getMemory(3) },
-            { title = i18n("memory") .. " 4", checked = mod.activeMemory() == 4, fn = function() mod.viewMemory(4) end, disabled = not mod.getMemory(4) },
-            { title = i18n("memory") .. " 5", checked = mod.activeMemory() == 5, fn = function() mod.viewMemory(5) end, disabled = not mod.getMemory(5) },
-        }},
-        { title = "  " .. i18n("save"), menu = {
-            { title = i18n("memory") .. " 1", fn = function() mod.saveMemory(1) end },
-            { title = i18n("memory") .. " 2", fn = function() mod.saveMemory(2) end },
-            { title = i18n("memory") .. " 3", fn = function() mod.saveMemory(3) end },
-            { title = i18n("memory") .. " 4", fn = function() mod.saveMemory(4) end },
-            { title = i18n("memory") .. " 5", fn = function() mod.saveMemory(5) end },
-        }},
-        { title = "  " .. i18n("import"), menu = {
-            { title = i18n("memory") .. " 1", fn = function() mod.importMemory(1) end },
-            { title = i18n("memory") .. " 2", fn = function() mod.importMemory(2) end },
-            { title = i18n("memory") .. " 3", fn = function() mod.importMemory(3) end },
-            { title = i18n("memory") .. " 4", fn = function() mod.importMemory(4) end },
-            { title = i18n("memory") .. " 5", fn = function() mod.importMemory(5) end },
-        }},
-        { title = "  " .. i18n("delete"), menu = {
-            { title = i18n("memory") .. " 1", fn = function() mod.deleteMemory(1) end, disabled = not mod.getMemory(1) },
-            { title = i18n("memory") .. " 2", fn = function() mod.deleteMemory(2) end, disabled = not mod.getMemory(2) },
-            { title = i18n("memory") .. " 3", fn = function() mod.deleteMemory(3) end, disabled = not mod.getMemory(3) },
-            { title = i18n("memory") .. " 4", fn = function() mod.deleteMemory(4) end, disabled = not mod.getMemory(4) },
-            { title = i18n("memory") .. " 5", fn = function() mod.deleteMemory(5) end, disabled = not mod.getMemory(5) },
-        }},
-        { title = "  " .. i18n("appearance"), menu = {
-            { title = i18n("fullFrame"),  checked = mod.stillsLayout() == "Full Frame", fn = function() mod.stillsLayout("Full Frame"); mod.update() end },
-            { title = "-", disabled = true },
-            { title = i18n("leftVertical"),  checked = mod.stillsLayout() == "Left Vertical", fn = function() mod.stillsLayout("Left Vertical"); mod.update() end },
-            { title = i18n("rightVertical"), checked = mod.stillsLayout() == "Right Vertical", fn = function() mod.stillsLayout("Right Vertical"); mod.update() end },
-            { title = "-", disabled = true },
-            { title = i18n("topHorizontal"), checked = mod.stillsLayout() == "Top Horizontal", fn = function() mod.stillsLayout("Top Horizontal"); mod.update() end },
-            { title = i18n("bottomHorizontal"), checked = mod.stillsLayout() == "Bottom Horizontal", fn = function() mod.stillsLayout("Bottom Horizontal"); mod.update() end },
-        }},
-        { title = "-", disabled = true },
-        --------------------------------------------------------------------------------
-        --
-        -- GRID OVERLAY:
-        --
-        --------------------------------------------------------------------------------
-        { title = string.upper(i18n("gridOverlay")) .. ":", disabled = true },
-        { title = "  " .. i18n("enable"), checked = mod.basicGridEnabled(), fn = function() mod.basicGridEnabled:toggle(); mod.update(); end },
-        { title = "  " .. i18n("appearance"), menu = {
-            { title = "  " .. i18n("color"), menu = {
-                { title = i18n("black"),    checked = mod.gridColor() == "#000000", fn = function() mod.setGridColor("#000000") end },
-                { title = i18n("white"),    checked = mod.gridColor() == "#FFFFFF", fn = function() mod.setGridColor("#FFFFFF") end },
-                { title = i18n("yellow"),   checked = mod.gridColor() == "#F4D03F", fn = function() mod.setGridColor("#F4D03F") end },
-                { title = i18n("red"),      checked = mod.gridColor() == "#FF5733", fn = function() mod.setGridColor("#FF5733") end },
-                { title = "-", disabled = true },
-                { title = i18n("custom"),   checked = mod.gridColor() == "CUSTOM" and mod.customGridColor(), fn = mod.setCustomGridColor },
-            }},
-            { title = "  " .. i18n("opacity"), menu = {
-                { title = "10%",  checked = mod.gridAlpha() == 10,  fn = function() mod.setGridAlpha(10) end },
-                { title = "20%",  checked = mod.gridAlpha() == 20,  fn = function() mod.setGridAlpha(20) end },
-                { title = "30%",  checked = mod.gridAlpha() == 30,  fn = function() mod.setGridAlpha(30) end },
-                { title = "40%",  checked = mod.gridAlpha() == 40,  fn = function() mod.setGridAlpha(40) end },
-                { title = "50%",  checked = mod.gridAlpha() == 50,  fn = function() mod.setGridAlpha(50) end },
-                { title = "60%",  checked = mod.gridAlpha() == 60,  fn = function() mod.setGridAlpha(60) end },
-                { title = "70%",  checked = mod.gridAlpha() == 70,  fn = function() mod.setGridAlpha(70) end },
-                { title = "80%",  checked = mod.gridAlpha() == 80,  fn = function() mod.setGridAlpha(80) end },
-                { title = "90%",  checked = mod.gridAlpha() == 90,  fn = function() mod.setGridAlpha(90) end },
-                { title = "100%", checked = mod.gridAlpha() == 100, fn = function() mod.setGridAlpha(100) end },
-            }},
-            { title = "  " .. i18n("segments"), menu = {
-                { title = "5",      checked = mod.gridSpacing() == 5,  fn = function() mod.setGridSpacing(5) end },
-                { title = "10",     checked = mod.gridSpacing() == 10, fn = function() mod.setGridSpacing(10) end },
-                { title = "15",     checked = mod.gridSpacing() == 15, fn = function() mod.setGridSpacing(15) end },
-                { title = "20",     checked = mod.gridSpacing() == 20, fn = function() mod.setGridSpacing(20) end },
-                { title = "25",     checked = mod.gridSpacing() == 25, fn = function() mod.setGridSpacing(25) end },
-                { title = "30",     checked = mod.gridSpacing() == 30, fn = function() mod.setGridSpacing(30) end },
-                { title = "35",     checked = mod.gridSpacing() == 35, fn = function() mod.setGridSpacing(35) end },
-                { title = "40",     checked = mod.gridSpacing() == 40, fn = function() mod.setGridSpacing(40) end },
-                { title = "45",     checked = mod.gridSpacing() == 45, fn = function() mod.setGridSpacing(45) end },
-                { title = "50",     checked = mod.gridSpacing() == 50, fn = function() mod.setGridSpacing(50) end },
-                { title = "55",     checked = mod.gridSpacing() == 55, fn = function() mod.setGridSpacing(55) end },
-                { title = "60",     checked = mod.gridSpacing() == 60, fn = function() mod.setGridSpacing(60) end },
-                { title = "65",     checked = mod.gridSpacing() == 65, fn = function() mod.setGridSpacing(65) end },
-                { title = "70",     checked = mod.gridSpacing() == 70, fn = function() mod.setGridSpacing(70) end },
-                { title = "75",     checked = mod.gridSpacing() == 75, fn = function() mod.setGridSpacing(70) end },
-                { title = "80",     checked = mod.gridSpacing() == 80, fn = function() mod.setGridSpacing(80) end },
-                { title = "85",     checked = mod.gridSpacing() == 85, fn = function() mod.setGridSpacing(85) end },
-                { title = "90",     checked = mod.gridSpacing() == 90, fn = function() mod.setGridSpacing(90) end },
-                { title = "95",     checked = mod.gridSpacing() == 95, fn = function() mod.setGridSpacing(95) end },
-                { title = "100",    checked = mod.gridSpacing() == 100, fn = function() mod.setGridSpacing(100) end },
-            }},
-        }},
-        { title = "-", disabled = true },
-        { title = i18n("reset") .. " " .. i18n("overlays"), fn = function() mod.resetOverlays() end },
-    }
-end
-
--- contextualMenu(event) -> none
--- Function
--- Builds the Final Cut Pro Overlay contextual menu.
---
--- Parameters:
---  * event - The `hs.eventtap` event
---
--- Returns:
---  * None
-local function contextualMenu(event)
-    local ui = fcp:viewer():UI()
-    local topBar = ui and axutils.childFromTop(ui, 1)
-    if topBar then
-        local barFrame = topBar:attributeValue("AXFrame")
-        local location = event:location() and geometry.point(event:location())
-        if barFrame and location and location:inside(geometry.rect(barFrame)) then
-            if mod._menu then
-                mod._menu:delete()
-                mod._menu = nil
-            end
-            mod._menu = menubar.new()
-            mod._menu:setMenu(generateMenu())
-            mod._menu:removeFromMenuBar()
-            mod._menu:popupMenu(location, true)
-        end
-    end
-end
-
 -- updater -> cp.deferred
 -- Variable
 -- A deferred timer that triggers the update function.
@@ -1540,15 +1610,16 @@ local plugin = {
 
 function plugin.init(deps)
     --------------------------------------------------------------------------------
-    -- Setup Event Tap:
-    --------------------------------------------------------------------------------
-    mod._eventtap = eventtap.new({events.rightMouseUp}, contextualMenu)
-
-    --------------------------------------------------------------------------------
     -- Setup the system menu:
     --------------------------------------------------------------------------------
     deps.menu.viewer
         :addMenu(10001, function() return i18n("overlay") end)
+        :addItems(999, function()
+            return {
+                { title = i18n("enableViewerContextualMenu"), fn = function() mod.enableViewerRightClick:toggle(); mod.update() end, checked = mod.enableViewerRightClick() },
+                { title = "-", disabled = true },
+            }
+        end)
         :addItems(1000, generateMenu)
 
     --------------------------------------------------------------------------------
@@ -1570,15 +1641,9 @@ function plugin.init(deps)
     --------------------------------------------------------------------------------
     fcp:viewer().frame:watch(function(value)
         if value then
-            mod.update()
+            deferredUpdate()
         end
     end)
-
-    --------------------------------------------------------------------------------
-    -- Force initial update:
-    --------------------------------------------------------------------------------
-    mod.capslock:update()
-    mod.update()
 
     --------------------------------------------------------------------------------
     -- Setup Commands:

--- a/src/plugins/finalcutpro/viewer/overlays.lua
+++ b/src/plugins/finalcutpro/viewer/overlays.lua
@@ -1083,9 +1083,9 @@ function mod.update()
             -- Destroy any Mouse Move Trackers:
             --------------------------------------------------------------------------------
             if mod._mouseMoveTracker then
-                for _, v in pairs(mod._mouseMoveTracker) do
-                    v:stop()
-                    v = nil
+                for i, _ in pairs(mod._mouseMoveTracker) do
+                    mod._mouseMoveTracker[i]:stop()
+                    mod._mouseMoveTracker[i] = nil
                 end
             end
         end


### PR DESCRIPTION
- The contextual menu that appears when you right-click on the top of
the Final Cut Pro Viewer is now disabled by default. You now have to
click “Enable Viewer Contextual Menu” from the CommandPost menubar to
enable it. This is an attempt to rule out any permission issues related
to the event tap that’s used to detect the right-click.
- Improved how we’re handling creating and destroying event taps in the
Viewer Overlays plugin.
- Closes #2202