### PR TITLE
Vimeo Toolbox now uses lua-csv

### DIFF
--- a/src/extensions/cp/tools/init.lua
+++ b/src/extensions/cp/tools/init.lua
@@ -2010,42 +2010,4 @@ function tools.isColor(object)
     return object and getmetatable(object) == getObjectMetatable("hs.drawing.color") or false
 end
 
---- cp.tools.fromCSV(string) -> table
---- Function
---- Convert from CSV string to table (converts a single line of a CSV file).
----
---- Parameters:
----  * string - A single line from a CSV file.
----
---- Returns:
----  * A table of each column data
----
---- Notes:
----  * Taken from http://lua-users.org/wiki/CsvUtils
-function tools.fromCSV(s)
-    s = s .. ','        -- ending comma
-    local t = {}        -- table to collect fields
-    local fieldstart = 1
-    repeat
-        -- next field is quoted? (start with `"'?)
-        if string.find(s, '^"', fieldstart) then
-            local a, c -- luacheck: ignore
-            local i  = fieldstart
-            repeat
-                -- find closing quote
-                a, i, c = string.find(s, '"("?)', i+1)
-            until c ~= '"'    -- quote not followed by quote?
-            if not i then error('unmatched "') end
-            local f = string.sub(s, fieldstart+1, i-1)
-            table.insert(t, (string.gsub(f, '""', '"')))
-            fieldstart = string.find(s, ',', i) + 1
-        else                -- unquoted; find next comma
-            local nexti = string.find(s, ',', fieldstart)
-            table.insert(t, string.sub(s, fieldstart, nexti-1))
-            fieldstart = nexti + 1
-        end
-    until fieldstart > string.len(s)
-    return t
-end
-
 return tools

--- a/src/extensions/languages/English_en.json
+++ b/src/extensions/languages/English_en.json
@@ -141,6 +141,7 @@
     "backToFront9": "Bak2Front",
     "backupInterval": "Backup Interval",
     "backupMinimumDuration": "Backup Minimum Duration",
+    "badCSVFileForVimeoToolbox": "This CSV file does not contain the contents we expect from Vimeo.\n\nPlease check the contents of the file and try again.\n\nIf you're still having issues importing a CSV file from Vimeo, please contact the CommandPost developers.",
     "badLoupedeckIcon": "Only supported image files (JPEG, PNG, TIFF, GIF or BMP) can be dragged and dropped here.",
     "badLoupedeckIconTip": "However, you can click the Drop Zone to import the icons from Application files.",
     "badStreamDeckIcon": "Only supported image files (JPEG, PNG, TIFF, GIF or BMP) are allowed as Stream Deck icons.",


### PR DESCRIPTION
- Updated the Vimeo Toolbox to use `lua-csv` for better file handling.
- Removed `cp.tools.fromCSV()` as it's no longer used.
- Added a better error message when a CSV fails.
- Closes #2792