### PR TITLE
Various Fixes

### DIFF
--- a/src/extensions/languages/English_en.json
+++ b/src/extensions/languages/English_en.json
@@ -668,7 +668,7 @@
     "daVinciResolveControlSurfaceResetEverythingConfirmation": "This will reset all DaVinci Resolve Control Surface items across all devices to the default values.",
     "daVinciResolveControlSurfaceResetUnitConfirmation": "This will reset all DaVinci Resolve Control Surface items for this particular unit to the default values.",
     "daVinciResolveControlSurfaceSupport": "DaVinci Resolve Control Surface Support",
-    "daVinciResolveControlSurfaceTip": "These features have been tested with Speed Editor Firmware v1.4.1.",
+    "daVinciResolveControlSurfaceTip": "DaVinci Resolve will override CommandPost when running.<br />These features have been tested with Speed Editor Firmware v1.4.1.<br />We recommend using a wired connection.",
     "decrease": "Decrease",
     "decreaseClipHeight": "Decrease Clip Height",
     "decreaseOpacity": "Decrease Opacity by %{amount} Percent",

--- a/src/plugins/core/controlsurfaces/resolve/default/Default.cpResolve
+++ b/src/plugins/core/controlsurfaces/resolve/default/Default.cpResolve
@@ -16,280 +16,396 @@
       "com.ecamm.EcammLive" : {
         "ignore" : true
       },
-      "org.latenitefilms.CommandPost" : {
-        "ignore" : true
+      "All Applications" : {
+        "1" : {
+          "SHTL" : {
+            "ledAlwaysOn" : true
+          },
+          "SNAP" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 9" : {
+            "ledAlwaysOn" : true
+          },
+          "DIS" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 4" : {
+            "ledAlwaysOn" : true
+          },
+          "SCRL" : {
+            "ledAlwaysOn" : true
+          },
+          "CLOSE UP" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 3" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 8" : {
+            "ledAlwaysOn" : true
+          },
+          "VIDEO ONLY" : {
+            "ledAlwaysOn" : true
+          },
+          "JOG" : {
+            "ledAlwaysOn" : true
+          },
+          "JOG WHEEL" : {
+            "turnRightAction" : {
+              "handlerID" : "global_mouse",
+              "action" : {
+                "y" : 1,
+                "amount" : 1,
+                "modifiers" : [
+
+                ],
+                "x" : 0,
+                "mode" : "scroll",
+                "unit" : "line"
+              },
+              "actionTitle" : "Mouse Scroll Wheel - 1 Line Up"
+            },
+            "turnLeftAction" : {
+              "handlerID" : "global_mouse",
+              "action" : {
+                "y" : -1,
+                "amount" : -1,
+                "modifiers" : [
+
+                ],
+                "x" : 0,
+                "mode" : "scroll",
+                "unit" : "line"
+              },
+              "actionTitle" : "Mouse Scroll Wheel - 1 Line Down"
+            }
+          },
+          "TRANS" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 2" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 7" : {
+            "ledAlwaysOn" : true
+          },
+          "SMTH CUT" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 1" : {
+            "ledAlwaysOn" : true
+          },
+          "CAM 6" : {
+            "ledAlwaysOn" : true
+          },
+          "AUDIO ONLY" : {
+            "ledAlwaysOn" : true
+          },
+          "SOURCE" : {
+            "pressAction" : {
+              "handlerID" : "global_shortcuts",
+              "action" : {
+                "character" : "a",
+                "id" : "a",
+                "modifiers" : [
+
+                ]
+              },
+              "actionTitle" : "A"
+            }
+          },
+          "CUT" : {
+            "ledAlwaysOn" : true
+          },
+          "FULL VIEW" : {
+            "pressAction" : {
+              "handlerID" : "global_cmds",
+              "action" : {
+                "id" : "cpLaunchFinalCutPro"
+              },
+              "actionTitle" : "Launch Final Cut Pro"
+            }
+          },
+          "CAM 5" : {
+            "ledAlwaysOn" : true
+          },
+          "LIVE OWR" : {
+            "ledAlwaysOn" : true
+          }
+        }
       },
