### PR TITLE
Improved Resolve Keyboard Jog Wheel Caching

### DIFF
--- a/src/plugins/core/controlsurfaces/resolve/manager/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/manager/init.lua
@@ -229,11 +229,6 @@ local shouldKillLEDCacheDueToResolve = false
 -- Jog Wheel Cache
 local speedEditorJogWheelCache = {}
 
--- jogModeOnDeviceCache -> table
--- Variable
--- Jog Mode Cache
-local jogModeOnDeviceCache = {}
-
 --- plugins.core.resolve.manager.buttonCallback(object, buttonID, pressed) -> none
 --- Function
 --- Control Surface Button Callback
@@ -265,14 +260,6 @@ function mod.buttonCallback(object, buttonID, pressed, jogWheelMode, jogWheelVal
     local serialNumber = object:serialNumber()
     local deviceType = object:deviceType()
     local deviceID = mod.deviceOrder[deviceType][serialNumber]
-
-    --------------------------------------------------------------------------------
-    -- Update the Jog Mode Cache if required:
-    --------------------------------------------------------------------------------
-    local jogModeOnDeviceCacheID = deviceType .. deviceID
-    if jogWheelMode then
-        jogModeOnDeviceCache[jogModeOnDeviceCacheID] = jogWheelMode
-    end
 
     local frontmostApplication = application.frontmostApplication()
     local bundleID = frontmostApplication:bundleID()
@@ -724,14 +711,10 @@ function mod.update()
             --------------------------------------------------------------------------------
             -- Update Jog Wheel Mode (only if needed):
             --------------------------------------------------------------------------------
-            local jogModeOnDeviceCacheID = deviceType .. deviceID
+            local _, currentJogMode = device:jogMode()
             local jogMode = (bankData and bankData.jogMode) or mod.DEFAULT_JOG_MODE
-            if jogModeOnDeviceCache[jogModeOnDeviceCacheID] ~= jogMode then
+            if currentJogMode ~= jogMode then
                 device:jogMode(jogMode)
-                jogModeOnDeviceCache[jogModeOnDeviceCacheID] = jogMode
-                --log.df("CHANGING JOG MODE TO: %s", jogMode)
-            --else
-                --log.df("ALREADY IN JOG MODE: %s", jogMode)
             end
 
             --------------------------------------------------------------------------------
@@ -907,11 +890,6 @@ end
 --- Returns:
 ---  * None
 function mod.stop()
-    --------------------------------------------------------------------------------
-    -- Kill the Jog Mode Cache:
-    --------------------------------------------------------------------------------
-    jogModeOnDeviceCache = {}
-
     --------------------------------------------------------------------------------
     -- Kill the LED cache:
     --------------------------------------------------------------------------------

--- a/src/plugins/core/controlsurfaces/resolve/manager/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/manager/init.lua
@@ -53,7 +53,6 @@ local JOG_WHEEL_ABSOLUTE_TWO = {
 -- JOG_WHEEL_ABSOLUTE_THREE -> table
 -- Constant
 -- Jog Wheel Trigger
-
 local JOG_WHEEL_ABSOLUTE_THREE = {
     ["Speed Editor"]    = 2040,
     ["Editor Keyboard"] = 2040,
@@ -230,6 +229,11 @@ local shouldKillLEDCacheDueToResolve = false
 -- Jog Wheel Cache
 local speedEditorJogWheelCache = {}
 
+-- jogModeOnDeviceCache -> table
+-- Variable
+-- Jog Mode Cache
+local jogModeOnDeviceCache = {}
+
 --- plugins.core.resolve.manager.buttonCallback(object, buttonID, pressed) -> none
 --- Function
 --- Control Surface Button Callback
@@ -261,6 +265,14 @@ function mod.buttonCallback(object, buttonID, pressed, jogWheelMode, jogWheelVal
     local serialNumber = object:serialNumber()
     local deviceType = object:deviceType()
     local deviceID = mod.deviceOrder[deviceType][serialNumber]
+
+    --------------------------------------------------------------------------------
+    -- Update the Jog Mode Cache if required:
+    --------------------------------------------------------------------------------
+    local jogModeOnDeviceCacheID = deviceType .. deviceID
+    if jogWheelMode then
+        jogModeOnDeviceCache[jogModeOnDeviceCacheID] = jogWheelMode
+    end
 
     local frontmostApplication = application.frontmostApplication()
     local bundleID = frontmostApplication:bundleID()
@@ -613,8 +625,6 @@ function mod.buttonCallback(object, buttonID, pressed, jogWheelMode, jogWheelVal
 
 end
 
-local jogModeOnDeviceCache = {}
-
 --- plugins.core.resolve.manager.update() -> none
 --- Function
 --- Updates all the control surface LEDs.
@@ -720,6 +730,8 @@ function mod.update()
                 device:jogMode(jogMode)
                 jogModeOnDeviceCache[jogModeOnDeviceCacheID] = jogMode
                 --log.df("CHANGING JOG MODE TO: %s", jogMode)
+            --else
+                --log.df("ALREADY IN JOG MODE: %s", jogMode)
             end
 
             --------------------------------------------------------------------------------
@@ -895,6 +907,11 @@ end
 --- Returns:
 ---  * None
 function mod.stop()
+    --------------------------------------------------------------------------------
+    -- Kill the Jog Mode Cache:
+    --------------------------------------------------------------------------------
+    jogModeOnDeviceCache = {}
+
     --------------------------------------------------------------------------------
     -- Kill the LED cache:
     --------------------------------------------------------------------------------

--- a/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
@@ -1085,7 +1085,6 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                             end
                         end
 
-                        local userApps = {}
                         local items = mod.items()
                         for _, device in pairs(items) do
                             for _, unit in pairs(device) do
@@ -1164,10 +1163,9 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                             end
                         end
 
-                        local userApps = {}
-                        local items = mod.items()
-                        for _, device in pairs(items) do
-                            for _, unit in pairs(device) do
+                        local i = mod.items()
+                        for _, d in pairs(i) do
+                            for _, unit in pairs(d) do
                                 for bundleID, v in pairs(unit) do
                                     if v.displayName then
                                         if lastApplication == bundleID then
@@ -1248,11 +1246,10 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                             end
                         end
 
-                        local userApps = {}
-                        local items = mod.items()
-                        for _, device in pairs(items) do
-                            for _, unit in pairs(device) do
-                                for bundleID, v in pairs(unit) do
+                        local i = mod.items()
+                        for _, d in pairs(i) do
+                            for _, u in pairs(d) do
+                                for bundleID, v in pairs(u) do
                                     if v.displayName then
                                         if lastApplication == bundleID then
                                             validApp = true
@@ -1333,11 +1330,10 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                             end
                         end
 
-                        local userApps = {}
-                        local items = mod.items()
-                        for _, device in pairs(items) do
-                            for _, unit in pairs(device) do
-                                for bundleID, v in pairs(unit) do
+                        local i = mod.items()
+                        for _, d in pairs(i) do
+                            for _, u in pairs(d) do
+                                for bundleID, v in pairs(u) do
                                     if v.displayName then
                                         if lastApplication == bundleID then
                                             validApp = true

--- a/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
@@ -105,6 +105,11 @@ local function renderPanel(context)
     return mod._renderPanel(context)
 end
 
+-- imageCache -> table
+-- Variable
+-- An image cache for objects we encode as URL strings
+local imageCache = {}
+
 -- insertImage(path)
 -- Function
 -- Encodes an image as a PNG URL String
@@ -115,9 +120,15 @@ end
 -- Returns:
 --  * The encoded URL string
 local function insertImage(path)
-    local p = mod._env:pathToAbsolute(path)
-    local i = imageFromPath(p)
-    return i:encodeAsURLString(false, "PNG")
+    if not imageCache[path] then
+        local p = mod._env:pathToAbsolute(path)
+        local i = imageFromPath(p)
+        local data = i:encodeAsURLString(false, "PNG")
+        imageCache[path] = data
+        return data
+    else
+        return imageCache[path]
+    end
 end
 
 -- generateContent() -> string
@@ -186,7 +197,6 @@ end
 -- Returns:
 --  * None
 local function updateUI(params)
-
     --------------------------------------------------------------------------------
     -- Get parameters from table or from saved data:
     --------------------------------------------------------------------------------
@@ -835,6 +845,8 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                     local info = path and infoForBundlePath(path)
                     local displayName = info and info.CFBundleDisplayName or info.CFBundleName or info.CFBundleExecutable
                     local bundleID = info and info.CFBundleIdentifier
+                    local applicationAdded = false
+
                     if displayName and bundleID then
                         local items = mod.items()
 
@@ -868,15 +880,29 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                             end
                         end
 
-                        if not items["Original"] then items["Original"] = {} end
-                        if not items["Original"]["1"] then items["Original"]["1"] = {} end
-                        if not items["Original"]["1"][bundleID] then items["Original"]["1"][bundleID] = {} end
+                        if not items[device] then items[device] = {} end
+                        if not items[device]["1"] then items[device]["1"] = {} end
+                        if not items[device]["1"][bundleID] then items[device]["1"][bundleID] = {} end
 
-                        items["Original"]["1"][bundleID].displayName = displayName
+                        items[device]["1"][bundleID].displayName = displayName
 
                         mod.items(items)
-                    else
-                        webviewAlert(mod._manager.getWebview(), function() end, i18n("failedToAddCustomApplication"), i18n("failedToAddCustomApplicationDescription"), i18n("ok"))
+
+                        --------------------------------------------------------------------------------
+                        -- Change last application:
+                        --------------------------------------------------------------------------------
+                        mod.lastApplication(bundleID)
+
+                        applicationAdded = true
+                    end
+
+                    if not applicationAdded then
+                        webviewAlert(mod._manager.getWebview(), function()
+                            --------------------------------------------------------------------------------
+                            -- Update the UI:
+                            --------------------------------------------------------------------------------
+                            mod._manager.refresh()
+                        end, i18n("failedToAddCustomApplication"), i18n("failedToAddCustomApplicationDescription"), i18n("ok"))
                         log.ef("Something went wrong trying to add a custom application.\n\nPath: '%s'\nbundleID: '%s'\ndisplayName: '%s'",path, bundleID, displayName)
                     end
 
@@ -1044,6 +1070,41 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                         end
 
                         --------------------------------------------------------------------------------
+                        -- Make sure the application is still valid:
+                        --------------------------------------------------------------------------------
+                        local lastApplication = mod.lastApplication()
+                        local validApp = false
+
+                        local registeredApps = mod._appmanager.getApplications()
+                        for bundleID, v in pairs(registeredApps) do
+                            if v.displayName then
+                                if lastApplication == bundleID then
+                                    validApp = true
+                                    break
+                                end
+                            end
+                        end
+
+                        local userApps = {}
+                        local items = mod.items()
+                        for _, device in pairs(items) do
+                            for _, unit in pairs(device) do
+                                for bundleID, v in pairs(unit) do
+                                    if v.displayName then
+                                        if lastApplication == bundleID then
+                                            validApp = true
+                                            break
+                                        end
+                                    end
+                                end
+                            end
+                        end
+
+                        if not validApp then
+                            mod.lastApplication("All Applications")
+                        end
+
+                        --------------------------------------------------------------------------------
                         -- Refresh the entire UI, as Custom Apps will now be gone:
                         --------------------------------------------------------------------------------
                         mod._manager.refresh()
@@ -1086,7 +1147,46 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                         end
 
                         mod.items(items)
-                        updateUI(params)
+
+                        --------------------------------------------------------------------------------
+                        -- Make sure the application is still valid:
+                        --------------------------------------------------------------------------------
+                        local lastApplication = mod.lastApplication()
+                        local validApp = false
+
+                        local registeredApps = mod._appmanager.getApplications()
+                        for bundleID, v in pairs(registeredApps) do
+                            if v.displayName then
+                                if lastApplication == bundleID then
+                                    validApp = true
+                                    break
+                                end
+                            end
+                        end
+
+                        local userApps = {}
+                        local items = mod.items()
+                        for _, device in pairs(items) do
+                            for _, unit in pairs(device) do
+                                for bundleID, v in pairs(unit) do
+                                    if v.displayName then
+                                        if lastApplication == bundleID then
+                                            validApp = true
+                                            break
+                                        end
+                                    end
+                                end
+                            end
+                        end
+
+                        if not validApp then
+                            mod.lastApplication("All Applications")
+                        end
+
+                        --------------------------------------------------------------------------------
+                        -- Refresh the entire UI, as Custom Apps may now be gone:
+                        --------------------------------------------------------------------------------
+                        mod._manager.refresh()
                     end
                 end, i18n("daVinciResolveControlSurfaceResetDeviceConfirmation"), i18n("doYouWantToContinue"), i18n("yes"), i18n("no"), "informational")
             end
@@ -1131,7 +1231,46 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                         end
 
                         mod.items(items)
-                        updateUI(params)
+
+                        --------------------------------------------------------------------------------
+                        -- Make sure the application is still valid:
+                        --------------------------------------------------------------------------------
+                        local lastApplication = mod.lastApplication()
+                        local validApp = false
+
+                        local registeredApps = mod._appmanager.getApplications()
+                        for bundleID, v in pairs(registeredApps) do
+                            if v.displayName then
+                                if lastApplication == bundleID then
+                                    validApp = true
+                                    break
+                                end
+                            end
+                        end
+
+                        local userApps = {}
+                        local items = mod.items()
+                        for _, device in pairs(items) do
+                            for _, unit in pairs(device) do
+                                for bundleID, v in pairs(unit) do
+                                    if v.displayName then
+                                        if lastApplication == bundleID then
+                                            validApp = true
+                                            break
+                                        end
+                                    end
+                                end
+                            end
+                        end
+
+                        if not validApp then
+                            mod.lastApplication("All Applications")
+                        end
+
+                        --------------------------------------------------------------------------------
+                        -- Refresh the entire UI, as Custom Apps may now be gone:
+                        --------------------------------------------------------------------------------
+                        mod._manager.refresh()
                     end
                 end, i18n("daVinciResolveControlSurfaceResetUnitConfirmation"), i18n("doYouWantToContinue"), i18n("yes"), i18n("no"), "informational")
             end
@@ -1177,7 +1316,46 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
                         end
 
                         mod.items(items)
-                        updateUI(params)
+
+                        --------------------------------------------------------------------------------
+                        -- Make sure the application is still valid:
+                        --------------------------------------------------------------------------------
+                        local lastApplication = mod.lastApplication()
+                        local validApp = false
+
+                        local registeredApps = mod._appmanager.getApplications()
+                        for bundleID, v in pairs(registeredApps) do
+                            if v.displayName then
+                                if lastApplication == bundleID then
+                                    validApp = true
+                                    break
+                                end
+                            end
+                        end
+
+                        local userApps = {}
+                        local items = mod.items()
+                        for _, device in pairs(items) do
+                            for _, unit in pairs(device) do
+                                for bundleID, v in pairs(unit) do
+                                    if v.displayName then
+                                        if lastApplication == bundleID then
+                                            validApp = true
+                                            break
+                                        end
+                                    end
+                                end
+                            end
+                        end
+
+                        if not validApp then
+                            mod.lastApplication("All Applications")
+                        end
+
+                        --------------------------------------------------------------------------------
+                        -- Refresh the entire UI, as Custom Apps may now be gone:
+                        --------------------------------------------------------------------------------
+                        mod._manager.refresh()
                     end
                 end, i18n("daVinciResolveControlSurfaceResetApplicationConfirmation"), i18n("doYouWantToContinue"), i18n("yes"), i18n("no"), "informational")
             end

--- a/src/plugins/core/razer/prefs/init.lua
+++ b/src/plugins/core/razer/prefs/init.lua
@@ -97,6 +97,11 @@ local function renderPanel(context)
     return mod._renderPanel(context)
 end
 
+-- imageCache -> table
+-- Variable
+-- An image cache for objects we encode as URL strings
+local imageCache = {}
+
 -- insertImage(path)
 -- Function
 -- Encodes an image as a PNG URL String
@@ -107,9 +112,15 @@ end
 -- Returns:
 --  * The encoded URL string
 local function insertImage(path)
-    local p = mod._env:pathToAbsolute(path)
-    local i = imageFromPath(p)
-    return i:encodeAsURLString(false, "PNG")
+    if not imageCache[path] then
+        local p = mod._env:pathToAbsolute(path)
+        local i = imageFromPath(p)
+        local data = i:encodeAsURLString(false, "PNG")
+        imageCache[path] = data
+        return data
+    else
+        return imageCache[path]
+    end
 end
 
 -- generateContent() -> string

--- a/src/plugins/core/tourbox/prefs/init.lua
+++ b/src/plugins/core/tourbox/prefs/init.lua
@@ -85,6 +85,11 @@ local function renderPanel(context)
     return mod._renderPanel(context)
 end
 
+-- imageCache -> table
+-- Variable
+-- An image cache for objects we encode as URL strings
+local imageCache = {}
+
 -- insertImage(path)
 -- Function
 -- Encodes an image as a PNG URL String
@@ -95,9 +100,15 @@ end
 -- Returns:
 --  * The encoded URL string
 local function insertImage(path)
-    local p = mod._env:pathToAbsolute(path)
-    local i = imageFromPath(p)
-    return i:encodeAsURLString(false, "PNG")
+    if not imageCache[path] then
+        local p = mod._env:pathToAbsolute(path)
+        local i = imageFromPath(p)
+        local data = i:encodeAsURLString(false, "PNG")
+        imageCache[path] = data
+        return data
+    else
+        return imageCache[path]
+    end
 end
 
 -- generateContent() -> string


### PR DESCRIPTION
- The jog wheel cache is now cleared when we "stop" Resolve keyboard support, and we update the cache when the jog wheel is triggered.
- Added an image cache to the Resolve, Razer and TourBox preferences panel for performance.
- When you add a custom application to the Resolve Keyboards, it now automatically selects that application once added.
- If you delete an application, device or everything on the Resolve Keyboard panel, it now resets the "last application" if that custom application no longer exists in the preferences file.
- Closes #2945
- Closes #2946