### PR TITLE
Bug Fixes

### DIFF
--- a/src/plugins/core/loupedeckct/manager/init.lua
+++ b/src/plugins/core/loupedeckct/manager/init.lua
@@ -631,6 +631,7 @@ local function callback(data)
     --------------------------------------------------------------------------------
     -- TREAT LEFT & RIGHT FUNCTION KEYS AS MODIFIERS:
     --------------------------------------------------------------------------------
+    local functionButtonPressed = false
     if data.id == ct.event.BUTTON_PRESS then
         if data.direction == "up" then
             if data.buttonID == ct.buttonID.LEFT_FN then
@@ -642,9 +643,11 @@ local function callback(data)
             end
         elseif data.direction == "down" then
             if data.buttonID == ct.buttonID.LEFT_FN then
+                functionButtonPressed = true
                 leftFnPressed = true
                 mod.refresh()
             elseif data.buttonID == ct.buttonID.RIGHT_FN then
+                functionButtonPressed = true
                 rightFnPressed = true
                 mod.refresh()
             end
@@ -654,10 +657,12 @@ local function callback(data)
     --------------------------------------------------------------------------------
     -- HANDLE FUNCTION KEYS AS MODIFIERS:
     --------------------------------------------------------------------------------
-    if leftFnPressed then
-        bankID = bankID .. "_LeftFn"
-    elseif rightFnPressed then
-        bankID = bankID .. "_RightFn"
+    if not functionButtonPressed then
+        if leftFnPressed then
+            bankID = bankID .. "_LeftFn"
+        elseif rightFnPressed then
+            bankID = bankID .. "_RightFn"
+        end
     end
 
     local item = items[bundleID]

--- a/src/plugins/core/loupedeckct/prefs/init.lua
+++ b/src/plugins/core/loupedeckct/prefs/init.lua
@@ -719,7 +719,17 @@ local function loupedeckCTPanelCallback(id, params)
                 -- Change the bank:
                 --------------------------------------------------------------------------------
                 local activeBanks = mod._ctmanager.activeBanks()
-                activeBanks[app] = bank
+
+                -- Remove the '_LeftFn' and '_RightFn'
+                local newBank = bank
+                if string.sub(bank, -7) == "_LeftFn" then
+                    newBank = string.sub(bank, 1, -8)
+                end
+                if string.sub(bank, -8) == "_RightFn" then
+                    newBank = string.sub(bank, 1, -9)
+                end
+
+                activeBanks[app] = newBank
                 mod._ctmanager.activeBanks(activeBanks)
 
                 --------------------------------------------------------------------------------

--- a/src/plugins/core/loupedeckplus/prefs/html/panel.html
+++ b/src/plugins/core/loupedeckplus/prefs/html/panel.html
@@ -227,21 +227,11 @@
 					{%
 					for i=1, numberOfBanks do
 						local selected = ""
-						if lastBank == tostring(i) .. "_LeftFn" then
+						if lastBank == tostring(i) .. "fn" then
 							selected = [[selected=""]]
 						end
 					%}
-					<option {{selected}} value="{{i}}_LeftFn">{{i}} (Left Fn)</option>
-					{% end %}
-					<option disabled>──────────</option>
-					{%
-					for i=1, numberOfBanks do
-						local selected = ""
-						if lastBank == tostring(i) .. "_RightFn" then
-							selected = [[selected=""]]
-						end
-					%}
-					<option {{selected}} value="{{i}}_RightFn">{{i}} (Right Fn)</option>
+					<option {{selected}} value="{{i}}fn">{{i}} (Fn)</option>
 					{% end %}
 				</select>
 			</span>

--- a/src/plugins/core/loupedeckplus/prefs/init.lua
+++ b/src/plugins/core/loupedeckplus/prefs/init.lua
@@ -422,6 +422,11 @@ local function loupedeckPanelCallback(id, params)
                 -- Change the bank:
                 --------------------------------------------------------------------------------
                 local activeBanks = mod._midi.activeLoupedeckBanks()
+
+                -- Remove the 'fn':
+                if string.sub(bank, -2) == "fn" then
+                    bank = string.sub(bank, 1, -3)
+                end
                 activeBanks[app] = bank
                 mod._midi.activeLoupedeckBanks(activeBanks)
 

--- a/src/plugins/core/midi/manager/init.lua
+++ b/src/plugins/core/midi/manager/init.lua
@@ -462,9 +462,10 @@ local function callback(_, deviceName, commandType, _, metadata)
             elseif commandType == "noteOff" then
                 loupedeckFnPressed = false
             end
-        end
-        if loupedeckFnPressed then
-            bankID = bankID .. "fn"
+        else
+            if loupedeckFnPressed == true then
+                bankID = bankID .. "fn"
+            end
         end
     else
         --------------------------------------------------------------------------------


### PR DESCRIPTION
- Fixed bug with Loupedeck+ Preferences panel where is incorrectly
listed both ‘Left Fn’ and ‘Right Fn’ when there’s only one function
button on the hardware.
- Fixed bug in Loupedeck CT and Loupedeck+ preferences panels where
changing the bank would incorrectly set the wrong bank if a `Fn` bank
was selected.
- Fixed a bug in Loupedeck CT and Loupedeck+ managers where a Fn key
press would not be correctly triggered.
- Closes #2326