-      "com.microsoft.teams" : {
+      "org.latenitefilms.CommandPost" : {
         "ignore" : true
       },
       "com.apple.FinalCut" : {
         "1" : {
           "SNAP" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "View",
                   "Snapping"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Snapping",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Snapping"
             }
           },
           "CAM 9" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle09",
-              "actionTitle" : "Cut and Switch to Viewer Angle 9",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 9"
             }
           },
           "CAM 4" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle04",
-              "actionTitle" : "Cut and Switch to Viewer Angle 4",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 4"
             }
           },
           "TIMELINE" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "Window",
                   "Go To",
                   "Timeline"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Timeline",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Timeline"
             }
           },
           "CAM 3" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle03",
-              "actionTitle" : "Cut and Switch to Viewer Angle 3",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 3"
             }
           },
           "CAM 8" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle08",
-              "actionTitle" : "Cut and Switch to Viewer Angle 8",
-              "handlerID" : "fcpx_shortcuts"
-            }
-          },
-          "VIDEO ONLY" : {
-            "pressAction" : {
-              "action" : "MultiAngleEditStyleVideo",
-              "actionTitle" : "Cut\/Switch Multicam Video Only",
-              "handlerID" : "fcpx_shortcuts"
-            }
-          },
-          "APPND" : {
-            "pressAction" : {
-              "action" : {
-                "plain" : true,
-                "locale" : "en",
-                "path" : [
-                  "Edit",
-                  "Append to Storyline"
-                ]
-              },
-              "actionTitle" : "Append to Storyline",
-              "handlerID" : "fcpx_menu"
-            }
-          },
-          "JOG WHEEL" : {
-            "turnRightAction" : {
-              "action" : "JumpToNextFrame",
-              "actionTitle" : "Go to Next Frame",
-              "handlerID" : "fcpx_shortcuts"
-            },
-            "turnLeftAction" : {
-              "action" : "JumpToPreviousFrame",
-              "actionTitle" : "Go to Previous Frame",
-              "handlerID" : "fcpx_shortcuts"
-            }
-          },
-          "STOP PLAY" : {
-            "pressAction" : {
-              "action" : {
-                "plain" : true,
-                "locale" : "en",
-                "path" : [
-                  "View",
-                  "Playback",
-                  "Play"
-                ]
-              },
-              "actionTitle" : "Play",
-              "handlerID" : "fcpx_menu"
-            }
-          },
-          "TRIM OUT" : {
-            "pressAction" : {
-              "action" : {
-                "plain" : true,
-                "locale" : "en",
-                "path" : [
-                  "Trim",
-                  "Trim End"
-                ]
-              },
-              "actionTitle" : "Trim End",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Cut and Switch to Viewer Angle 8"
             }
           },
           "TRANS" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "AddTransition",
-              "actionTitle" : "Add Default Transition",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Add Default Transition"
+            }
+          },
+          "APPND" : {
+            "pressAction" : {
+              "handlerID" : "fcpx_menu",
+              "action" : {
+                "path" : [
+                  "Edit",
+                  "Append to Storyline"
+                ],
+                "locale" : "en",
+                "plain" : true
+              },
+              "actionTitle" : "Append to Storyline"
+            }
+          },
+          "JOG WHEEL" : {
+            "turnRightAction" : {
+              "handlerID" : "fcpx_shortcuts",
+              "action" : "JumpToNextFrame",
+              "actionTitle" : "Go to Next Frame"
+            },
+            "turnLeftAction" : {
+              "handlerID" : "fcpx_shortcuts",
+              "action" : "JumpToPreviousFrame",
+              "actionTitle" : "Go to Previous Frame"
+            }
+          },
+          "STOP PLAY" : {
+            "pressAction" : {
+              "handlerID" : "fcpx_menu",
+              "action" : {
+                "path" : [
+                  "View",
+                  "Playback",
+                  "Play"
+                ],
+                "locale" : "en",
+                "plain" : true
+              },
+              "actionTitle" : "Play"
+            }
+          },
+          "VIDEO ONLY" : {
+            "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
+              "action" : "MultiAngleEditStyleVideo",
+              "actionTitle" : "Cut\/Switch Multicam Video Only"
+            }
+          },
+          "TRIM OUT" : {
+            "pressAction" : {
+              "handlerID" : "fcpx_menu",
+              "action" : {
+                "path" : [
+                  "Trim",
+                  "Trim End"
+                ],
+                "locale" : "en",
+                "plain" : true
+              },
+              "actionTitle" : "Trim End"
             }
           },
           "CAM 2" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle02",
