### PR TITLE
Fixed a bug in cp.localized

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/main/EffectsBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/EffectsBrowser.lua
@@ -26,6 +26,7 @@ local If                                = require "cp.rx.go.If"
 local WaitUntil                         = require "cp.rx.go.WaitUntil"
 
 local ninjaDoubleClick                  = tools.ninjaDoubleClick
+local upper                             = tools.upper
 
 local EffectsBrowser = Group:subclass("cp.apple.finalcutpro.main.EffectsBrowser")
 
@@ -378,8 +379,15 @@ end
 --- Returns:
 ---  * `axuielementObject` object.
 function EffectsBrowser:videoCategoryRowsUI()
-    local video = self:app():string("FFVideo"):upper()
-    local audio = self:app():string("FFAudio"):upper()
+    --------------------------------------------------------------------------------
+    -- NOTE: We have to use cp.tools.upper, because the built-in Lua :upper()
+    --       doesn't handle non-English characters very well. For example:
+    --
+    -- cp.apple.finalcutpro:string("FFVideo") = Vídeo
+    -- cp.tools.upper(cp.apple.finalcutpro:string("FFVideo")) = VÍDEO
+    --------------------------------------------------------------------------------
+    local video = upper(self:app():string("FFVideo"))
+    local audio = upper(self:app():string("FFAudio"))
 
     return self:_startEndRowsUI(video, audio)
 end

--- a/src/extensions/cp/localized/init.lua
+++ b/src/extensions/cp/localized/init.lua
@@ -63,7 +63,8 @@ local function readLocalizedStrings(stringsFile, name)
         --------------------------------------------------------------------------------
         -- PROPERTY LIST
         --
-        -- Example:
+        -- Examples:
+        --
         -- <?xml version="1.0" encoding="UTF-8"?>
         -- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         -- <plist version="1.0">
@@ -72,10 +73,23 @@ local function readLocalizedStrings(stringsFile, name)
         --  <string>Standardtitel</string>
         -- </dict>
         -- </plist>
+        --
+        -- <?xml version="1.0" encoding="UTF-8"?>
+        -- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        -- <plist version="1.0">
+        -- <dict>
+        -- 	<key>Black &amp; White</key>
+        -- 	<string>Blanco y negro</string>
+        -- </dict>
+        -- </plist>
         --------------------------------------------------------------------------------
         local contents = plist.read(stringsPath)
         if contents then
-            local localName = contents[escapeXML(name)]
+            --------------------------------------------------------------------------------
+            -- NOTE: hs.plist.read seems to already unescape the key, so first we'll try
+            --       a plain text version, then we'll try the escapeXML version.
+            --------------------------------------------------------------------------------
+            local localName = contents[name] or contents[escapeXML(name)]
             return localName and unescapeXML(localName)
         --------------------------------------------------------------------------------
         -- PLAIN TEXT


### PR DESCRIPTION
- Fixed a bug in `cp.localized()` which prevented translations with escaped characters (i.e. `&amp;`) to fail.
- Fixed a bug in the Effects Browser that caused selecting the Video Category to fail in Spanish, due to incorrect uppercase characters.
- Closes #2935
- Closes #2936