### PR TITLE
Added Korean translation for "Show Horizon"

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/init.lua
+++ b/src/extensions/cp/apple/finalcutpro/init.lua
@@ -222,7 +222,7 @@ fcp.EVENT_DESCRIPTION_PATH = "/Contents/Frameworks/TLKit.framework/Versions/A/Re
 --- cp.apple.finalcutpro.FLEXO_LANGUAGES -> table
 --- Constant
 --- Table of Final Cut Pro's supported Languages for the Flexo Framework
-fcp.FLEXO_LANGUAGES	= Set("de", "en", "es_419", "es", "fr", "id", "ja", "ms", "vi", "zh_CN")
+fcp.FLEXO_LANGUAGES	= Set("de", "en", "es_419", "es", "fr", "id", "ja", "ms", "vi", "zh_CN", "ko")
 
 --- cp.apple.finalcutpro.ALLOWED_IMPORT_VIDEO_EXTENSIONS -> table
 --- Constant

--- a/src/extensions/cp/apple/finalcutpro/strings.lua
+++ b/src/extensions/cp/apple/finalcutpro/strings.lua
@@ -118,7 +118,7 @@ function mod:_bestVersion(locale, version)
     local prev = nil
 
     for _,ver in ipairs(versions) do
-        if ver < version then
+        if ver <= version then
             prev = ver
         end
         if ver > version then

--- a/src/extensions/cp/apple/finalcutpro/strings/de/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/de/10.4.0.strings
@@ -3,8 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPCodecs</key>
-    <string>Codecs</string>
     <key>CPShowHorizon</key>
     <string>Horizont einblenden</string>
 </dict>

--- a/src/extensions/cp/apple/finalcutpro/strings/en/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/en/10.4.0.strings
@@ -3,8 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPCodecs</key>
-    <string>Codecs</string>
     <key>CPShowHorizon</key>
     <string>Show Horizon</string>
 </dict>

--- a/src/extensions/cp/apple/finalcutpro/strings/es/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/es/10.4.0.strings
@@ -3,8 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPCodecs</key>
-    <string>Códecs</string>
     <key>CPShowHorizon</key>
     <string>Mostrar horizonte</string>
 </dict>

--- a/src/extensions/cp/apple/finalcutpro/strings/fr/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/fr/10.4.0.strings
@@ -3,8 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPCodecs</key>
-    <string>Codecs</string>
     <key>CPShowHorizon</key>
     <string>Afficher l’horizon</string>
 </dict>

--- a/src/extensions/cp/apple/finalcutpro/strings/ja/10.4.0.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/ja/10.4.0.strings
@@ -3,8 +3,6 @@
 <!-- Missing I18N keys values for FCPX. Generally prefixed with "CP" to avoid clashes with existing keys.  -->
 <plist version="1.0">
 <dict>
-    <key>CPCodecs</key>
-    <string>コーデック</string>
     <key>CPShowHorizon</key>
     <string>水平線を表示</string>
 </dict>

--- a/src/extensions/cp/apple/finalcutpro/strings/ko/10.6.2.strings
+++ b/src/extensions/cp/apple/finalcutpro/strings/ko/10.6.2.strings
@@ -4,6 +4,6 @@
 <plist version="1.0">
 <dict>
     <key>CPShowHorizon</key>
-    <string>显示水平</string>
+    <string>가로 보기</string>
 </dict>
 </plist>

--- a/src/plugins/finalcutpro/hud/panels/search/init.lua
+++ b/src/plugins/finalcutpro/hud/panels/search/init.lua
@@ -132,7 +132,8 @@ local function getColumnNames()
         ["Audio Configuration"] = fcp:string("Audio Channel Config"),
         ["File Type"] = fcp:string("file type"),
         ["Date Imported"] = fcp:string("Date Imported"),
-        ["Codecs"] = fcp:string("CPCodecs"),
+        ["Original Codecs"] =  fcp:string("Original Codecs"),
+        ["Proxy Codecs"] =  fcp:string("Proxy Codecs"),
         ["360° Mode"] = fcp:string("FFOrganizerFilterHUDFormatInfoSphericalType"),
         ["Stereoscopic Mode"] = fcp:string("FFMD3DStereoMode"),
     }


### PR DESCRIPTION
- Removed the "CPCodecs", as it's been replaced with "Original Codecs" and "Proxy Codecs".
- Added Korean to our list of Flexo Languages.
- Fixed bug in the strings "best version" code to allow for exact matches.
- Closes #2927