### PR TITLE
Fixed bug in "Copy Application" function

### DIFF
--- a/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
+++ b/src/plugins/core/controlsurfaces/resolve/prefs/init.lua
@@ -1605,7 +1605,13 @@ local function daVinciResolveControlSurfacePanelCallback(id, params)
 
                 local data = items[device][unit][app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[device][unit][destinationApp].displayName
                     items[device][unit][destinationApp] = copy(data)
+                    items[device][unit][destinationApp].displayName = originalDisplayName
+
                     mod.items(items)
                 end
             end

--- a/src/plugins/core/loupedeck/prefs/init.lua
+++ b/src/plugins/core/loupedeck/prefs/init.lua
@@ -676,7 +676,13 @@ local function loupedeckPanelCallback(id, params)
 
                 local data = items[app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[destinationApp].displayName
                     items[destinationApp] = fnutils.copy(data)
+                    items[destinationApp].displayName = originalDisplayName
+
                     mod.items(items)
                 end
             end

--- a/src/plugins/core/loupedeckctandlive/prefs/init.lua
+++ b/src/plugins/core/loupedeckctandlive/prefs/init.lua
@@ -2619,7 +2619,13 @@ function mod.mt:panelCallback(id, params)
                     if not items[lastDevice] then
                         items[lastDevice] = {}
                     end
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[lastDevice][destinationApp].displayName
                     items[lastDevice][destinationApp] = fnutils.copy(data)
+                    items[lastDevice][destinationApp].displayName = originalDisplayName
+
                     self.items(items)
                 end
             end

--- a/src/plugins/core/loupedeckplus/prefs/init.lua
+++ b/src/plugins/core/loupedeckplus/prefs/init.lua
@@ -677,7 +677,12 @@ local function loupedeckPlusPanelCallback(id, params)
 
                 local data = items[app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[destinationApp].displayName
                     items[destinationApp] = fnutils.copy(data)
+                    items[destinationApp].displayName = originalDisplayName
                     mod.items(items)
                 end
             end

--- a/src/plugins/core/midi/prefs/init.lua
+++ b/src/plugins/core/midi/prefs/init.lua
@@ -1086,7 +1086,12 @@ local function midiPanelCallback(id, params)
 
                 local data = items[app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[destinationApp].displayName
                     items[destinationApp] = fnutils.copy(data)
+                    items[destinationApp].displayName = originalDisplayName
                     mod.items(items)
                 end
             end

--- a/src/plugins/core/razer/prefs/init.lua
+++ b/src/plugins/core/razer/prefs/init.lua
@@ -1252,13 +1252,24 @@ local function razerPanelCallback(id, params)
 
                 local data = items[device] and items[device][app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[device][destinationApp].displayName
                     items[device][destinationApp] = fnutils.copy(data)
+                    items[device][destinationApp].displayName = originalDisplayName
+
                     mod.items(items)
 
                     --------------------------------------------------------------------------------
                     -- Refresh the hardware (and trash the LED cache):
                     --------------------------------------------------------------------------------
                     mod._razerManager.refresh(true)
+
+                    --------------------------------------------------------------------------------
+                    -- Refresh the UI:
+                    --------------------------------------------------------------------------------
+                    mod._manager.refresh()
                 end
             end
 

--- a/src/plugins/core/streamdeck/prefs/init.lua
+++ b/src/plugins/core/streamdeck/prefs/init.lua
@@ -1644,7 +1644,12 @@ local function streamDeckPanelCallback(id, params)
 
                 local data = items[device][unit][app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[device][unit][destinationApp].displayName
                     items[device][unit][destinationApp] = copy(data)
+                    items[device][unit][destinationApp].displayName = originalDisplayName
                     mod.items(items)
                 end
             end

--- a/src/plugins/core/tourbox/prefs/init.lua
+++ b/src/plugins/core/tourbox/prefs/init.lua
@@ -794,7 +794,12 @@ local function tourBoxPanelCallback(id, params)
 
                 local data = items[app]
                 if data then
+                    --------------------------------------------------------------------------------
+                    -- Don't replace the display name:
+                    --------------------------------------------------------------------------------
+                    local originalDisplayName = items[destinationApp].displayName
                     items[destinationApp] = fnutils.copy(data)
+                    items[destinationApp].displayName = originalDisplayName
                     mod.items(items)
                 end
             end


### PR DESCRIPTION
- The "Copy Application" button in Control Surfaces would also copy across the display name, so if you copy a built-in application to a user-added application, it would incorrectly replace the display name.
- Closes #3144