### PR TITLE
Restored previously renamed Color Wheel Saturation & Brightness actions

### DIFF
--- a/src/plugins/core/action/manager/activator.lua
+++ b/src/plugins/core/action/manager/activator.lua
@@ -629,6 +629,16 @@ function activator:incPopularity(choice, id)
     end
 end
 
+-- _sortChoices(choices, query) -> table
+-- Function
+-- Sorts choices.
+--
+-- Parameters:
+--  * choices - a table of choices
+--  * query - the current query string
+--
+-- Returns:
+--  * A sorted table of choices
 local function _sortChoices(choices, query)
     local queryLen = query and query:len() or 0
 
@@ -765,6 +775,11 @@ function activator:activeChoices()
         if (showHidden or not choice.hidden) and not disabledHandlers[choice.type] then
             -- Check if we are filtering by query
             if queryLen > 0 then
+                -- Don't show deprecated actions in the Search Console:
+                if choice.text:sub(1, 11) == "Deprecated:" then
+                    return false
+                end
+
                 -- Store the match index for sorting later.
                 choice.textMatch = choice.text:lower():find(query, 1, true)
                 if choice.textMatch then

--- a/src/plugins/finalcutpro/midi/controls/colorwheels.lua
+++ b/src/plugins/finalcutpro/midi/controls/colorwheels.lua
@@ -975,10 +975,10 @@ function plugin.init(deps)
     local holdDownShiftToChangeValueAtSmallerIncrementsAndOptionToReset = i18n("holdDownShiftToChangeValueAtSmallerIncrementsAndOptionToReset")
 
     local colourWheels = {
-        { title = i18n("master"),       control = fcp.inspector.color.colorWheels.master,       id = "master" },
-        { title = i18n("shadows"),      control = fcp.inspector.color.colorWheels.shadows,      id = "shadows" },
-        { title = i18n("midtones"),     control = fcp.inspector.color.colorWheels.midtones,     id = "midtones" },
-        { title = i18n("highlights"),   control = fcp.inspector.color.colorWheels.highlights,   id = "highlights" },
+        { title = i18n("master"),       control = fcp.inspector.color.colorWheels.master,       id = "master",      legacyID = "colorWheelMaster" },
+        { title = i18n("shadows"),      control = fcp.inspector.color.colorWheels.shadows,      id = "shadows",     legacyID = "colorWheelShadows" },
+        { title = i18n("midtones"),     control = fcp.inspector.color.colorWheels.midtones,     id = "midtones",    legacyID = "colorWheelMidtones" },
+        { title = i18n("highlights"),   control = fcp.inspector.color.colorWheels.highlights,   id = "highlights",  legacyID = "colorWheelHighlights" },
     }
 
     for _, v in pairs(colourWheels) do
@@ -1046,6 +1046,16 @@ function plugin.init(deps)
             fn = makeAbsoluteSaturationHandler(function() return v.control end, true),
         })
 
+            --------------------------------------------------------------------------------
+            -- Deprecated/Legacy Action for 1.0.6 users:
+            --------------------------------------------------------------------------------
+            deps.manager.controls:new(v.legacyID .. "Saturation", {
+                group = "fcpx",
+                text = format("Deprecated: %s - %s - %s (%s)", colorWheel, v.title, saturation, absolute),
+                subText = midiControlColorWheel,
+                fn = makeAbsoluteSaturationHandler(function() return v.control end, true),
+            })
+
         --------------------------------------------------------------------------------
         -- Saturation (Relative A):
         --------------------------------------------------------------------------------
@@ -1075,6 +1085,16 @@ function plugin.init(deps)
             subText = midiControlColorWheel,
             fn = makeAbsoluteBrightnessHandler(function() return v.control end, true),
         })
+
+            --------------------------------------------------------------------------------
+            -- Deprecated/Legacy Action for 1.0.6 users:
+            --------------------------------------------------------------------------------
+            deps.manager.controls:new(v.legacyID .. "Brightness", {
+                group = "fcpx",
+                text = format("Deprecated: %s - %s - %s (%s)", colorWheel, v.title, brightness, absolute),
+                subText = midiControlColorWheel,
+                fn = makeAbsoluteBrightnessHandler(function() return v.control end, true),
+            })
 
         --------------------------------------------------------------------------------
         -- Brightness (Relative A):


### PR DESCRIPTION
- The Search Console will now no longer list any actions that begin
with “Deprecated:”.
- Closes #2480