### PR TITLE
Fixed "Photos and Audio" menubar item now "Photos, Videos and Audio"

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/main/LibrariesFilmstrip.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/LibrariesFilmstrip.lua
@@ -174,7 +174,7 @@ end
 --- Returns:
 ---  * A table of `axuielementObject` objects or `nil` if no clip UI could be found.
 function LibrariesFilmstrip:clipsUI(filterFn)
-    local ui = self:contentsUI()
+    local ui = self.contentsUI()
     if ui then
         local clips = childrenMatching(ui, function(child)
             return child:attributeValue("AXRole") == "AXGroup"
@@ -218,7 +218,7 @@ end
 --- Returns:
 ---  * A table of `axuielementObject` objects or `nil` if no clips are selected.
 function LibrariesFilmstrip:selectedClipsUI()
-    local ui = self:contentsUI()
+    local ui = self.contentsUI()
     if ui then
         local children = ui:attributeValue("AXSelectedChildren")
         local clips = {}
@@ -271,7 +271,7 @@ function LibrariesFilmstrip:showClip(clip)
             --------------------------------------------------------------------------------
             -- We need to scroll:
             --------------------------------------------------------------------------------
-            local oFrame = self:contentsUI():attributeValue("AXFrame")
+            local oFrame = self.contentsUI():attributeValue("AXFrame")
             local scrollHeight = oFrame.h - vFrame.h
 
             local vValue
@@ -395,7 +395,7 @@ end
 ---  * `true` if successful otherwise `false`.
 function LibrariesFilmstrip:selectAll(clips)
     clips = clips or self:clips()
-    local contents = self:contentsUI()
+    local contents = self.contentsUI()
     if clips and contents then
         local clipsUI = _clipsToUI(clips)
         contents:setAttributeValue("AXSelectedChildren", clipsUI)
@@ -414,7 +414,7 @@ end
 --- Returns:
 ---  * `true` if successful otherwise `false`.
 function LibrariesFilmstrip:deselectAll()
-    local contents = self:contentsUI()
+    local contents = self.contentsUI()
     if contents then
         contents:setAttributeValue("AXSelectedChildren", {})
         return true

--- a/src/extensions/cp/apple/finalcutpro/main/MediaBrowser.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/MediaBrowser.lua
@@ -16,16 +16,22 @@ local ScrollArea                        = require "cp.ui.ScrollArea"
 local SplitGroup                        = require "cp.ui.SplitGroup"
 local TextField						    = require "cp.ui.TextField"
 
+local semver                            = require "semver"
+
 local cache                             = axutils.cache
 local childMatching                     = axutils.childMatching
-
 
 local MediaBrowser = Group:subclass("cp.apple.finalcutpro.main.MediaBrowser")
 
 --- cp.apple.finalcutpro.main.MediaBrowser.TITLE -> string
 --- Constant
---- Photos & Audio Title.
-MediaBrowser.static.TITLE = "Photos and Audio"
+--- Photos & Audio Title in v10.6.2 and later.
+MediaBrowser.static.TITLE = "Photos, Videos and Audio"
+
+--- cp.apple.finalcutpro.main.MediaBrowser.LEGACY_TITLE -> string
+--- Constant
+--- Photos & Audio Title in v10.6.1 and earlier.
+MediaBrowser.static.LEGACY_TITLE = "Photos and Audio"
 
 --- cp.apple.finalcutpro.main.MediaBrowser.MAX_SECTIONS -> number
 --- Constant
@@ -108,10 +114,13 @@ end
 ---  * The `MediaBrowser` object.
 function MediaBrowser:show()
     local menuBar = self:app().menu
-    -----------------------------------------------------------------------
-    -- Go there direct:
-    -----------------------------------------------------------------------
-    menuBar:selectMenu({"Window", "Go To", MediaBrowser.TITLE})
+
+    local menuTitle = MediaBrowser.TITLE
+    if self:app().version() < semver("10.6.2") then
+        menuTitle = MediaBrowser.LEGACY_TITLE
+    end
+
+    menuBar:selectMenu({"Window", "Go To", menuTitle})
     just.doUntil(function() return self:isShowing() end)
     return self
 end


### PR DESCRIPTION
- Fixed a bug caused by Apple changing the menubar item from "Photos and Audio" in 10.6.1 and earlier to "Photos, Videos and Audio".
-  Fixed a strange bug in `cp.apple.finalcutpro.main.LibrariesFilmstrip` where `:contentsUI()` would sometimes fail. I have no idea why. Hopefully @randomeizer can eventually solve in #3062.
- Closes #3061