### PR TITLE
Added a "Relative (Fine Control)" Jog Wheel Mode for Resolve Keyboards

### DIFF
--- a/src/extensions/languages/English_en.json
+++ b/src/extensions/languages/English_en.json
@@ -1772,6 +1772,7 @@
     "rejected": "Rejected",
     "relative": "Relative",
     "relativeA": "Relative A",
+    "relativeFineControl": "Relative (Fine Control)",
     "release": "Release",
     "releaseAction": "Release Action",
     "releaseActionDownModifier": "Release Action (Down Modifier)",

--- a/src/plugins/core/controlsurfaces/resolve/prefs/html/panel.html
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/html/panel.html
@@ -959,6 +959,21 @@
 									<option value="11000">13</option>
 									<option value="12000">14</option>
 									<option value="13000">15</option>
+									<option value="14000">16</option>
+									<option value="15000">17</option>
+									<option value="16000">18</option>
+									<option value="17000">19</option>
+									<option value="18000">20</option>
+									<option value="19000">21</option>
+									<option value="20000">22</option>
+									<option value="21000">23</option>
+									<option value="22000">24</option>
+									<option value="23000">25</option>
+									<option value="24000">26</option>
+									<option value="25000">27</option>
+									<option value="26000">28</option>
+									<option value="27000">29</option>
+									<option value="28000">30</option>
 								</select>
 							</td>
 						</tr>

--- a/src/plugins/core/controlsurfaces/resolve/prefs/html/panel.html
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/html/panel.html
@@ -903,6 +903,7 @@
 							<td width="229px">
 								<select id="jogMode" style="width: 210px;" onchange="changeJogMode()">
     								<option value="RELATIVE">{{ i18n("relative") }}</option>
+    								<option value="RELATIVE FINE CONTROL">{{ i18n("relativeFineControl") }}</option>
 									<option value="ABSOLUTE">{{ i18n("absolute") }}</option>
 									<option value="ABSOLUTE ZERO">{{ i18n("absoluteSnapsToZero") }}</option>
 								</select>


### PR DESCRIPTION
- Added a new "Relative (Fine Control)" option to the Resolve Keyboard Jog Wheel Mode which uses a different algorithm.
- Increased the amount of sensitivity options.
- Added a timer to reset the LED lights every 5mins to hopefully keep the device awake.
- Closes [#2963](https://github.com/CommandPost/CommandPost/issues/2963)