-              "actionTitle" : "Cut and Switch to Viewer Angle 2",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 2"
             }
           },
           "CAM 7" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle07",
-              "actionTitle" : "Cut and Switch to Viewer Angle 7",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 7"
             }
           },
           "OUT" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "Mark",
                   "Set Range End"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Set Range End",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Set Range End"
             }
           },
           "PLACE ON TOP" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "Edit",
                   "Connect to Primary Storyline"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Connect to Primary Storyline",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Connect to Primary Storyline"
             }
           },
           "CAM 1" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle01",
-              "actionTitle" : "Cut and Switch to Viewer Angle 1",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 1"
             }
           },
           "SOURCE" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "Window",
                   "Go To",
                   "Event Viewer"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Event Viewer",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Event Viewer"
             }
           },
           "CAM 6" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle06",
-              "actionTitle" : "Cut and Switch to Viewer Angle 6",
-              "handlerID" : "fcpx_shortcuts"
-            }
-          },
-          "AUDIO ONLY" : {
-            "pressAction" : {
-              "action" : "MultiAngleEditStyleAudio",
-              "actionTitle" : "Cut\/Switch Multicam Audio Only",
-              "handlerID" : "fcpx_shortcuts"
-            }
-          },
-          "CUT" : {
-            "pressAction" : {
-              "action" : {
-                "plain" : true,
-                "locale" : "en",
-                "path" : [
-                  "Trim",
-                  "Blade"
-                ]
-              },
-              "actionTitle" : "Blade",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Cut and Switch to Viewer Angle 6"
             }
           },
           "TRIM IN" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "Trim",
                   "Trim Start"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Trim Start",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Trim Start"
+            }
+          },
+          "CUT" : {
+            "pressAction" : {
+              "handlerID" : "fcpx_menu",
+              "action" : {
+                "path" : [
+                  "Trim",
+                  "Blade"
+                ],
+                "locale" : "en",
+                "plain" : true
+              },
+              "actionTitle" : "Blade"
             }
           },
           "FULL VIEW" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "View",
                   "Playback",
                   "Play Full Screen"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Play Full Screen",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Play Full Screen"
+            }
+          },
+          "AUDIO ONLY" : {
+            "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
+              "action" : "MultiAngleEditStyleAudio",
+              "actionTitle" : "Cut\/Switch Multicam Audio Only"
             }
           },
           "CAM 5" : {
             "pressAction" : {
+              "handlerID" : "fcpx_shortcuts",
               "action" : "CutSwitchAngle05",
-              "actionTitle" : "Cut and Switch to Viewer Angle 5",
-              "handlerID" : "fcpx_shortcuts"
+              "actionTitle" : "Cut and Switch to Viewer Angle 5"
             }
           },
           "IN" : {
             "pressAction" : {
+              "handlerID" : "fcpx_menu",
               "action" : {
-                "plain" : true,
-                "locale" : "en",
                 "path" : [
                   "Mark",
                   "Set Range Start"
-                ]
+                ],
+                "locale" : "en",
+                "plain" : true
               },
-              "actionTitle" : "Set Range Start",
-              "handlerID" : "fcpx_menu"
+              "actionTitle" : "Set Range Start"
             }
           }
         }
