### PR TITLE
Automatically apply action image to Loupedeck Touch Button

### DIFF
--- a/src/plugins/core/loupedeckctandlive/prefs/init.lua
+++ b/src/plugins/core/loupedeckctandlive/prefs/init.lua
@@ -32,7 +32,6 @@ local imageFromAppBundle        = image.imageFromAppBundle
 local imageFromPath             = image.imageFromPath
 local imageFromURL              = image.imageFromURL
 local infoForBundlePath         = application.infoForBundlePath
-local infoForBundlePath         = application.infoForBundlePath
 local mergeTable                = tools.mergeTable
 local removeFilenameFromPath    = tools.removeFilenameFromPath
 local spairs                    = tools.spairs


### PR DESCRIPTION
- If you assign an action that has a custom image in the Search Console, that image will now be applied to the Loupedeck CT & Live Touch Bar button.
- You can now pick applications when applying a custom image to a Touch Bar button in the Loupedeck CT & Live control surfaces panel.
- Closes #2611