### PR TITLE
Review how to we use hs.eventtap.keyStroke()

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -20,7 +20,6 @@ local applicationwatcher        = require "hs.application.watcher"
 local ax                        = require "hs._asm.axuielement"
 local fs                        = require "hs.fs"
 local inspect                   = require "hs.inspect"
-local keycodes                  = require "hs.keycodes"
 local task                      = require "hs.task"
 local timer                     = require "hs.timer"
 

--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -20,6 +20,7 @@ local applicationwatcher        = require "hs.application.watcher"
 local ax                        = require "hs._asm.axuielement"
 local fs                        = require "hs.fs"
 local inspect                   = require "hs.inspect"
+local keycodes                  = require "hs.keycodes"
 local task                      = require "hs.task"
 local timer                     = require "hs.timer"
 
@@ -47,6 +48,7 @@ local format                    = string.format
 local Given                     = go.Given
 local If                        = go.If
 local insert                    = table.insert
+local keyStroke                 = tools.keyStroke
 local printf                    = hs.printf
 local processInfo               = hs.processInfo
 local tableFilter               = tools.tableFilter
@@ -204,6 +206,21 @@ end
 ---  * The Bundle ID.
 function app:bundleID()
     return self._bundleID
+end
+
+--- cp.app:keyStroke(modifiers, character) -> none
+--- Method
+--- Generates and emits a single keystroke event pair for the supplied keyboard
+--- modifiers and character to the application.
+---
+--- Parameters:
+---  * modifiers - A table containing the keyboard modifiers to apply ("fn", "ctrl", "alt", "cmd" or "shift")
+---  * character - A string containing a character to be emitted
+---
+--- Returns:
+---  * None
+function app:keyStroke(modifiers, character)
+    keyStroke(modifiers, character, self._hsApplication)
 end
 
 --- cp.app.preferences <cp.app.prefs>

--- a/src/extensions/cp/apple/finalcutpro/export/GoToPrompt.lua
+++ b/src/extensions/cp/apple/finalcutpro/export/GoToPrompt.lua
@@ -4,15 +4,16 @@
 
 local require               = require
 
-local eventtap              = require "hs.eventtap"
-
 local axutils               = require "cp.ui.axutils"
 local just                  = require "cp.just"
 local prop                  = require "cp.prop"
+local tools                 = require "cp.tools"
 
 local Button				= require "cp.ui.Button"
 
 local childFromLeft			= axutils.childFromLeft
+local keyStroke             = tools.keyStroke
+local doUntil               = just.doUntil
 
 local GoToPrompt = {}
 
@@ -108,8 +109,11 @@ end):bind(GoToPrompt)
 ---  * The `cp.apple.finalcutpro.export.GoToPrompt` object for method chaining.
 function GoToPrompt:show()
     if self:parent():isShowing() then
-        eventtap.keyStroke({"cmd", "shift"}, "g")
-        just.doUntil(function() return self:isShowing() end)
+        --------------------------------------------------------------------------------
+        -- NOTE: I tried sending the keyStroke directly to FCPX, but it didn't work.
+        --------------------------------------------------------------------------------
+        keyStroke({"cmd", "shift"}, "g")
+        doUntil(function() return self:isShowing() end)
     end
     return self
 end

--- a/src/extensions/cp/apple/finalcutpro/viewer/ControlBar.lua
+++ b/src/extensions/cp/apple/finalcutpro/viewer/ControlBar.lua
@@ -6,7 +6,6 @@
 local log               = require "hs.logger" .new "ViewerCB"
 
 local canvas            = require "hs.canvas"
-local eventtap          = require "hs.eventtap"
 local geometry          = require "hs.geometry"
 local pasteboard        = require "hs.pasteboard"
 
@@ -168,7 +167,7 @@ function ControlBar.lazy.prop:timecode()
                         -- Trigger CMD+V. For some weird reason trigging the menubar or Paste shortcut
                         -- via the Final Cut Pro API doesn't work - probably needs to be Rx-ified.
                         --------------------------------------------------------------------------------
-                        eventtap.keyStroke({"cmd"}, "v")
+                        self:app():keyStroke({"cmd"}, "v")
 
                         --------------------------------------------------------------------------------
                         -- Wait until we see the timecode in the viewer:
