### PR TITLE
Various bug fixes in Relative A MIDI Controls

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/inspector/color/ColorWheels.lua
+++ b/src/extensions/cp/apple/finalcutpro/inspector/color/ColorWheels.lua
@@ -80,6 +80,7 @@ function ColorWheels:initialize(parent)
     self.temperatureSlider.value:mirror(self.temperatureTextField.value)
     self.mixSlider.value:mirror(self.mixTextField.value)
     self.tintSlider.value:mirror(self.tintTextField.value)
+    self.hueSlider.value:mirror(self.hueTextField.value)
 end
 
 --- cp.apple.finalcutpro.inspector.color.ColorWheels.contentUI <cp.prop: hs._asm.axuielement; read-only>
@@ -140,14 +141,14 @@ end
 --- Field
 --- The tint for the corrector. A number from `-50` to `50`.
 function ColorWheels.lazy.prop:tint()
-    return self.tintTextField.value
+    return self.tintSlider.value
 end
 
 --- cp.apple.finalcutpro.inspector.color.ColorWheels.hue <cp.prop: number>
 --- Field
 --- The hue for the corrector. A number from `0` to `360`.
 function ColorWheels.lazy.prop:hue()
-    return self.hueTextField.value
+    return self.hueSlider.value
 end
 
 --------------------------------------------------------------------------------
@@ -270,6 +271,9 @@ function ColorWheels.lazy.value:mixSlider()
     )
 end
 
+--- cp.apple.finalcutpro.inspector.color.ColorWheels.mixTextField <cp.ui.TextField>
+--- Field
+--- A `TextField` that provides access to the 'Mix' slider.
 function ColorWheels.lazy.value:mixTextField()
     return TextField(self,
         function()
@@ -299,6 +303,9 @@ function ColorWheels.lazy.value:temperatureSlider()
     )
 end
 
+--- cp.apple.finalcutpro.inspector.color.ColorWheels.temperatureTextField <cp.ui.TextField>
+--- Field
+--- A `TextField` that provides access to the 'Temperature' slider.
 function ColorWheels.lazy.value:temperatureTextField()
     return TextField(self,
         function()
@@ -306,7 +313,7 @@ function ColorWheels.lazy.value:temperatureTextField()
             return ui and childMatching(ui, TextField.matches)
         end,
         toRegionalNumber, toRegionalNumberString
-    )
+    ):forceFocus()
 end
 
 --- cp.apple.finalcutpro.inspector.color.ColorWheels.tintRow <cp.ui.PropertyRow>
@@ -329,6 +336,9 @@ function ColorWheels.lazy.value:tintSlider()
     )
 end
 
+--- cp.apple.finalcutpro.inspector.color.ColorWheels.tintTextField <cp.ui.TextField>
+--- Field
+--- A `TextField` that provides access to the 'Tint' slider.
 function ColorWheels.lazy.value:tintTextField()
     return TextField(self,
         function()
@@ -347,6 +357,18 @@ function ColorWheels.lazy.value:hueRow()
     return PropertyRow(self, "PAECorrectorEffectHue")
 end
 
+--- cp.apple.finalcutpro.inspector.color.ColorWheels.hueSlider <cp.ui.Slider>
+--- Field
+--- Returns a `Slider` that provides access to the 'Hue' slider.
+function ColorWheels.lazy.value:hueSlider()
+    return Slider(self,
+        function()
+            local ui = self.hueRow:children()
+            return ui and childMatching(ui, Slider.matches)
+        end
+    )
+end
+
 --- cp.apple.finalcutpro.inspector.color.ColorWheels.hueTextField <cp.ui.TextField>
 --- Field
 --- A `TextField` that provides access to the 'Hue' slider.
@@ -357,7 +379,7 @@ function ColorWheels.lazy.value:hueTextField()
             return ui and childMatching(ui, TextField.matches)
         end,
         toRegionalNumber, toRegionalNumberString
-    )
+    ):forceFocus()
 end
 
 return ColorWheels

--- a/src/extensions/languages/English.json
+++ b/src/extensions/languages/English.json
@@ -1562,6 +1562,8 @@
         "resetsTemperatureUsingAMIDIDevice": "Resets the Temperature using a MIDI Device.",
         "resetsTintUsingAMIDIDevice": "Resets the Tint using a MIDI Device.",
         "resetUnit": "Reset Unit",
+        "resetWheel": "Reset Wheel",
+        "resetWheelSaturationAndBrightness": "Reset Wheel, Saturation & Brightness",
         "resolve_application_manager_label": "Application Manager",
         "resolve_group": "DaVinci Resolve",
         "resolve_manager_label": "Resolve Manager",

--- a/src/plugins/finalcutpro/midi/controls/colorboard.lua
+++ b/src/plugins/finalcutpro/midi/controls/colorboard.lua
@@ -146,7 +146,7 @@ local function makePercentHandlerRelativeA(puckFinderFn)
     return function(metadata)
         if optionPressed() then
             if puck:isShowing() then
-                puck:value(0)
+                puck:reset()
                 value = 0
             else
                 puck:show()
@@ -194,7 +194,7 @@ local function makeAngleHandlerRelativeA(puckFinderFn)
     return function(metadata)
         if optionPressed() then
             if puck:isShowing() then
-                puck:value(0)
+                puck:reset()
                 value = 0
             else
                 puck:show()

--- a/src/plugins/finalcutpro/midi/controls/colorwheels.lua
+++ b/src/plugins/finalcutpro/midi/controls/colorwheels.lua
@@ -221,6 +221,25 @@ local function makeResetColorWheelHandler(wheelFinderFn)
     end
 end
 
