### PR TITLE
Color Board controls now work correctly in all languages

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/inspector/Inspector.lua
+++ b/src/extensions/cp/apple/finalcutpro/inspector/Inspector.lua
@@ -210,7 +210,7 @@ function Inspector.lazy.prop:isFullHeight()
             self:show()
             local currentValue = thisProp:get()
             if newValue ~= currentValue then
-                self:app().menu:selectMenu({"View", "Toggle Inspector Height"})
+                self:app().menu:selectMenu({"View", "Toggle Inspector Height"}, {plain=true})
             end
         end
     )

--- a/src/extensions/cp/apple/finalcutpro/inspector/color/ColorBoardAspect.lua
+++ b/src/extensions/cp/apple/finalcutpro/inspector/color/ColorBoardAspect.lua
@@ -194,7 +194,7 @@ end
 function ColorBoardAspect.lazy.value:master()
     return ColorPuck(
         self, ColorPuck.RANGE.master,
-        {"CPColorBoardMaster", "cb master puck display name"},
+        {"PAE4WayCorrectorViewControllerMasterLabel"},
         self._hasAngle
     )
 end
@@ -205,7 +205,7 @@ end
 function ColorBoardAspect.lazy.value:shadows()
     return ColorPuck(
         self, ColorPuck.RANGE.shadows,
-        {"CPBolorBoardShadows", "cb shadow puck display name"},
+        {"PAE4WayCorrectorViewControllerShadowsLabel"},
         self._hasAngle
     )
 end
@@ -216,7 +216,7 @@ end
 function ColorBoardAspect.lazy.value:midtones()
     return ColorPuck(
         self, ColorPuck.RANGE.midtones,
-        {"CPColorBoardMidtones", "cb midtone puck display name"},
+        {"PAE4WayCorrectorViewControllerMidtonesLabel"},
         self._hasAngle
     )
 end
@@ -227,7 +227,7 @@ end
 function ColorBoardAspect.lazy.value:highlights()
     return ColorPuck(
         self, ColorPuck.RANGE.highlights,
-        {"CPColorBoardHighlights", "cb highlight puck display name"},
+        {"PAE4WayCorrectorViewControllerHighlightsLabel"},
         self._hasAngle
     )
 end

--- a/src/extensions/cp/apple/finalcutpro/strings/de/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/de/10.4.0.strings
@@ -3,10 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPColorBoardMidtones</key>
-    <string>Mitteltöne</string>
-    <key>CPColorBoardHighlights</key>
-    <string>Hervorhebungen</string>
     <key>CPCodecs</key>
     <string>Codecs</string>
     <key>CPShowHorizon</key>

--- a/src/extensions/cp/apple/finalcutpro/strings/fr/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/fr/10.4.0.strings
@@ -3,10 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPColorBoardMidtones</key>
-    <string>Intermédiaires</string>
-    <key>CPColorBoardHighlights</key>
-    <string>Tons clairs</string>
     <key>CPCodecs</key>
     <string>Codecs</string>
     <key>CPShowHorizon</key>

--- a/src/extensions/cp/apple/finalcutpro/strings/ja/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/ja/10.4.0.strings
@@ -3,8 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPColorBoardMidtones</key>
-    <string>中間色調</string>
     <key>CPCodecs</key>
     <string>コーデック</string>
     <key>CPShowHorizon</key>


### PR DESCRIPTION
- Changed the Color Board language keys, so we no longer have to have them hardcoded in our strings workaround file. Tested on all languages.
- Fixed bug where "View > Toggle Inspector Height" was not working in German due to non-standard characters.
- Closes #2518 and #2529