@@ -298,6 +414,9 @@
         "ignore" : true
       },
       "us.zoom.xos" : {
+        "ignore" : true
+      },
+      "com.microsoft.teams" : {
         "ignore" : true
       },
       "com.apple.Compressor" : {

--- a/src/plugins/core/controlsurfaces/resolve/manager/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/manager/init.lua
@@ -54,7 +54,7 @@ mod.snippetsRefreshFrequency = config.prop("daVinciResolveControlSurface.prefere
 --- plugins.core.resolve.manager.automaticallySwitchApplications <cp.prop: boolean>
 --- Field
 --- Enable or disable the automatic switching of applications.
-mod.automaticallySwitchApplications = config.prop("daVinciResolveControlSurface.automaticallySwitchApplications", false)
+mod.automaticallySwitchApplications = config.prop("daVinciResolveControlSurface.automaticallySwitchApplications", true)
 
 --- plugins.core.resolve.manager.lastBundleID <cp.prop: string>
 --- Field
@@ -450,7 +450,7 @@ function mod.discoveryCallback(connected, object)
     else
         local deviceType = mod.getDeviceType()
         if connected then
-            --log.df("DaVinci Resolve Control Surface Connected: %s - %s", deviceType, serialNumber)
+            log.df("DaVinci Resolve Control Surface Connected: %s - %s", deviceType, serialNumber)
             mod.devices[deviceType][serialNumber] = object:callback(mod.buttonCallback)
 
             --------------------------------------------------------------------------------
@@ -470,7 +470,7 @@ function mod.discoveryCallback(connected, object)
             mod.update()
         else
             if mod.devices and mod.devices[deviceType][serialNumber] then
-                --log.df("DaVinci Resolve Control Surface Disconnected: %s - %s", deviceType, serialNumber)
+                log.df("DaVinci Resolve Control Surface Disconnected: %s - %s", deviceType, serialNumber)
                 mod.devices[deviceType][serialNumber] = nil
             else
                 log.ef("Disconnected DaVinci Resolve Control Surface wasn't previously registered: %s - %s", deviceType, serialNumber)

--- a/src/plugins/core/controlsurfaces/resolve/prefs/css/resolve.css
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/css/resolve.css
@@ -46,80 +46,7 @@ input[type="color"]::-webkit-color-swatch {
 	background-image: -webkit-linear-gradient(#fbf8f8 0%, #f0f0f0 30%, #e3e3e3 45%, #d7d7d7 60%, #cbc9c9 100%);
 }
 
-.speedEditorDropdown {
-	width: 200px;
-	float: left;
-}
 
-.speedEditor {
-	margin-top: 10px;
-	table-layout: fixed;
-	width: 100%;
-	white-space: nowrap;
-	border: 1px solid #cccccc;
-	padding: 8px;
-	background-color: #161616;
-	text-align: left;
-}
-
-.speedEditor td {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.sdTip {
-	color: #436694;
-	font-style: italic;
-	padding-top: 5px;
-	display: block;
-	clear: both;
-}
-
-.sdButtonLabel {
-	-webkit-appearance: none;
-	text-shadow:0 1px 0 rgba(0,0,0,0.4);
-	background-color: rgba(65,65,65,1);
-	color: #bfbfbc;
-	text-decoration: none;
-	padding: 2px 18px 2px 5px;
-	border:0.5px solid black;
-	margin: 2px 2px;
-	display: inline-block;
-	border-radius: 3px;
-	border-radius: 0px;
-	cursor: default;
-	font-family: -apple-system;
-	font-size: 13px;
-	width: 225px;
-}
-
-.sdRowIcon {
-	width: 10%;
-}
-
-.sdRowAction {
-	width: 40%;
-}
-
-.sdRowActionButton {
-	width: 5%;
-}
-
-.sdRowLabel {
-	width: 27%;
-}
-
-.sdResetGroup {
-	margin: 10px 0px 0px 5px;
-	text-align: center;
-	float: left;
-	width: 200px;
-}
-
-.sdRowOrder {
-	width: 8%;
-}
 
 .speedEditor thead {
 	font-weight: bold;
@@ -166,147 +93,15 @@ input[type="color"]::-webkit-color-swatch {
 	width: 150px;
 }
 
-/*
-.speedEditor tbody tr:hover {
-	background-color: #006dd4;
-	color: white;
-}
-*/
-
-.resetStreamDeck {
-	margin: 10px 0px;
-	text-align: center;
-	float: left;
-	width: 200px;
-}
-
-.buttonDisabled {
-	pointer-events:none;
-	opacity: 0.4;
-}
-
-.speedEditorControl {
-	padding-top: 0px;
-	padding-bottom: 3pt;
-	padding-left: 20px;
-	margin-top: 0px;
-	margin-bottom: 2px;
-	margin-right: 0px;
-	margin-left: 0px;
-	height: 20px;
-}
-
-.sdActionTextbox {
-	-webkit-appearance: none;
-	text-shadow:0 1px 0 rgba(0,0,0,0.4);
-	background-color: rgba(65,65,65,1);
-	color: #bfbfbc;
-	text-decoration: none;
-	padding: 2px 18px 2px 5px;
-	border:0.5px solid black;
-	margin: 2px 2px;
-	display: inline-block;
-	border-radius: 3px;
-	border-radius: 0px;
-	cursor: default;
-	font-family: -apple-system;
-	font-size: 13px;
-	width: 350px;
-}
-
-.sdActionButton {
-	padding: 5px 5px !important;
-}
-
-#speedEditorController {
-	font-weight: bold;
-}
-
 #speedEditorGroupControls {
 	min-height: 295px;
-}
-
-#speedEditorGroupControls .speedEditorGroup {
-	/* display: none; */
 }
 
 #speedEditorGroupControls .speedEditorGroup.selected {
 	display: block;
 }
 
-.speedEditorGroupSelect {
-	float: right;
-}
-
-/* ICON DROP ZONE: */
-
-.dropzone {
-  position: relative;
-  border: 2.5px dotted #FFF;
-  border-radius: 5px;
-  color: white;
-  font: bold 12px/50px arial;
-  height: 90px;
-  /* margin: 7.5px auto; */
-  text-align: center;
-  width: 90px;
-}
-
-.dropzone.hover {
-  border: 2.5px solid #5760e7;
-  color: #5760e7;
-}
-
-.dropzone.dropped {
-  background: #222;
-  border: 2.5px solid #444;
-}
-
-.dropzone div {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.dropzone img {
-  max-width: 100%;
-  max-height: 100%;
-  display: block;
-  margin: 0 auto;
-  height: 90px;
-}
-
-.dropzone [type="file"] {
-  cursor: pointer;
-  position: absolute;
-  opacity: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.touchButtonDropZone {
-  cursor: pointer;
-  position: absolute;
-  opacity: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  border: 0;
-  margin: 0;
-  font-size: 0;
-  border-image-width: 0;
-}
-
-.touchButtonDropZone::-webkit-file-upload-button {
-  visibility: hidden;
-}
-
-/* NEW STUFF */
+/* Speed Editor Panel */
 
 .speedEditor {
 	margin-top: 10px;
@@ -374,134 +169,18 @@ input[type="color"]::-webkit-color-swatch {
 	padding: 5px 5px !important;
 }
 
-/* ICON DROP ZONE: */
+/* Speed Editor User Interface */
 
-.dropzone {
-  position: relative;
-  border: 2.5px dotted #FFF;
-  border-radius: 5px;
-  color: white;
-  font: bold 12px/50px arial;
-  height: 90px;
-  /* margin: 7.5px auto; */
-  text-align: center;
-  width: 90px;
-}
-
-.dropzone.hover {
-  border: 2.5px solid #5760e7;
-  color: #5760e7;
-}
-
-.dropzone.dropped {
-  background: #222;
-  border: 2.5px solid #444;
-}
-
-.dropzone div {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.dropzone img {
-  max-width: 100%;
-  max-height: 100%;
-  display: block;
-  margin: 0 auto;
-  height: 90px;
-}
-
-.dropzone [type="file"] {
-  cursor: pointer;
-  position: absolute;
-  opacity: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.touchButtonDropZone {
-  cursor: pointer;
-  position: absolute;
-  opacity: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  border: 0;
-  margin: 0;
-  font-size: 0;
-  border-image-width: 0;
-}
-
-.touchButtonDropZone::-webkit-file-upload-button {
-  visibility: hidden;
-}
-
-/* User Interfaces */
-
-#speededitorOriginalUI {
-    display: inline-table;
-    background-color: black;
-}
-
-#speededitorMiniUI {
-    display: inline-table;
-    background-color: black;
-}
-
-#speededitorXLUI {
-    display: inline-table;
-    background-color: black;
-}
-
-#speededitorOriginalUI td {
-    width: 40px;
-    height: 40px;
-    min-width: 40px;
-    border-radius: 10px;
-    border: 2px #aaa solid;
-    background: #222;
-    overflow: none;
-    text-align: center;
-    color: #fff;
-    cursor: pointer;
-    pointer-events: auto;
-    background-size:contain;
-}
-
-#speededitorMiniUI td {
-    width: 40px;
-    height: 40px;
-    min-width: 40px;
-    border-radius: 10px;
-    border: 2px #aaa solid;
-    background: #222;
-    overflow: none;
-    text-align: center;
-    color: #fff;
-    cursor: pointer;
-    pointer-events: auto;
-    background-size:contain;
-}
-
-#speededitorXLUI td {
-    width: 40px;
-    height: 40px;
-    min-width: 40px;
-    border-radius: 10px;
-    border: 2px #aaa solid;
-    background: #222;
-    overflow: none;
-    text-align: center;
-    color: #fff;
-    cursor: pointer;
-    pointer-events: auto;
-    background-size:contain;
+#speedEditorUI {
+	position:relative;
+	left:0px;
+	top:0px;
+	width:447px;
+	height:482px;
+	font-size:0px;
+	background-image: url({* insertImage('images/speededitor.png') *});
+	background-repeat: no-repeat;
+	background-size: 447px 482px;
 }
 
 .seButton {

--- a/src/plugins/core/controlsurfaces/resolve/prefs/html/panel.html
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/html/panel.html
@@ -463,7 +463,7 @@
 	<thead>
 		<tr>
 			<th width="458px" style="text-align: center";>
-                <table id="speedEditorUI" width="447" height="482" border="0" cellpadding="0" cellspacing="0" style="background-image:url({* insertImage('images/speededitor.png') *});">
+                <table id="speedEditorUI" width="447" height="482" border="0" cellpadding="0" cellspacing="0" *});">
                     <tr>
                         <td width="447" height="139" colspan="27">
                     </tr>

