### PR TITLE
Issue/2990-timeline-toolbar

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/timeline/ToolPalette.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/ToolPalette.lua
@@ -1,0 +1,230 @@
+--- === cp.apple.finalcutpro.timeline.ToolPalette ===
+---
+--- Represents the Tool Palette Menu Button in the Timeline.
+---
+--- Extends:
+--- * [MenuButton](cp.ui.MenuButton.md)
+
+local require                   = require
+
+-- local log                       = require "hs.logger".new "ToolPalette"
+
+local MenuButton                = require "cp.ui.MenuButton"
+local strings                   = require "cp.apple.finalcutpro.strings"
+
+local ToolPalette = MenuButton:subclass("cp.apple.finalcutpro.timeline.ToolPalette")
+
+-- Note: Because this button has an icon label, not text, they are all blank strings.
+-- As such, we have to check the value by reading the AXHelp value of the MenuButton.
+-- This gives us a localized string
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.OPTIONS <table of tables>
+--- Constant
+--- The options for the Tool Palette Menu Button.
+---
+--- Notes:
+--- * Contains `SELECT`, `TRIM`, `POSITION`, `RANGE`, `BLADE`, `ZOOM`, and `HAND`.
+ToolPalette.static.OPTIONS = {
+    SELECT = {
+        AXHelpKey = "FFArrowToolTip",
+        AXIdentifier = "selectToolArrowOrRangeSelection:",
+    },
+    TRIM = {
+        AXHelpKey = "FFTrimToolTip",
+        AXIdentifier = "selectToolTrim:",
+    },
+    POSITION = {
+        AXHelpKey = "FFPositionToolTip",
+        AXIdentifier = "selectToolPlacement:",
+    },
+    RANGE = {
+        AXHelpKey = "FFRangeSelectionToolTip",
+        AXIdentifier = "selectToolRangeSelection:",
+    },
+    BLADE = {
+        AXHelpKey = "FFBladeToolTip",
+        AXIdentifier = "selectToolBlade:",
+    },
+    ZOOM = {
+        AXHelpKey = "FFZoomToolTip",
+        AXIdentifier = "selectToolZoom:",
+    },
+    HAND = {
+        AXHelpKey = "FFHandToolTip",
+        AXIdentifier = "selectToolHand:",
+    },
+}
+
+-- findOption(axHelp) -> table | nil
+-- Function
+-- Returns the option for the given AXHelp value.
+--
+-- Parameters:
+--  * axHelp - The AXHelp value to find.
+--
+-- Returns:
+--  * The option for the given AXHelp value.
+function ToolPalette.static.findOption(axHelp)
+    for _, option in pairs(ToolPalette.OPTIONS) do
+        local helpValue = strings:find(option.AXHelpKey)
+        -- check if axHelp starts with the helpValue
+        if axHelp:sub(1, #helpValue) == helpValue then
+            return option
+        end
+    end
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.value <cp.prop: ToolPalette.OPTIONS, live?, read-write>
+--- Field
+--- A `cp.prop` containing the current [OPTIONS](#OPTIONS) value of the Tool Palette. May be `nil` if the toolbar is not available.
+function ToolPalette.lazy.prop:value()
+    -- mutate the UI
+    return self.UI:mutate(
+        function(original)
+            local ui = original()
+            if ui then
+                return ToolPalette.findOption(ui.AXHelp)
+            end
+        end,
+        -- when setting, match the option table to the menu that matches the AXIdentifier
+        function(newValue, original)
+            local ui = original()
+            if not ui then return end
+
+            local currentValue = original:get()
+            if currentValue == newValue then return end
+
+            local items = ui:performAction("AXPress")[1]
+            if not items then return end
+
+            local valueIdentifier = newValue.AXIdentifier
+            for _, item in ipairs(items.AXChildren) do
+                if item.AXIdentifier == valueIdentifier then
+                    item:performAction("AXPress")
+                    return
+                end
+            end
+            items:performAction("AXCancel")
+        end
+    )
+    -- if anyone starts watching, then register with the app notifier.
+    :preWatch(function(_,thisProp)
+        self:app():notifier():watchFor("AXMenuItemSelected", function()
+            thisProp:update()
+        end)
+    end)
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isSelect <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `SELECT` option.
+function ToolPalette.lazy.prop:isSelect()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.SELECT
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.SELECT)
+            end
+        end
+    )
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isTrim <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `TRIM` option.
+function ToolPalette.lazy.prop:isTrim()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.TRIM
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.TRIM)
+            end
+        end
+    )
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isPosition <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `POSITION` option.
+function ToolPalette.lazy.prop:isPosition()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.POSITION
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.POSITION)
+            end
+        end
+    )
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isRange <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `RANGE` option.
+function ToolPalette.lazy.prop:isRange()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.RANGE
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.RANGE)
+            end
+        end
+    )
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isBlade <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `BLADE` option.
+function ToolPalette.lazy.prop:isBlade()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.BLADE
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.BLADE)
+            end
+        end
+    )
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isZoom <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `ZOOM` option.
+function ToolPalette.lazy.prop:isZoom()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.ZOOM
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.ZOOM)
+            end
+        end
+    )
+end
+
+--- cp.apple.finalcutpro.timeline.ToolPalette.isHand <cp.prop: boolean>
+--- Field
+--- A `cp.prop` that indicates if the Tool Palette is set to the `HAND` option.
+function ToolPalette.lazy.prop:isHand()
+    return self.value:mutate(
+        function(original)
+            return original() == ToolPalette.OPTIONS.HAND
+        end,
+        function(newValue, original)
+            if newValue then
+                original:set(ToolPalette.OPTIONS.HAND)
+            end
+        end
+    )
+end
+
+return ToolPalette

