### PR TITLE
Timeline Batch Export Improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,6 @@
 # Set default charset
 [*.{js,htm,html,sass,css,lua,lp}]
 charset = utf-8
-# indent_style = space
+indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true

--- a/src/plugins/finalcutpro/export/batch/batch.lua
+++ b/src/plugins/finalcutpro/export/batch/batch.lua
@@ -579,7 +579,7 @@ function mod.getDestinationFolder()
     return exportPath and pathToAbsolute(exportPath)
 end
 
---- plugins.finalcutpro.export.batch.getDestinationFolder() -> string | nil
+--- plugins.finalcutpro.export.batch.getDestinationPreset() -> string | nil
 --- Function
 --- Gets the destination preset.
 ---
@@ -601,6 +601,32 @@ function mod.getDestinationPreset()
     if destinationPreset == i18n("sendToCompressor") then
         if not compressor:isInstalled() then
             --log.df("Apple Compressor could not be detected.")
+            destinationPreset = nil
+            config.set("batchExportDestinationPreset", nil)
+        end
+    end
+
+    --------------------------------------------------------------------------------
+    -- Make sure the Destination Preset actually exists in the menubar:
+    --------------------------------------------------------------------------------
+    if destinationPreset and destinationPreset ~= i18n("sendToCompressor") then
+        local doesExistInMenu = fcp.menu:findMenuUI({"File", "Share", function(menuItem)
+            local title = menuItem and menuItem:attributeValue("AXTitle")
+
+            --------------------------------------------------------------------------------
+            -- Remove the (default)…:
+            --------------------------------------------------------------------------------
+            if title and title:sub(-13) == " (default)…" then
+                title = title:sub(1, -14)
+            end
+            --------------------------------------------------------------------------------
+            -- Remove the …:
+            --------------------------------------------------------------------------------
+            title = tools.replace(title, "…", "")
+
+            return title == destinationPreset
+        end})
+        if not doesExistInMenu then
             destinationPreset = nil
             config.set("batchExportDestinationPreset", nil)
         end


### PR DESCRIPTION
- Check to see if the chosen Destination Preset actually exists in the menubar.
- Changed the `.editorconfig` to use spaces as the indent style to hopefully get around all the de-tab issues I've been having on my M1.
- Closes #2811