--- a/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
@@ -1463,7 +1463,7 @@ function plugin.init(deps, env)
         label           = "Resolve",
         image           = imageFromPath(env:pathToAbsolute("images/resolve.icns")),
         tooltip         = i18n("daVinciResolve"),
-        height          = 960,
+        height          = 995,
     })
         :addHeading(1, i18n("daVinciResolveControlSurfaceSupport"))
         :addContent(2, [[

--- a/src/plugins/core/razer/prefs/css/razer_tartarus_v2.css
+++ b/src/plugins/core/razer/prefs/css/razer_tartarus_v2.css
@@ -8,6 +8,8 @@
 	height:625px;
 	font-size:0px;
 	background-image:url({* insertImage('images/razer_tartarus_v2.png') *});
+	background-repeat: no-repeat;
+	background-size: 429px 625px;
 }
 
 #razer_tartarus_v2_01 {

--- a/src/plugins/core/tourbox/prefs/css/tourbox.css
+++ b/src/plugins/core/tourbox/prefs/css/tourbox.css
@@ -164,6 +164,9 @@ input[type="color"]::-webkit-color-swatch {
 	height:403px;
 	font-size:0px;
 	background-image:url({* insertImage('images/background.png') *});
+	background-repeat: no-repeat;
+	background-size: 447px 403px;
+
 }
 
 #TourBox-01 {


### PR DESCRIPTION
- Fixed CSS issues with Speed Editor, Razer and Tourbox UI's.
- Removed unnecessary CSS from the Speed Editor code.
- "Automatically Switch Applications" for the Speed Editor is now enabled by default.
- Tweaked the default Speed Editor layout to turn all LEDs on and use Jog Wheel as mouse scroll wheel.
- Tweaked the orange tip text in the Speed Editor preferences panel.
- Fixed a bug in CommandPost-App which prevented settings LEDs for the CAM buttons on a Speed Editor.
- Closes #2887