### PR TITLE
Add filename and display name to info inspector

### DIFF
--- a/src/extensions/cp/apple/finalcutpro/inspector/info/InfoInspector.lua
+++ b/src/extensions/cp/apple/finalcutpro/inspector/info/InfoInspector.lua
@@ -103,6 +103,9 @@ function InfoInspector:initialize(parent)
 
         audioOutputChannels     = staticText "Audio Channel Count",
         audioSampleRate         = staticText "Audio Sample Rate",
+
+        filename                = staticText "Filename",
+        displayName             = staticText "Display name",
     }
 end
 

--- a/src/plugins/finalcutpro/hud/panels/search/init.lua
+++ b/src/plugins/finalcutpro/hud/panels/search/init.lua
@@ -136,6 +136,8 @@ local function getColumnNames()
         ["Proxy Codecs"] =  fcp:string("Proxy Codecs"),
         ["360° Mode"] = fcp:string("FFOrganizerFilterHUDFormatInfoSphericalType"),
         ["Stereoscopic Mode"] = fcp:string("FFMD3DStereoMode"),
+        ["Filename"] = fcp:string("Filename"),
+        ["Display name"] = fcp:string("Display name"),
     }
 end
 


### PR DESCRIPTION
but for some reason it does not work :D

```
Warning:PropertyRow: Unable to find a label with these keys: [1]{ "Filename" }
Warning:PropertyRow: Unable to find a label with these keys: [1]{ "Display name" }
```

<img width="401" alt="image" src="https://github.com/CommandPost/CommandPost/assets/2387356/f3909bd5-100a-4cad-ade5-2293f5e4cfd7">
