### PR TITLE
Fixed bug where quotes weren't properly escaped when exporting a CSV

### DIFF
--- a/src/extensions/cp/ui/Table.lua
+++ b/src/extensions/cp/ui/Table.lua
@@ -596,7 +596,7 @@ function Table:toCSV()
                             if cell:attributeValue("AXRole") == "AXTextField" then
                                 -- If there's only an AXTable > AXRow:
                                 local item = cell:attributeValue("AXValue")
-                                result = result .. [["]] .. item .. [["]]
+                                result = result .. [["]] .. item:gsub([["]], [[""]]) .. [["]]
                                 if c ~= #cells then
                                     result = result .. ","
                                 else
@@ -608,7 +608,7 @@ function Table:toCSV()
                                 -- If there's an AXTable > AXRow > AXCell:
                                 local field = childMatching(cell, StaticText.matches) or childMatching(cell, TextField.matches) or childMatching(cell, MenuButton.matches)
                                 local item = (field and field:attributeValue("AXValue")) or (field and field:attributeValue("AXTitle")) or ""
-                                result = result .. [["]] .. item .. [["]]
+                                result = result .. [["]] .. item:gsub([["]], [[""]]) .. [["]]
                                 if c ~= #cells then
                                     result = result .. ","
                                 else

--- a/src/plugins/finalcutpro/toolbox/shotdata/init.lua
+++ b/src/plugins/finalcutpro/toolbox/shotdata/init.lua
@@ -571,8 +571,8 @@ local function processFCPXML(path)
                     local currentHeading = TEMPLATE_ORDER[i]
                     local value = row[currentHeading]
                     if value then
-                        if value:match(",") then
-                            output = output .. [["]] .. value .. [["]]
+                        if value:match(",") or value:match([["]]) then
+                            output = output .. [["]] .. value:gsub([["]], [[""]]) .. [["]]
                         else
                             output = output .. value
                         end


### PR DESCRIPTION
- Fixed the bug in both the Shot Data Toolbox, Save Browser Contents to CSV and Save Timeline Index to CSV.
- Closes #2620