@@ -186,7 +185,7 @@ function ControlBar.lazy.prop:timecode()
                             log.ef("Failed to paste to timecode entry (cp.apple.finalcutpro.viewer.Viewer.timecode). Expected: '%s', Got: '%s'.", timecodeValue, tcField:value())
                             return
                         else
-                            eventtap.keyStroke({}, 'return')
+                            self:app():keyStroke({}, 'return')
                         end
                     end
 

--- a/src/extensions/cp/commands/shortcut.lua
+++ b/src/extensions/cp/commands/shortcut.lua
@@ -5,13 +5,15 @@
 local require = require
 local log                   = require "hs.logger".new"shortcut"
 
-local eventtap              = require "hs.eventtap"
 local hotkey                = require "hs.hotkey"
 local keycodes              = require "hs.keycodes"
 
 local englishKeyCodes       = require "cp.commands.englishKeyCodes"
-
 local prop                  = require "cp.prop"
+local tools                 = require "cp.tools"
+
+local keyStroke             = tools.keyStroke
+local map                   = keycodes.map
 
 -- The shortcut class
 local shortcut = {}
@@ -38,7 +40,7 @@ hotkey.setLogLevel("error")
 function shortcut.textToKeyCode(input)
     local result = englishKeyCodes[input]
     if not result then
-        result = keycodes.map[input]
+        result = map[input]
         if not result then
             result = ""
         end
@@ -249,8 +251,9 @@ end
 --- Returns:
 ---  * `self`
 function shortcut.mt:trigger()
-    local keyCode = shortcut.textToKeyCode(self:getKeyCode())
-    eventtap.keyStroke(self._modifiers, keyCode, 0)
+    local character = shortcut.textToKeyCode(self:getKeyCode())
+    local modifiers = self._modifiers or {}
+    keyStroke(modifiers, character)
     return self
 end
 

--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -13,6 +13,7 @@ local fs                = require "hs.fs"
 local geometry          = require "hs.geometry"
 local host              = require "hs.host"
 local inspect           = require "hs.inspect"
+local keycodes          = require "hs.keycodes"
 local mouse             = require "hs.mouse"
 local osascript         = require "hs.osascript"
 local screen            = require "hs.screen"
@@ -24,8 +25,11 @@ local config            = require "cp.config"
 
 local v                 = require "semver"
 
+local event             = eventtap.event
 local insert            = table.insert
 local locale            = host.locale
+local map               = keycodes.map
+local newKeyEvent       = event.newKeyEvent
 local usleep            = timer.usleep
 
 local tools = {}
@@ -33,27 +37,27 @@ local tools = {}
 -- LEFT_MOUSE_DOWN -> number
 -- Constant
 -- Left Mouse Down ID.
-local LEFT_MOUSE_DOWN = eventtap.event.types["leftMouseDown"]
+local LEFT_MOUSE_DOWN = event.types["leftMouseDown"]
 
 -- LEFT_MOUSE_UP -> number
 -- Constant
 -- Left Mouse Up ID.
-local LEFT_MOUSE_UP = eventtap.event.types["leftMouseUp"]
+local LEFT_MOUSE_UP = event.types["leftMouseUp"]
 
 -- RIGHT_MOUSE_DOWN -> number
 -- Constant
 -- Right Mouse Down ID.
-local RIGHT_MOUSE_DOWN = eventtap.event.types["rightMouseDown"]
+local RIGHT_MOUSE_DOWN = event.types["rightMouseDown"]
 
 -- RIGHT_MOUSE_UP -> number
 -- Constant
 -- Right Mouse Up ID.
-local RIGHT_MOUSE_UP = eventtap.event.types["rightMouseUp"]
+local RIGHT_MOUSE_UP = event.types["rightMouseUp"]
 
 -- CLICK_STATE -> number
 -- Constant
 -- Click State ID.
-local CLICK_STATE = eventtap.event.properties.mouseEventClickState
+local CLICK_STATE = event.properties.mouseEventClickState
 
 -- DEFAULT_DELAY -> number
 -- Constant
@@ -86,6 +90,33 @@ function string:split(delimiter) -- luacheck: ignore
       end
    end
    return list
