### PR TITLE
Bug Fix

### DIFF
--- a/src/extensions/cp/web/html.lua
+++ b/src/extensions/cp/web/html.lua
@@ -8,44 +8,43 @@
 ---
 --- ```lua
 --- local html = require "cp.web.html"
---- print html.p "Hello world!"								-- "<p>Hello world!</p>"
---- print html.p { class = "custom" } "Hello world!"		-- "<p class='custom'>Hello world!</p>"
+--- print html.p "Hello world!"                             -- "<p>Hello world!</p>"
+--- print html.p { class = "custom" } "Hello world!"        -- "<p class='custom'>Hello world!</p>"
 --- print html.p { class = "custom" } (
---- 	html.b "Bold" .. " and " .. html.i "italic" .. "."
+---     html.b "Bold" .. " and " .. html.i "italic" .. "."
 --- )
 --- -- "<p class='custom'><b>Bold</b> and <i>italic</i>.</p>"
---- print html("1 < 2")										-- "1 &lt; 2" (escaped)
---- print html("1 < 2", true)								-- "1 < 2" (unescaped)
---- print html.p ("<b>bold</b>", true)						-- "<p><b>bold</b></p>"
+--- print html("1 < 2")                                     -- "1 &lt; 2" (escaped)
+--- print html("1 < 2", true)                               -- "1 < 2" (unescaped)
+--- print html.p ("<b>bold</b>", true)                      -- "<p><b>bold</b></p>"
 --- ```
 ---
 --- Be aware that concatonating with ".." can behave unexpectedly in some cases. For example:
 ---
 --- ```lua
 --- local name = "world!"
---- print html.p "Hello " .. name					-- "<p>Hello </p>world!"
+--- print html.p "Hello " .. name                   -- "<p>Hello </p>world!"
 --- ```
 ---
 --- The `"Hello"` gets inserted into the `p` tag, but the `name` gets concatonated after the closing tag.
 --- To get the `name` inside the `p` tag, we need to put brackets around the content:
 ---
 --- ```lua
---- print html.p ("Hello " .. name)					-- "<p>Hello world!</p>"
+--- print html.p ("Hello " .. name)                 -- "<p>Hello world!</p>"
 --- ```
 ---
 --- Any tag name can be generated, along with any attribute. The results are correctly escaped.
 --- There are two 'special' tag names:
----  * `CDATA`	- will generate a `&lt;![CDATA[ ... ]]&gt;` section with the content contained.
----  * `__`		- (double underscore) will generate a `&lt!-- ... --&gt` comment block.
+---  * `CDATA`  - will generate a `&lt;![CDATA[ ... ]]&gt;` section with the content contained.
+---  * `__`     - (double underscore) will generate a `&lt!-- ... --&gt` comment block.
 
-local require = require
+local require       = require
 
-local block				    = require "cp.web.block"
+local block         = require "cp.web.block"
 
-local template 			  = require "resty.template"
+local template      = require "resty.template"
 
-local htmlEscape			= template.escape
-
+local htmlEscape    = template.escape
 
 local html = {}
 
@@ -54,7 +53,7 @@ local html = {}
 --- Checks if the `value` is an `cp.web.html` block.
 ---
 --- Parameters:
---- * value		- the value to check
+--- * value     - the value to check
 ---
 --- Returns:
 --- * `true` if it is an HTML block, or `false` otherwise.

--- a/src/plugins/core/loupedeckplus/prefs/init.lua
+++ b/src/plugins/core/loupedeckplus/prefs/init.lua
@@ -339,7 +339,7 @@ local function loupedeckPanelCallback(id, params)
             --------------------------------------------------------------------------------
             -- Clear an action:
             --------------------------------------------------------------------------------
-            local app = params["app"]
+            local app = params["application"]
             local bank = params["bank"]
             local button = params["button"]
 


### PR DESCRIPTION
- Fixed typo in the code that triggers the “Clear” button in Loupedeck+
preferences.
- Removed tabs in `cp.web.html`.
- Closes #2332