### PR TITLE
Fixed actions to "Switch To" Custom Application in Loupedeck Preferences

### DIFF
--- a/src/plugins/core/loupedeckctandlive/manager/init.lua
+++ b/src/plugins/core/loupedeckctandlive/manager/init.lua
@@ -789,11 +789,13 @@ function mod.new(deviceType)
             -- Add User Added Applications from Loupedeck Preferences:
             local items = o.items()
 
-            for bundleID, v in pairs(items) do
-                if not applications[bundleID] and v.displayName then
-                    applications[bundleID] = {
-                        displayName = v.displayName
-                    }
+            for _, unitObj in pairs(items) do
+                for bundleID, v in pairs(unitObj) do
+                    if not applications[bundleID] and v.displayName then
+                        applications[bundleID] = {
+                            displayName = v.displayName
+                        }
+                    end
                 end
             end
 


### PR DESCRIPTION
- Eric Badura reports that if you add a custom application to the Loupedeck Preferences (i.e. Logic Pro X) and turn off "Automatically Switch Applications", there no actions for switching to Logic Pro X. This fixes that.
- Closes #2840