+end
+
+--- cp.tools.keyStroke(modifiers, character, app) -> none
+--- Method
+--- Generates and emits a single keystroke event pair for the supplied keyboard
+--- modifiers and character to the application.
+---
+--- Parameters:
+---  * modifiers - A table containing the keyboard modifiers to apply ("fn", "ctrl", "alt", "cmd" or "shift")
+---  * character - A string containing a character to be emitted
+---  * app - The optional `hs.application` you want to target
+---
+--- Returns:
+---  * None
+function tools.keyStroke(modifiers, character, app)
+    modifiers = modifiers or {}
+
+    for _, v in pairs(modifiers) do
+        newKeyEvent(map[v], true):post(app)
+    end
+
+    newKeyEvent(character, true):post(app)
+    newKeyEvent(character, false):post(app)
+
+    for _, v in pairs(modifiers) do
+        newKeyEvent(map[v], false):post(app)
+    end
 end
 
 --- cp.tools.shiftPressed() -> boolean
@@ -1065,9 +1096,9 @@ end
 function tools.leftClick(point, delay, clickNumber)
     delay = delay or DEFAULT_DELAY
     clickNumber = clickNumber or 1
-    eventtap.event.newMouseEvent(LEFT_MOUSE_DOWN, point):setProperty(CLICK_STATE, clickNumber):post()
+    event.newMouseEvent(LEFT_MOUSE_DOWN, point):setProperty(CLICK_STATE, clickNumber):post()
     if delay > 0 then usleep(delay) end
-    eventtap.event.newMouseEvent(LEFT_MOUSE_UP, point):setProperty(CLICK_STATE, clickNumber):post()
+    event.newMouseEvent(LEFT_MOUSE_UP, point):setProperty(CLICK_STATE, clickNumber):post()
 end
 
 --- cp.tools.rightClick(point[, delay, clickNumber]) -> none
@@ -1084,9 +1115,9 @@ end
 function tools.rightClick(point, delay, clickNumber)
     delay = delay or DEFAULT_DELAY
     clickNumber = clickNumber or 1
-    eventtap.event.newMouseEvent(RIGHT_MOUSE_DOWN, point):setProperty(CLICK_STATE, clickNumber):post()
+    event.newMouseEvent(RIGHT_MOUSE_DOWN, point):setProperty(CLICK_STATE, clickNumber):post()
     if delay > 0 then usleep(delay) end
-    eventtap.event.newMouseEvent(RIGHT_MOUSE_UP, point):setProperty(CLICK_STATE, clickNumber):post()
+    event.newMouseEvent(RIGHT_MOUSE_UP, point):setProperty(CLICK_STATE, clickNumber):post()
 end
 
 --- cp.tools.doubleLeftClick(point[, delay]) -> none

--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -107,15 +107,15 @@ end
 function tools.keyStroke(modifiers, character, app)
     modifiers = modifiers or {}
 
-    for _, v in pairs(modifiers) do
-        newKeyEvent(map[v], true):post(app)
+    for _, m in pairs(modifiers) do
+        newKeyEvent(map[m], true):post(app)
     end
 
     newKeyEvent(character, true):post(app)
     newKeyEvent(character, false):post(app)
 
-    for _, v in pairs(modifiers) do
-        newKeyEvent(map[v], false):post(app)
+    for _, m in pairs(modifiers) do
+        newKeyEvent(map[m], false):post(app)
     end
 end
 

--- a/src/plugins/finalcutpro/browser/addnote.lua
+++ b/src/plugins/finalcutpro/browser/addnote.lua
@@ -8,7 +8,6 @@ local require                   = require
 
 local chooser                   = require "hs.chooser"
 local drawing                   = require "hs.drawing"
-local eventtap                  = require "hs.eventtap"
 local menubar                   = require "hs.menubar"
 local mouse                     = require "hs.mouse"
 local screen                    = require "hs.screen"
@@ -273,10 +272,8 @@ function mod.addNoteToSelectedClips()
                     local clipNotesField = selected[notesFieldID][1]
                     clipNotesField:setAttributeValue("AXFocused", true)
                     clipNotesField:setAttributeValue("AXValue", result["text"])
+                    clipNotesField:performAction("AXConfirm")
                     clipNotesField:setAttributeValue("AXFocused", false)
-                    if not filmstripView then
-                        eventtap.keyStroke({}, "return") -- List view requires an "return" key press
-                    end
 
                     --------------------------------------------------------------------------------
                     -- First clip complete:
