### PR TITLE
Improve Loupedeck Import/Export options to allow for individual applications and banks

### DIFF
--- a/src/plugins/core/loupedeckct/prefs/html/panel.html
+++ b/src/plugins/core/loupedeckct/prefs/html/panel.html
@@ -612,6 +612,8 @@
 				id: "loupedeckCTPanelCallback",
 				params: {
 					type: "importSettings",
+					application: document.getElementById("application").value,
+					bank: document.getElementById("bank").value,
 				},
 			}
 			postMessage(result);
@@ -626,6 +628,8 @@
 				id: "loupedeckCTPanelCallback",
 				params: {
 					type: "exportSettings",
+					application: document.getElementById("application").value,
+					bank: document.getElementById("bank").value,
 				},
 			}
 			postMessage(result);
@@ -1193,8 +1197,8 @@
 					<table class="loupedeck" style="height: 526px;" id="noLoupedeck">
 						<tr>
 							<th>
-								<p style="font-size: 12px; font-weight: normal;">{{ i18n("loupedeckCTStoreSettingsOnFlashDriveLineOne") }}</p>
-								<p style="font-size: 12px; font-weight: normal;">{{ i18n("loupedeckCTStoreSettingsOnFlashDriveLineTwo") }}</p>
+								<p style="font-size: 12px; font-weight: normal;">{* i18n("loupedeckCTStoreSettingsOnFlashDriveLineOne") *}</p>
+								<p style="font-size: 12px; font-weight: normal;">{* i18n("loupedeckCTStoreSettingsOnFlashDriveLineTwo") *}</p>
 							</th>
 						</tr>
 					</table>

--- a/src/plugins/core/streamdeck/prefs/init.lua
+++ b/src/plugins/core/streamdeck/prefs/init.lua
@@ -76,7 +76,7 @@ mod.lastImportPath = config.prop("streamDeck.preferences.lastImportPath", os.get
 --- plugins.core.streamdeck.prefs.lastApplication <cp.prop: string>
 --- Field
 --- Last Application used in the Preferences Panel.
-mod.lastApplication = config.prop("streamDeck.preferences.lastApplication", "org.latenitefilms.CommandPost")
+mod.lastApplication = config.prop("streamDeck.preferences.lastApplication", "All Applications")
 
 --- plugins.core.streamdeck.prefs.lastApplication <cp.prop: string>
 --- Field


### PR DESCRIPTION
- Fixed formatting bug in Loupedeck CT store settings on flash warning.
- Loupedeck CT & Stream Deck Preferences windows now default to “All
Applications” on fresh install.
- Closes #2295