--- a/src/extensions/cp/apple/finalcutpro/timeline/Toolbar.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Toolbar.lua
@@ -2,9 +2,10 @@
 ---
 --- Timeline Toolbar
 
-local require = require
+local require                           = require
 
-local axutils							= require "cp.ui.axutils"
+local fn                                = require "cp.fn"
+local ax                                = require "cp.fn.ax"
 
 local Button                            = require "cp.ui.Button"
 local CheckBox                          = require "cp.ui.CheckBox"
@@ -14,13 +15,17 @@ local RadioButton						= require "cp.ui.RadioButton"
 local RadioGroup                        = require "cp.ui.RadioGroup"
 local StaticText                        = require "cp.ui.StaticText"
 
-local Appearance				        = require "cp.apple.finalcutpro.timeline.Appearance"
+local delegator                         = require "cp.delegator"
 
-local cache                             = axutils.cache
-local childFromLeft, childFromRight     = axutils.childFromLeft, axutils.childFromRight
-local childMatching                     = axutils.childMatching
+local Appearance				        = require "cp.apple.finalcutpro.timeline.Appearance"
+local ToolPalette                       = require "cp.apple.finalcutpro.timeline.ToolPalette"
+
+local chain                             = fn.chain
+local cache, childMatching              = ax.cache, ax.childMatching
 
 local Toolbar = Group:subclass("cp.apple.finalcutpro.timeline.Toolbar")
+    :include(delegator)
+    :delegateTo("clip", "browser") -- allow properties of `clip` and `browser` to be accessed directly
 
 --- cp.apple.finalcutpro.timeline.Toolbar.matches(element) -> boolean
 --- Function
@@ -45,11 +50,11 @@ end
 --- Returns:
 --- * The new Toolbar instance.
 function Toolbar:initialize(timeline)
-    local UI = timeline.UI:mutate(function(original)
-        return cache(self, "_ui", function()
-            return childMatching(original(), Toolbar.matches) -- _NS:237 in FCPX 10.4
-        end, Toolbar.matches)
-    end)
+    local UI = timeline.UI:mutate(
+        cache(self, "_ui", Toolbar.matches)(
+            childMatching(Toolbar.matches)
+        )
+    )
 
     Group.initialize(self, timeline, UI)
 end
@@ -64,107 +69,283 @@ end
 --- Field
 --- The [CheckBox](cp.ui.CheckBox.md) which indicates if the Timeline Index is visible.
 function Toolbar.lazy.value:index()