@@ -291,10 +288,8 @@ function mod.addNoteToSelectedClips()
                     local clipNotesField = clip[notesFieldID][1]
                     clipNotesField:setAttributeValue("AXFocused", true)
                     clipNotesField:setAttributeValue("AXValue", result["text"])
+                    clipNotesField:performAction("AXConfirm")
                     clipNotesField:setAttributeValue("AXFocused", false)
-                    if not filmstripView then
-                        eventtap.keyStroke({}, "return") -- List view requires an "return" key press
-                    end
                 end
             end
 

--- a/src/plugins/finalcutpro/browser/clearnotes.lua
+++ b/src/plugins/finalcutpro/browser/clearnotes.lua
@@ -6,8 +6,6 @@ local require = require
 
 --local log                   = require "hs.logger".new "clearNotes"
 
-local eventtap              = require "hs.eventtap"
-
 local axutils               = require "cp.ui.axutils"
 local fcp                   = require "cp.apple.finalcutpro"
 local tools                 = require "cp.tools"
@@ -95,7 +93,8 @@ function plugin.init(deps)
 
                 selectedNotesField:setAttributeValue("AXFocused", true)
                 selectedNotesField:setAttributeValue("AXValue", "")
-                eventtap.keyStroke({}, "return") -- List view requires an "return" key press
+                selectedNotesField:performAction("AXConfirm")
+                selectedNotesField:setAttributeValue("AXFocused", false)
             end
 
             --------------------------------------------------------------------------------

--- a/src/plugins/finalcutpro/fullscreen/shortcuts.lua
+++ b/src/plugins/finalcutpro/fullscreen/shortcuts.lua
@@ -116,12 +116,12 @@ function mod.ninjaKeyStroke(whichModifier, whichKey)
     --------------------------------------------------------------------------------
     -- Press 'Escape':
     --------------------------------------------------------------------------------
-    eventtap.keyStroke({""}, "escape")
+    fcp:keyStroke({}, "escape")
 
     --------------------------------------------------------------------------------
     -- Perform Keystroke:
     --------------------------------------------------------------------------------
-    eventtap.keyStroke(whichModifier, whichKey)
+    fcp:keyStroke(whichModifier, whichKey)
 
     --------------------------------------------------------------------------------
     -- Go back to Full Screen Playback:

--- a/src/plugins/finalcutpro/fullscreen/stopped.lua
+++ b/src/plugins/finalcutpro/fullscreen/stopped.lua
@@ -30,7 +30,7 @@ function plugin.init(deps)
                 if doUntil(function()
                     return fcp:fullScreenWindow():isShowing()
                 end, 5, 0.1) then
-                    eventtap.keyStroke({}, "space")
+                    fcp:keyStroke({}, "space")
                     return
                 end
             end

--- a/src/plugins/finalcutpro/midi/controls/timeline.lua
+++ b/src/plugins/finalcutpro/midi/controls/timeline.lua
@@ -6,8 +6,6 @@ local require = require
 
 --local log               = require "hs.logger".new "timeline"
 
-local eventtap          = require "hs.eventtap"
-
 local axutils		    = require "cp.ui.axutils"
 local deferred          = require "cp.deferred"
 local fcp               = require "cp.apple.finalcutpro"
@@ -15,7 +13,6 @@ local i18n              = require "cp.i18n"
 local tools             = require "cp.tools"
 
 local childWithRole     = axutils.childWithRole
-local keyStroke         = eventtap.keyStroke
 local rescale           = tools.rescale
 
 -- MAX_14BIT -> number
@@ -39,7 +36,7 @@ local MAX_7BIT  = 0x7F
 -- Returns:
 --  * None
 local function doNextFrame()
-    keyStroke({"shift"}, "right", 0)
+    fcp:keyStroke({"shift"}, "right")
 end
 
 -- doPreviousFrame() -> none
@@ -52,7 +49,7 @@ end
 -- Returns:
 --  * None
 local function doPreviousFrame()
-    keyStroke({"shift"}, "left", 0)
+    fcp:keyStroke({"shift"}, "left")
 end
 
 -- createTimelineScrub() -> function

