### PR TITLE
Make Loupedeck Live re-use Razer Stream Controller image logic

### DIFF
--- a/src/extensions/hs/loupedeck/init.lua
+++ b/src/extensions/hs/loupedeck/init.lua
@@ -1464,7 +1464,10 @@ function mod.mt:updateScreenImage(screen, imageBytes, frame, callbackFn)
     -- The Razer Stream Controller only has one screen object, so we need to do
     -- a bit of processing to convert it back into left, middle and right screens:
     --------------------------------------------------------------------------------
-    if self.deviceType == mod.deviceTypes.RAZER_STREAM_CONTROLLER then
+    if (
+      self.deviceType == mod.deviceTypes.RAZER_STREAM_CONTROLLER or
+      self.deviceType == mod.deviceTypes.LIVE
+    ) then
         if not frame then
             frame = {}
         end


### PR DESCRIPTION
What's in the PR:

This is a "dumbfix" for PR #3219.

It changes rendering condition to use same logic as one being used for Razer Stream Controller.

It might not cover all the cases, as it's possible that some Loupedecks Live don't have such logic and thus manual toggle might be needed.

Feel free to edit/discard.
