### PR TITLE
Fixed a bug that was breaking Disk Auto-mount Plugin

### DIFF
--- a/src/extensions/cp/battery.lua
+++ b/src/extensions/cp/battery.lua
@@ -182,7 +182,9 @@ end
 local function init()
     for key,value in pairs(battery) do
         if EXCLUDED[key] ~= true and type(value) == "function" then
-            mod[key] = prop(value):label(string.format("cp.battery: %s", key))
+            mod[key] = prop(function()
+                return value()
+            end):label(string.format("cp.battery: %s", key))
         end
     end
     return mod


### PR DESCRIPTION
- Hammerspoon recently changed `hs.battery` so its more strict in terms of valid arguments - so if you pass in arguments to a function that's expecting none, you'll now get a Lua error. `cp.prop` was passing in two arguments, which was breaking `cp.battery`. This fixes that.
- Closes #3016