--- a/src/plugins/finalcutpro/text2speech/init.lua
+++ b/src/plugins/finalcutpro/text2speech/init.lua
@@ -566,10 +566,8 @@ function mod._completeProcess()
         local selectedNotesField = selectedClip[notesFieldID][1]
         selectedNotesField:setAttributeValue("AXFocused", true)
         selectedNotesField:setAttributeValue("AXValue", mod._lastTextToSpeak)
+        selectedNotesField:performAction("AXConfirm")
         selectedNotesField:setAttributeValue("AXFocused", false)
-        if not filmstripView then
-            eventtap.keyStroke({}, "return") -- List view requires an "return" key press
-        end
 
         --------------------------------------------------------------------------------
         -- Restore Filmstrip View:

--- a/src/plugins/finder/dateandtime/dateandtime.lua
+++ b/src/plugins/finder/dateandtime/dateandtime.lua
@@ -2,10 +2,9 @@
 ---
 --- Types the date and time in the "YYYYMMDD HHMM" format.
 
-local require = require
+local require       = require
 
-local eventtap = require("hs.eventtap")
-
+local eventtap      = require "hs.eventtap"
 
 local plugin = {
     id              = "finder.dateandtime",

--- a/src/plugins/finder/pasteboard/history.lua
+++ b/src/plugins/finder/pasteboard/history.lua
@@ -6,7 +6,6 @@ local require           = require
 
 --local log               = require "hs.logger".new "pbHistory"
 
-local eventtap          = require "hs.eventtap"
 local pasteboard        = require "hs.pasteboard"
 local timer             = require "hs.timer"
 
@@ -17,7 +16,7 @@ local tools             = require "cp.tools"
 
 local doAfter           = timer.doAfter
 local doEvery           = timer.doEvery
-local keyStroke         = eventtap.keyStroke
+local keyStroke         = tools.keyStroke
 local stringMaxLength   = tools.stringMaxLength
 local trim              = tools.trim
 

--- a/src/plugins/finder/pasteboard/pasteboard.lua
+++ b/src/plugins/finder/pasteboard/pasteboard.lua
@@ -2,15 +2,18 @@
 ---
 --- Handy text tools.
 
-local require = require
+local require           = require
 
-local log                   = require("hs.logger").new("textTools")
+local log               = require "hs.logger".new "textTools"
 
-local eventtap              = require("hs.eventtap")
-local pasteboard            = require("hs.pasteboard")
+local eventtap          = require "hs.eventtap"
+local pasteboard        = require "hs.pasteboard"
 
-local tools                 = require("cp.tools")
+local tools             = require "cp.tools"
 
+local keyStroke         = tools.keyStroke
+local keyStrokes        = eventtap.keyStrokes
+local playErrorSound    = tools.playErrorSound
 
 local mod = {}
 
@@ -26,7 +29,7 @@ local mod = {}
 ---  * None
 function mod.processText(value, copyAndPaste)
     if copyAndPaste then
-        eventtap.keyStroke({"command"}, "c")
+        keyStroke({"command"}, "c")
     end
     local contents = pasteboard.getContents()
     if contents and type(contents) == "string" then
@@ -40,13 +43,12 @@ function mod.processText(value, copyAndPaste)
         end
         pasteboard.setContents(result)
         if copyAndPaste then
-            eventtap.keyStroke({"command"}, "v")
+            keyStroke({"command"}, "v")
         end
     else
         log.ef("Pasteboard Contents is invalid: %s", contents)
     end
 end
-
 
 local plugin = {
     id              = "finder.pasteboard",
@@ -88,9 +90,9 @@ function plugin.init(deps)
         :whenActivated(function()
             local pasteboardContents = pasteboard.getContents()
             if pasteboardContents then
-                eventtap.keyStrokes(pasteboardContents)
+                keyStrokes(pasteboardContents)
             else
-                tools.playErrorSound()
+                playErrorSound()
             end
         end)
 


### PR DESCRIPTION
- Added `cp.tools.keyStroke()`.
- Added `cp.apple.finalcutpro:keyStroke()` which internally uses
`cp.tools.keyStroke()`, but sends the keystroke specifically to Final
Cut Pro X.
- Migrated all plugins to use these new functions.
- Updated the `browser.addnote` and `browser.clearnotes` to use the
`AXConfirm` action rather than triggering the `return` key.
- Closes #2229