### PR TITLE
Titles to Keywords Improvements

### DIFF
--- a/src/extensions/languages/English_en.json
+++ b/src/extensions/languages/English_en.json
@@ -2395,6 +2395,7 @@
     "transform": "Transform",
     "transition": "Transition",
     "transition_group": "Transition",
+    "treatFavoriteAndRejectAsRatingsInsteadOfKeywords": "Treat FAVORITE and REJECT as Ratings instead of Keywords",
     "trebleBoost": "Treble Boost",
     "trebleBoost9": "Treble +",
     "trebleReduce": "Treble Reduce",

--- a/src/plugins/finalcutpro/toolbox/titlestokeywords/html/panel.html
+++ b/src/plugins/finalcutpro/toolbox/titlestokeywords/html/panel.html
@@ -111,6 +111,7 @@
 <p class="uiItem"><label><input type="checkbox" id="mergeWithExistingEvent" onchange="updateChecked(this)"> {{ i18n("mergeWithExistingEvent") }}</label></p>
 <p class="uiItem"><label><input type="checkbox" id="useTitleContentsInsteadOfTitleName" onchange="updateChecked(this)"> {{ i18n("useTitleContentsInsteadOfTitleName") }}</label></p>
 <p class="uiItem"><label><input type="checkbox" id="replaceCommasWithAlternativeCommas" onchange="updateChecked(this)"> {{ i18n("replaceCommasWithAlternativeCommas") }}</label></p>
+<p class="uiItem"><label><input type="checkbox" id="treatFavoriteAndRejectAsRatingsInsteadOfKeywords" onchange="updateChecked(this)"> {{ i18n("treatFavoriteAndRejectAsRatingsInsteadOfKeywords") }}</label></p>
 
 <table width="100%">
 	<tr>


### PR DESCRIPTION
- Added option to "Treat FAVORITE and REJECT as Ratings instead of Keywords".
- When "Treat FAVORITE and REJECT as Ratings instead of Keywords" is enabled it will automatically create a "REJECT" and "FAVORITE" title when using "Create Titles from Text".
- Closes #3111