### PR TITLE
Various MIDI bug fixes and improvements

### DIFF
--- a/src/extensions/languages/English.json
+++ b/src/extensions/languages/English.json
@@ -1055,6 +1055,7 @@
         "history": "History",
         "historyIsEmpty": "History is empty",
         "historySize": "History Size",
+        "holdDownShiftToChangeValueAtFinerSmallerIncrements": "Hold down SHIFT to change value at finer/smaller increments.",
         "holdDownShortcutKeyToRepeatAction": "Hold down shortcut key to repeat action.",
         "horizontal": "Horizontal",
         "horizontal4": "Horz",

--- a/src/plugins/core/midi/prefs/init.lua
+++ b/src/plugins/core/midi/prefs/init.lua
@@ -136,7 +136,7 @@ local function generateContent()
     local virtualMidiDevices = mod._midi.virtualDevices()
     local devices = {}
     for _, device in pairs(midiDevices) do
-        if device ~= "Loupedeck+" then
+        if device ~= "Loupedeck" and device ~= "Loupedeck+" then
             table.insert(devices, device)
         end
     end
@@ -276,7 +276,7 @@ local function updateUI(highlightRow)
 
         local foundDevice = false
         for _, deviceName in ipairs(midiDevices) do
-            if deviceName ~= "Loupedeck+" and deviceName ~= "virtual_Loupedeck+" then
+            if deviceName ~= "Loupedeck" and deviceName ~= "virtual_Loupedeck" and deviceName ~= "Loupedeck+" and deviceName ~= "virtual_Loupedeck+" then
                 local selected = ""
                 if device == deviceName then
                     selected = [[selected=""]]
@@ -305,7 +305,7 @@ local function updateUI(highlightRow)
         ]]
         local foundVirtualDevice = false
         for _, deviceName in ipairs(virtualMidiDevices) do
-            if deviceName ~= "Loupedeck+" and deviceName ~= "virtual_Loupedeck+" then
+            if deviceName ~= "Loupedeck" and deviceName ~= "virtual_Loupedeck" and deviceName ~= "Loupedeck+" and deviceName ~= "virtual_Loupedeck+" then
                 local selected = ""
                 if device == "virtual_" .. deviceName then
                     selected = [[selected=""]]
@@ -503,7 +503,7 @@ local function startLearning(params)
         --------------------------------------------------------------------------------
         -- Prevent Loupedeck+'s from appearing in the MIDI Preferences:
         --------------------------------------------------------------------------------
-        if deviceName ~= "Loupedeck+" and deviceName ~= "virtual_Loupedeck+" then
+        if deviceName ~= "Loupedeck" and deviceName ~= "virtual_Loupedeck" and deviceName ~= "Loupedeck+" and deviceName ~= "virtual_Loupedeck+" then
             if string.sub(deviceName, 1, 8) == "virtual_" then
                 learningMidiDevices[deviceName] = midi.newVirtualSource(string.sub(deviceName, 9))
             else
@@ -630,7 +630,7 @@ local function startLearning(params)
 
                         if commandType == "noteOff" or commandType == "noteOn" then
                             setItem("number", learnButton, learnApplication, learnBank, metadata.note)
-                            setItem("value", learnButton, learnApplication, learnBank, "")
+                            setItem("value", learnButton, learnApplication, learnBank, metadata.velocity)
                         elseif commandType == "controlChange" then
                             setItem("number", learnButton, learnApplication, learnBank, metadata.controllerNumber)
                             setItem("value", learnButton, learnApplication, learnBank, controllerValue)

--- a/src/plugins/finalcutpro/midi/controls/audio.lua
+++ b/src/plugins/finalcutpro/midi/controls/audio.lua
@@ -70,7 +70,7 @@ function plugin.init(deps)
     local manager = deps.manager
     local params = {
         group = "fcpx",
-        text = i18n("volume") .. "(" .. i18n("absolute") .. ")",
+        text = i18n("volume") .. " (" .. i18n("absolute") .. ")",
         subText = i18n("midiVolumeDescription"),
         fn = createAbsoluteMIDIVolumeSlider(),
     }

--- a/src/plugins/finalcutpro/midi/controls/zoom.lua
+++ b/src/plugins/finalcutpro/midi/controls/zoom.lua
@@ -23,7 +23,7 @@ local function createAbsoluteMIDIZoomSlider()
     end)
 
     local updateUI = deferred.new(0.01):action(function()
-        appearance.show()
+        appearance:show()
         appearance.zoomAmount(value)
         hide()
     end)


### PR DESCRIPTION
- You can now use a velocity value for the “Note Off” and “Note On”
commands. Velocity is now detected by the “Learn” button.
- The MIDI bank functions now ignore AudioSwift if it is the frontmost
app.
- Fixed typo in “Volume (Absolute)” action.
- Added relative MIDI colour board controls.
- Fixed bug in MIDI zoom action.
- Fixed bug which prevented MIDI commands from working if you manually
entered them in the MIDI Preferences panel.
- Closes #2421