-    return CheckBox(self, self.UI:mutate(function(original)
-        return cache(self, "_index", function()
-            return childFromLeft(original(), 1, CheckBox.matches)
-        end, CheckBox.matches)
-    end))
+    return CheckBox(self, self.UI:mutate(
+        cache(self, "_index", CheckBox.matches)(
+            chain // childMatching(CheckBox.matches, 1, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.cp.apple.finalcutpro.timeline.Timeline.connectClip <cp.ui.Button>
+--- Field
+--- The [Button](cp.ui.Button.md) which connects a clip from the Browser to the Primary Storyline in the Timeline.
+function Toolbar.lazy.value:connectClip()
+    return Button(self, self.UI:mutate(
+        cache(self, "_connectClip", Button.matches)(
+            childMatching(Button.matches, 1, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.insertClip <cp.ui.Button>
+--- Field
+--- The [Button](cp.ui.Button.md) which inserts a clip from the Browser into the Timeline.
+function Toolbar.lazy.value:insertClip()
+    return Button(self, self.UI:mutate(
+        cache(self, "_insertClip", Button.matches)(
+            childMatching(Button.matches, 2, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.appendClip <cp.ui.Button>
+--- Field
+--- The [Button](cp.ui.Button.md) which appends a clip from the Browser into the Timeline.
+function Toolbar.lazy.value:appendClip()
+    return Button(self, self.UI:mutate(
+        cache(self, "_appendClip", Button.matches)(
+            childMatching(Button.matches, 3, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.overwriteClip <cp.ui.Button>
+--- Field
+--- The [Button](cp.ui.Button.md) which overwrites a clip from the Browser into the Timeline.
+function Toolbar.lazy.value:overwriteClip()
+    return Button(self, self.UI:mutate(
+        cache(self, "_overwriteClip", Button.matches)(
+            childMatching(Button.matches, 4, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.clipMedia <cp.ui.MenuButton>
+--- Field
+--- The [MenuButton](cp.ui.MenuButton.md) which allows the user to select the media type that will
+--- be connected/inserted/appended/overwritten into the Timeline.
+function Toolbar.lazy.value:clipMedia()
+    return MenuButton(self, self.UI:mutate(
+        cache(self, "_clipMedia", MenuButton.matches)(
+            chain // childMatching(Group.matches, 1, ax.leftToRight) >> childMatching(MenuButton.matches)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.toolPalette <cp.apple.finalcutpro.timeline.ToolPalette>
+--- Field
+--- The [ToolPalette](cp.apple.finalcutpro.timeline.ToolPalette.md), which allows the user to select the tool
+--- that is being used to manipulate the timeline at present.
+function Toolbar.lazy.value:toolPalette()
+    return ToolPalette(self, self.UI:mutate(
+        cache(self, "_toolPalette", ToolPalette.matches)(
+            chain // childMatching(Group.matches, 2, ax.leftToRight) >> childMatching(ToolPalette.matches)
+        )
+    ))
 end
 
 --- cp.apple.finalcutpro.timeline.Toolbar.back <cp.ui.Button>
 --- Field
 --- The [Button](cp.ui.Button.md) for "go back in timeline history".
 function Toolbar.lazy.value:back()
-    return Button(self, self.UI:mutate(function(original)
-        return cache(self, "_back", function()
-            return childFromLeft(original(), 5, Button.matches)
-        end, Button.matches)
-    end))
+    return Button(self, self.UI:mutate(
+        cache(self, "_back", Button.matches)(
+            childMatching(Button.matches, 5, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.title <cp.ui.MenuButton>
+--- Field
+--- The [MenuButton](cp.ui.MenuButton.md) which lists the current project and allows
+--- the user to switch select actions to perform with this project.
+function Toolbar.lazy.value:title()
+    return MenuButton(self, self.UI:mutate(
+        cache(self, "_title", MenuButton.matches)(
+            childMatching(MenuButton.matches, 1, ax.leftToRight)
+        )
+    ))
+end
+
+
+--- cp.apple.finalcutpro.timeline.Toolbar.duration <cp.ui.StaticText>
+--- Field
+--- The [StaticText](cp.ui.StaticText.md) which displays the duration of the Timeline.
+--- It may contain a single timecode, in which case it is the timecode for the current project/sequence.
+--- Alternately, it may contain two timelines, separated by " / ", in which case it is the duration of the
+--- currently selected clips, then the current project/sequence duration.
+function Toolbar.lazy.value:duration()
+    return StaticText(self, self.UI:mutate(
+        cache(self, "_duration", StaticText.matches)(
+            childMatching(StaticText.matches, 1, ax.leftToRight)
+        )
+    ))
 end
 
 --- cp.apple.finalcutpro.timeline.Toolbar.forward <cp.ui.Button>
 --- Field
 --- The [Button](cp.ui.Button.md) for "go forward in timeline history".
 function Toolbar.lazy.value:forward()
-    return Button(self, self.UI:mutate(function(original)
-        return cache(self, "_forward", function()
-            return childFromLeft(original(), 6, Button.matches)
-        end, Button.matches)
-    end))
+    return Button(self, self.UI:mutate(
+        cache(self, "_forward", Button.matches)(
+            childMatching(Button.matches, 6, ax.leftToRight)
+        )
+    ))
 end
 
---- === cp.apple.finalcutpro.timeline.Toolbar.Skimming ===
+--- cp.apple.finalcutpro.timeline.Toolbar.clip <cp.apple.finalcutpro.timeline.Toolbar.Clip>
+--- Field
+--- The [Clip](cp.apple.finalcutpro.timeline.Toolbar.Clip.md) group of checkbox items.
+function Toolbar.lazy.value:clip()
+    return Toolbar.Clip(self)
+end
+
+-----------------------------------------------------------------------
+-- NOTE: These are "delegated" to via the `clip` field.
+-----------------------------------------------------------------------
+
+--- cp.apple.finalcutpro.timeline.Toolbar.trimAlignedEdges <cp.ui.CheckBox>
+--- Field
+--- The [CheckBox](cp.ui.CheckBox.md) which allows the user to trim the edges of the selected clips.
 ---
---- Provides access to mouse/trackpad skimming options.
+--- Notes:
+--- * As of FCP 10.6.3, this is currently always hidden, and cannot have its value changed.
+--- * Uncertain in exactly which version this turned up.
 
-Toolbar.static.Skimming = Group:subclass("cp.apple.finalcutpro.timeline.Toolbar.Skimming")
+--- cp.apple.finalcutpro.timeline.Toolbar.skimming <cp.ui.CheckBox>
+--- Field
+--- The [CheckBox](cp.ui.CheckBox.md) that indicates if video/audio skimming is active.
 
--- cp.apple.finalcutpro.timeline.Toolbar.Skimming(toolbar) -> Toolbar.Skimming
+--- cp.apple.finalcutpro.timeline.Toolbar.audioSkimming <cp.ui.CheckBox>
+--- Field
+--- The [CheckBox](cp.ui.CheckBox.md) that indicates if audio is played while skimming.
+
+--- cp.apple.finalcutpro.timeline.Toolbar.solo <cp.ui.CheckBox>
+--- Field
+--- The [CheckBox](cp.ui.CheckBox.md) that indicates if audio is soloed on the selected clip(s).
+
+--- cp.apple.finalcutpro.timeline.Toolbar.snapping <cp.ui.CheckBox>
+--- Field
+--- The [CheckBox](cp.ui.CheckBox.md) that indicates if snapping is enabled.
+
+--- cp.apple.finalcutpro.timeline.Toolbar.appearanceToggle <cp.ui.CheckBox>
+--- Field
+--- A `CheckBox` field which will toggle the `appearance` popover.
+function Toolbar.lazy.value:appearanceToggle()
+    return CheckBox(self:parent(), self.UI:mutate(
+        cache(self, "_appearanceToggle", CheckBox.matches)(
+            childMatching(CheckBox.matches, 1, ax.rightToLeft)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.appearance <cp.apple.finalcutpro.timeline.Appearance>
+--- Field
+--- The [Appearance](cp.apple.finalcutpro.timeline.Appearance.md) button/palette control.
+function Toolbar.lazy.value:appearance()
+    return Appearance(self.appearanceToggle)
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.browser <cp.apple.finalcutpro.timeline.Toolbar.Browser>
+--- Field
+--- The [Toolbar.Browser](cp.apple.finalcutpro.timeline.Toolbar.Browser.md) containing buttons that will toggle the Effects/Transitions browsers.
+function Toolbar.lazy.value:browser()
+    return Toolbar.Browser(self)
+end
+
+-----------------------------------------------------------------------
+-- NOTE: These are "delegated" to via the `browser` field.
+-----------------------------------------------------------------------
+
+--- cp.apple.finalcutpro.timeline.Toolbar.effects <cp.ui.RadioButton>
+--- Field
+--- The [RadioButton](cp.ui.RadioButton.md) which toggles the 'Effects' browser visibility.
+
+--- cp.apple.finalcutpro.timeline.Toolbar.transitions <cp.ui.RadioButton>
+--- Field
+--- The [RadioButton](cp.ui.RadioButton.md) which toggles the 'Transitions' browser visibility.
+
+-----------------------------------------------------------------------
+-- Utility Classes
+-----------------------------------------------------------------------
+
+--- === cp.apple.finalcutpro.timeline.Toolbar.Clip ===
+---
+--- Provides access to clip options such as skimming, audio skimming, soloing and snap.
+
+Toolbar.static.Clip = Group:subclass("cp.apple.finalcutpro.timeline.Toolbar.Clip")
+
+-- cp.apple.finalcutpro.timeline.Toolbar.Clip(toolbar) -> Toolbar.Clip
 -- Private Constructor
--- Creates a new `Toolbar.Skimming` group.
+-- Creates a new `Toolbar.Clip` group.
 --
 -- Parameters:
 -- * toolbar - the [Toolbar](cp.apple.finalcutpro.timeline.Toolbar.md).
-function Toolbar.Skimming:initialize(toolbar)
-    Group.initialize(self, toolbar, toolbar.UI:mutate(function(original)
-        return cache(self, "_skimming", function()
-            return childFromRight(original(), 1, Group.matches)
-        end, Group.matches)
-    end))
+function Toolbar.Clip:initialize(toolbar)
+    Group.initialize(self, toolbar, toolbar.UI:mutate(
+        cache(toolbar, "_clip", Group.matches)(
+            childMatching(Group.matches, 1, ax.rightToLeft)
+        )
+    ))
 end
 
---- cp.apple.finalcutpro.timeline.Toolbar.Skimming.active <cp.ui.CheckBox>
+--- cp.apple.finalcutpro.timeline.Toolbar.Clip.trimAlignedEdges <cp.ui.CheckBox>
+--- Field
+--- The [CheckBox](cp.ui.CheckBox.md) which allows the user to trim the edges of the selected clips.
+---
+--- Notes:
+--- * As of FCP 10.6.3, this is currently always hidden, and cannot have its value changed.
+--- * Uncertain in exactly which version this turned up.
+function Toolbar.Clip.lazy.value:trimAlignedEdges()
+    return CheckBox(self, self.UI:mutate(
+        cache(self, "_trimAlignedEdges", CheckBox.matches)(
+            childMatching(CheckBox.matches, 1, ax.leftToRight)
+        )
+    ))
+end
+
+--- cp.apple.finalcutpro.timeline.Toolbar.Clip.skimming <cp.ui.CheckBox>
 --- Field
 --- The [CheckBox](cp.ui.CheckBox.md) that indicates if video/audio skimming is active.
-function Toolbar.Skimming.lazy.value:active()
-    return CheckBox(self, self.UI:mutate(function(original)
-        return childFromLeft(original(), 2, CheckBox.matches)
-    end))
+function Toolbar.Clip.lazy.value:skimming()
+    return CheckBox(self, self.UI:mutate(
+        cache(self, "_active", CheckBox.matches)(
+            childMatching(CheckBox.matches, 4, ax.rightToLeft)
+        )
+    ))
 end
 
---- cp.apple.finalcutpro.timeline.Toolbar.Skimming.audio <cp.ui.CheckBox>
+--- cp.apple.finalcutpro.timeline.Toolbar.Clip.audioSkimming <cp.ui.CheckBox>
 --- Field
 --- The [CheckBox](cp.ui.CheckBox.md) that indicates if audio is played while skimming.
-function Toolbar.Skimming.lazy.value:audio()
-    return CheckBox(self, self.UI:mutate(function(original)
-        return childFromLeft(original(), 3, CheckBox.matches)
-    end))
+function Toolbar.Clip.lazy.value:audioSkimming()
+    return CheckBox(self, self.UI:mutate(
+        cache(self, "_audioSkimming", CheckBox.matches)(
+            childMatching(CheckBox.matches, 3, ax.rightToLeft)
+        )
+    ))
 end
 
---- cp.apple.finalcutpro.timeline.Toolbar.Skimming.solo <cp.ui.CheckBox>
+--- cp.apple.finalcutpro.timeline.Toolbar.Clip.solo <cp.ui.CheckBox>
 --- Field
---- The [CheckBox](cp.ui.CheckBox.md) that indicates if audio is soloing the selected clip(s).
-function Toolbar.Skimming.lazy.value:solo()
-    return CheckBox(self, self.UI:mutate(function(original)
-        return childFromLeft(original(), 4, CheckBox.matches)
-    end))
+--- The [CheckBox](cp.ui.CheckBox.md) that indicates if audio is soloed on the selected clip(s).
+function Toolbar.Clip.lazy.value:solo()
+    return CheckBox(self, self.UI:mutate(
+        cache(self, "_solo", CheckBox.matches)(
+            childMatching(CheckBox.matches, 2, ax.rightToLeft)
+        )
+    ))
 end
 
---- cp.apple.finalcutpro.timeline.Toolbar.Skimming.snapping <cp.ui.CheckBox>
+--- cp.apple.finalcutpro.timeline.Toolbar.Clip.snapping <cp.ui.CheckBox>
 --- Field
 --- The [CheckBox](cp.ui.CheckBox.md) that indicates if snapping is enabled.
-function Toolbar.Skimming.lazy.value:snapping()
-    return CheckBox(self, self.UI:mutate(function(original)
-        return childFromLeft(original(), 5, CheckBox.matches)
-    end))
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.skimming <cp.apple.finalcutpro.timeline.Toolbar.Skimming>
---- Field
---- The [Skimming](cp.apple.finalcutpro.timeline.Toolbar.Skimming.md) group of checkbox items.
-function Toolbar.lazy.value:skimming()
-    return Toolbar.Skimming(self)
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.skimmingGroup <cp.ui.Group>
---- Field
---- A [Group](cp.ui.Group.md) containing buttons relating to mouse skimming behaviour, waveforms, snapping, etc.
-function Toolbar.lazy.value:skimmingGroup()
-    return Group(self, self.UI:mutate(function(original)
-        return cache(self, "_skimmingGroup", function()
-            return childFromRight(original(), 1, Group.matches)
-        end, Group.matches)
-    end))
+function Toolbar.Clip.lazy.value:snapping()
+    return CheckBox(self, self.UI:mutate(
+        cache(self, "_snapping", CheckBox.matches)(
+            childMatching(CheckBox.matches, 1, ax.rightToLeft)
+        )
+    ))
 end
 
 --- === cp.apple.finalcutpro.timeline.Toolbar.Browser ===
@@ -180,78 +361,33 @@ Toolbar.static.Browser = RadioGroup:subclass("cp.apple.finalcutpro.timeline.Tool
 -- Parameters:
 -- * toolbar - The [Toolbar](cp.apple.finalcutpro.timeline.Toolbar.md).
 function Toolbar.Browser:initialize(toolbar)
-    RadioGroup.initialize(self, toolbar, toolbar.UI:mutate(function(original)
-        return cache(self, "_browser", function()
-            return childFromRight(original(), 1, RadioGroup.matches)
-        end, RadioGroup.matches)
-    end))
+    RadioGroup.initialize(self, toolbar, toolbar.UI:mutate(
+        cache(toolbar, "_browser", RadioGroup.matches)(
+            childMatching(RadioGroup.matches, 1, ax.rightToLeft)
+        )
+    ))
 end
 
 --- cp.apple.finalcutpro.timeline.Toolbar.Browser.effects <cp.ui.RadioButton>
 --- Field
 --- The [RadioButton](cp.ui.RadioButton.md) which toggles the 'Effects' browser visibility.
 function Toolbar.Browser.lazy.value:effects()
-    return RadioButton(self, function()
-        return childFromLeft(self:UI(), 1)
-    end)
+    return RadioButton(self, self.UI:mutate(
+        cache(self, "_effects", RadioButton.matches)(
+            childMatching(RadioButton.matches, 1, ax.leftToRight)
+        )
+    ))
 end
 
 --- cp.apple.finalcutpro.timeline.Toolbar.Browser.transitions <cp.ui.RadioButton>
 --- Field
 --- The [RadioButton](cp.ui.RadioButton.md) which toggles the 'Transitions' browser visibility.
 function Toolbar.Browser.lazy.value:transitions()
-    return RadioButton(self, function()
-        return childFromLeft(self:UI(), 2)
-    end)
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.browser <cp.apple.finalcutpro.timeline.Toolbar.Browser>
---- Field
---- The [Toolbar.Browser](cp.apple.finalcutpro.timeline.Toolbar.Browser.md) containing buttons that will toggle the Effects/Transitions browsers.
-function Toolbar.lazy.value:browser()
-    return Toolbar.Browser(self, self.UI:mutate(function(original)
-        return cache(self, "_browser", function()
-            return childFromRight(original(), 1, Toolbar.Browser.matches)
-        end, Toolbar.Browser.matches)
-    end))
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.title <cp.ui.MenuButton>
---- Field
---- The title [MenuButton](cp.ui.MenuButton.md) from the Timeline Titlebar.
-function Toolbar.lazy.value:title()
-    return MenuButton(self, self.UI:mutate(function(original)
-        return cache(self, "_titleUI", function()
-            return childFromLeft(original(), 1, MenuButton.matches)
-        end)
-    end))
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.duration <cp.ui.StaticText>
---- Field
---- The duration [StaticText](cp.ui.StaticText.md) from the Timeline Titlebar.
-function Toolbar.lazy.value:duration()
-    return StaticText(self, self.UI:mutate(function(original)
-        return cache(self, "_durationUI", function()
-            return childFromLeft(original(), 2, StaticText.matches)
-        end)
-    end))
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.appearanceToggle <cp.ui.CheckBox>
---- Field
---- A `CheckBox` field which will toggle the `appearance` popover.
-function Toolbar.lazy.value:appearanceToggle()
-    return CheckBox(self:parent(), self.UI:mutate(function(original)
-        return childFromRight(original(), 1, CheckBox.matches)
-    end))
-end
-
---- cp.apple.finalcutpro.timeline.Toolbar.appearance <cp.apple.finalcutpro.timeline.Appearance>
---- Field
---- The [Appearance](cp.apple.finalcutpro.timeline.Appearance.md) button/palette control.
-function Toolbar.lazy.value:appearance()
-    return Appearance(self.appearanceToggle)
+    return RadioButton(self, self.UI:mutate(
+        cache(self, "_transitions", RadioButton.matches)(
+            childMatching(RadioButton.matches, 2, ax.leftToRight)
+        )
+    ))
 end
 
 return Toolbar

--- a/src/extensions/cp/apple/finalcutpro/timeline/Toolbar.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Toolbar.lua
@@ -132,13 +132,13 @@ function Toolbar.lazy.value:clipMedia()
     ))
 end
 
---- cp.apple.finalcutpro.timeline.Toolbar.toolPalette <cp.apple.finalcutpro.timeline.ToolPalette>
+--- cp.apple.finalcutpro.timeline.Toolbar.tool <cp.apple.finalcutpro.timeline.ToolPalette>
 --- Field
 --- The [ToolPalette](cp.apple.finalcutpro.timeline.ToolPalette.md), which allows the user to select the tool
 --- that is being used to manipulate the timeline at present.
-function Toolbar.lazy.value:toolPalette()
+function Toolbar.lazy.value:tool()
     return ToolPalette(self, self.UI:mutate(
-        cache(self, "_toolPalette", ToolPalette.matches)(
+        cache(self, "_tool", ToolPalette.matches)(
             chain // childMatching(Group.matches, 2, ax.leftToRight) >> childMatching(ToolPalette.matches)
         )
     ))

--- a/src/extensions/cp/ui/Element.lua
+++ b/src/extensions/cp/ui/Element.lua
@@ -508,7 +508,7 @@ function Element:doHighlight(color, duration)
     :Label("cp.ui.Element:doHighlight(color, duration)")
 end
 
---- cp.ui.Element:highlight([color], [duration])
+--- cp.ui.Element:highlight([color], [duration]) -> cp.ui.Element
 --- Method
 --- Highlights the `Element` with the specified `color` and `duration`.
 ---
@@ -517,9 +517,10 @@ end
 ---  * duration	- The `number` of seconds to highlight for. (defaults to `3` seconds)
 ---
 --- Returns:
----  * Nothing
+---  * the same `Element` instance.
 function Element:highlight(color, duration)
     self:doHighlight(color, duration):Now()
+    return self
 end
 
 

--- a/src/extensions/cp/ui/MenuButton.lua
+++ b/src/extensions/cp/ui/MenuButton.lua
@@ -60,11 +60,11 @@ function MenuButton.lazy.prop:value()
                 if items then
                     for _,item in ipairs(items) do
                         if item:attributeValue("AXTitle") == newValue then
-                            item:doAXPress()
+                            item:performAction("AXPress")
                             return
                         end
                     end
-                    items:doCancel()
+                    items:performAction("AXCancel")
                 end
             end
         end
@@ -383,8 +383,8 @@ function MenuButton:__call(parent, value)
     return self:value(value)
 end
 
-function MenuButton:__tostring()
-    return string.format("cp.ui.MenuButton: %s (%s)", self:title(), self:parent())
+function MenuButton:__valuestring()
+    return string.format("%s (%s)", self:title(), self:parent())
 end
 
 return MenuButton

--- a/src/tests/cp/apple/finalcutpro/_test.lua
+++ b/src/tests/cp/apple/finalcutpro/_test.lua
@@ -508,29 +508,29 @@ return test.suite("cp.apple.finalcutpro"):with(
         function()
             local toolbar = fcp.timeline.toolbar
 
-            local clipId, effectsGroup
+            local clipId --, effectsGroup
             local version = fcp:version()
 
             ok(version and type(version) == "table")
 
             if version >= v("10.3.2") then
                 clipId = "_NS:178"
-                effectsGroup = "_NS:165"
+                -- effectsGroup = "_NS:165"
             end
 
             if version >= v("10.3.3") then
                 clipId = "_NS:179"
-                effectsGroup = "_NS:166"
+                -- effectsGroup = "_NS:166"
             end
 
             if version >= v("10.4.4") then
                 clipId = "_NS:183"
-                effectsGroup = "_NS:170"
+                -- effectsGroup = "_NS:170"
             end
 
             ok(toolbar:isShowing())
             ok(toolbar.clip:UI() ~= nil)
-            ok(clipID and toolbar.clip:UI():attributeValue("AXIdentifier") == clipId)
+            ok(clipId and toolbar.clip:UI():attributeValue("AXIdentifier") == clipId)
 
             -- TODO: Chris disabled on 20201228 because effectsGroup is no longer used in the FCPX API.
             -- ok(toolbar.effectsGroup:UI() ~= nil)

--- a/src/tests/cp/apple/finalcutpro/_test.lua
+++ b/src/tests/cp/apple/finalcutpro/_test.lua
@@ -508,29 +508,29 @@ return test.suite("cp.apple.finalcutpro"):with(
         function()
             local toolbar = fcp.timeline.toolbar
 
-            local skimmingId, effectsGroup
+            local clipId, effectsGroup
             local version = fcp:version()
 
             ok(version and type(version) == "table")
 
             if version >= v("10.3.2") then
-                skimmingId = "_NS:178"
+                clipId = "_NS:178"
                 effectsGroup = "_NS:165"
             end
 
             if version >= v("10.3.3") then
-                skimmingId = "_NS:179"
+                clipId = "_NS:179"
                 effectsGroup = "_NS:166"
             end
 
             if version >= v("10.4.4") then
-                skimmingId = "_NS:183"
+                clipId = "_NS:183"
                 effectsGroup = "_NS:170"
             end
 
             ok(toolbar:isShowing())
-            ok(toolbar.skimming:UI() ~= nil)
-            ok(skimmingId and toolbar.skimming:UI():attributeValue("AXIdentifier") == skimmingId)
+            ok(toolbar.clip:UI() ~= nil)
+            ok(clipID and toolbar.clip:UI():attributeValue("AXIdentifier") == clipId)
 
             -- TODO: Chris disabled on 20201228 because effectsGroup is no longer used in the FCPX API.
             -- ok(toolbar.effectsGroup:UI() ~= nil)


### PR DESCRIPTION
Fixes #2990.

This adds API values for all buttons on the timeline. In particular, it adds the `cp.apple.finalcut.timeline.ToolPalette` custom MenuButton, with the following features:

* returns a `ToolPalette.OPTIONS` value from the `ToolPalette:value()` `cp.prop` (eg. `ToolPalette.OPTIONS.SELECT`, etc)
* Has `isXXX()` `cp.prop` fields to easily check for which option is currently selected. Eg:
  * `fcp.timeline.toolbar.tool:isSelect()` - checks if currently using the `Select` tool.
  * `fcp.timeline.toolbar.tool:isZoom(true)` - sets it to use the `Zoom` tool (if the Timeline is currently visible)