### PR TITLE
Changing timecode via FCPX API is now more reliable

### DIFF
--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -221,7 +221,8 @@ end
 --- Returns:
 ---  * None
 function app:keyStroke(modifiers, character)
-    keyStroke(modifiers, character, self._hsApplication)
+    local app = self:hsApplication()
+    keyStroke(modifiers, character, app)
 end
 
 --- cp.app.preferences <cp.app.prefs>

--- a/src/extensions/cp/app.lua
+++ b/src/extensions/cp/app.lua
@@ -221,8 +221,7 @@ end
 --- Returns:
 ---  * None
 function app:keyStroke(modifiers, character)
-    local app = self:hsApplication()
-    keyStroke(modifiers, character, app)
+    keyStroke(modifiers, character, self:hsApplication())
 end
 
 --- cp.app.preferences <cp.app.prefs>

--- a/src/extensions/cp/apple/commandeditor/init.lua
+++ b/src/extensions/cp/apple/commandeditor/init.lua
@@ -188,7 +188,7 @@ function mod.shortcutsFromCommandSet(id, commandSet)
 
     local commands = commandSet[id]
     if not commands then
-        log.ef("Command does not exist in Command Set: %s", id)
+        --log.ef("Command does not exist in Command Set: %s", id)
         return nil
     end
 

--- a/src/extensions/cp/apple/finalcutpro/init.lua
+++ b/src/extensions/cp/apple/finalcutpro/init.lua
@@ -1147,7 +1147,8 @@ function fcp:doShortcut(whichShortcut)
     :Then(function()
         local shortcuts = self:getCommandShortcuts(whichShortcut)
         if shortcuts and #shortcuts > 0 then
-            shortcuts[1]:trigger()
+            local app = self:application()
+            shortcuts[1]:trigger(app)
             return true
         else
             return Throw(i18n("fcpShortcut_NoShortcutAssigned", {id=whichShortcut}))

--- a/src/extensions/cp/apple/finalcutpro/init.lua
+++ b/src/extensions/cp/apple/finalcutpro/init.lua
@@ -1147,8 +1147,7 @@ function fcp:doShortcut(whichShortcut)
     :Then(function()
         local shortcuts = self:getCommandShortcuts(whichShortcut)
         if shortcuts and #shortcuts > 0 then
-            local app = self:application()
-            shortcuts[1]:trigger(app)
+            shortcuts[1]:trigger(self:application())
             return true
         else
             return Throw(i18n("fcpShortcut_NoShortcutAssigned", {id=whichShortcut}))

--- a/src/extensions/cp/apple/finalcutpro/timeline/Contents.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Contents.lua
@@ -327,7 +327,7 @@ end
 function Contents:_filterClips(clips, expandGroups, filterFn)
     if expandGroups then
         return self:_expandClips(clips, filterFn)
-    elseif filterFn ~= nil then
+    elseif type(filterFn) == "function" and type(clips) == "table" then
         return fnutils.filter(clips, filterFn)
     else
         return clips

--- a/src/extensions/cp/apple/finalcutpro/viewer/ControlBar.lua
+++ b/src/extensions/cp/apple/finalcutpro/viewer/ControlBar.lua
@@ -6,7 +6,6 @@
 local log               = require "hs.logger" .new "ViewerCB"
 
 local canvas            = require "hs.canvas"
-local eventtap          = require "hs.eventtap"
 local geometry          = require "hs.geometry"
 local pasteboard        = require "hs.pasteboard"
 local timer             = require "hs.timer"

--- a/src/extensions/cp/commands/shortcut.lua
+++ b/src/extensions/cp/commands/shortcut.lua
@@ -246,14 +246,14 @@ end
 --- This will trigger the keystroke specified in the shortcut.
 ---
 --- Parameters:
----  * None
+---  * app - An optional `hs.application` object.
 ---
 --- Returns:
 ---  * `self`
-function shortcut.mt:trigger()
+function shortcut.mt:trigger(app)
     local character = shortcut.textToKeyCode(self:getKeyCode())
     local modifiers = self._modifiers or {}
-    keyStroke(modifiers, character)
+    keyStroke(modifiers, character, app)
     return self
 end
 

--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -138,6 +138,7 @@ function tools.keyStroke(modifiers, character, app)
         if m == "command" then m = "cmd" end
         if m == "option" then m = "alt" end
         if m == "control" then m = "ctrl" end
+        if m == "function" then m = "fn" end
         newKeyEvent(map[m], true):post(app)
     end
 
@@ -148,6 +149,7 @@ function tools.keyStroke(modifiers, character, app)
         if m == "command" then m = "cmd" end
         if m == "option" then m = "alt" end
         if m == "control" then m = "ctrl" end
+        if m == "function" then m = "fn" end
         newKeyEvent(map[m], false):post(app)
     end
 end


### PR DESCRIPTION
- If a "Paste Timecode" shortcut key is assigned, we'll use that, otherwise we'll just "type" the timecode value into the Viewer. This seems to work much better than the previous pasteboard workaround.
- `fcp:doShortcut()` now sends those shortcut keys directly to Final Cut Pro.
- Better error detection in the Timeline Contents API.
- Fixed a bug in `cp.tools.keyStroke` which didn't handle "function" modifiers.
- Closes #2528