+-- makeResetColorWheelSatAndBrightnessHandler(puckFinderFn) -> function
+-- Function
+-- Creates a 'handler' for resetting a Color Wheel, Saturation & Brightness.
+--
+-- Parameters:
+--  * puckFinderFn - a function that will return the `ColorPuck` to reset.
+--
+-- Returns:
+--  * a function that will receive the MIDI control metadata table and process it.
+local function makeResetColorWheelSatAndBrightnessHandler(wheelFinderFn)
+    return function()
+        local wheel = wheelFinderFn()
+        wheel:show()
+        wheel:colorOrientation({right=0, up=0})
+        wheel:brightnessValue(0)
+        wheel:saturationValue(1)
+    end
+end
+
 -- makeRelativeAWheelHandler(puckFinderFn) -> function
 -- Function
 -- Creates a 'handler' for wheel controls, applying them to the puck returned by the `puckFinderFn`
@@ -350,7 +369,7 @@ local function makeRelativeABrightnessHandler(wheelFinderFn)
 
         if optionPressed() then
             if wheel:isShowing() then
-                wheel:brightnessValue(1)
+                wheel:brightnessValue(0)
                 brightnessShift = 0
             else
                 wheel:show()
@@ -523,7 +542,7 @@ local function makeRelativeATemperatureHandler()
             return
         end
 
-        local increment = (shiftPressed() and 0.001) or 0.01
+        local increment = (shiftPressed() and 1) or 25
         local midiValue = metadata.pitchChange or metadata.fourteenBitValue
         if midiValue < 8000 then
             temperatureShift = temperatureShift + increment
@@ -620,7 +639,7 @@ local function makeRelativeATintHandler()
             return
         end
 
-        local increment = (shiftPressed() and 0.001) or 0.01
+        local increment = (shiftPressed() and 0.1) or 1
         local midiValue = metadata.pitchChange or metadata.fourteenBitValue
         if midiValue < 8000 then
             tintShift = tintShift + increment
@@ -717,7 +736,7 @@ local function makeRelativeAHueHandler()
             return
         end
 
-        local increment = (shiftPressed() and 0.001) or 0.01
+        local increment = (shiftPressed() and 0.1) or 5
         local midiValue = metadata.pitchChange or metadata.fourteenBitValue
         if midiValue < 8000 then
             hueShift = hueShift + increment
@@ -805,7 +824,7 @@ local function makeRelativeAMixHandler()
 
         if optionPressed() then
             if wheel:isShowing() then
-                wheel:mix(0)
+                wheel:mix(1)
                 mixShift = 0
             else
                 wheel:show()
@@ -813,7 +832,7 @@ local function makeRelativeAMixHandler()
             return
         end
 
-        local increment = (shiftPressed() and 0.001) or 0.01
+        local increment = (shiftPressed() and 0.01) or 0.05
         local midiValue = metadata.pitchChange or metadata.fourteenBitValue
         if midiValue < 8000 then
             mixShift = mixShift + increment
@@ -838,7 +857,7 @@ local function makeResetMixHandler()
     return function()
         local wheel = fcp.inspector.color.colorWheels
         wheel:show()
-        wheel:mix(0)
+        wheel:mix(1)
     end
 end
 
@@ -949,7 +968,9 @@ function plugin.init(deps)
     local temperature   = i18n("temperature")
     local tint          = i18n("tint")
     local vertical      = i18n("vertical")
+    local resetWheel    = i18n("resetWheel")
 
+    local resetWheelSaturationAndBrightness = i18n("resetWheelSaturationAndBrightness")
     local midiControlColorWheel = i18n("midiControlColorWheel")
     local holdDownShiftToChangeValueAtSmallerIncrementsAndOptionToReset = i18n("holdDownShiftToChangeValueAtSmallerIncrementsAndOptionToReset")
 
@@ -1000,9 +1021,19 @@ function plugin.init(deps)
         --------------------------------------------------------------------------------
         deps.manager.controls:new(v.id .. "Reset", {
             group = "fcpx",
-            text = format("%s - %s - %s", colorWheel, v.title, reset),
+            text = format("%s - %s - %s", colorWheel, v.title, resetWheel),
             subText = i18n("resetsAColorWheelUsingAMIDIDevice"),
             fn = makeResetColorWheelHandler(function() return v.control end),
+        })
+
+        --------------------------------------------------------------------------------
+        -- Color Wheel - Reset Color Wheel, Saturation & Brightness:
+        --------------------------------------------------------------------------------
+        deps.manager.controls:new(v.id .. "ResetWheelSaturationBrightness", {
+            group = "fcpx",
+            text = format("%s - %s - %s", colorWheel, v.title, resetWheelSaturationAndBrightness),
+            subText = i18n("resetsAColorWheelUsingAMIDIDevice"),
+            fn = makeResetColorWheelSatAndBrightnessHandler(function() return v.control end),
         })
 
         --------------------------------------------------------------------------------


### PR DESCRIPTION
- Fixed issue in FCPX API for controlling Hue, Tint & Temperature.
- Fixed issue when resetting Color Board controls.
- Fixed issue when resetting Brightness with the OPTION key.
- Fixed issue when resetting Mix with OPTION key.
- Fixed temperature increments.
- Fixed tint increments.
- Fixed hue increments.
- Fixed mix increments.
- Added action for resetting Color Wheel, Saturation & Brightness.
- Closes #2432