### PR TITLE
Fix #3328: Loupedeck plugin bug in init.lua

### DIFF
--- a/src/extensions/hs/loupedeck/init.lua
+++ b/src/extensions/hs/loupedeck/init.lua
@@ -374,7 +374,9 @@ function mod.mt:initaliseDevice()
                 if firmwareVersion > semver("0.2.5") then
                     log.df("Loupedeck device is running firmware greater than v0.2.5, so using Razer screen format.")
                     self.loupedeckDeviceIsUsingRazerFirmware = true
-
+                elseif firmwareVersion == semver("0.1.2") then -- firmwareVersion 0.1.2 is newer than 0.2.5 go figure
+                    log.df("Loupedeck device is running newest firmware v0.1.2, so using Razer screen format.")
+                    self.loupedeckDeviceIsUsingRazerFirmware = true
                     --------------------------------------------------------------------------------
                     -- Refresh the screen:
                     --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes issue #3328 by correcting a bug in the Loupedeck plugin's init.lua file (the 3 lines at line number 377)
The fix was tested by reloading extensions via the Developer menu and verifying plugin behavior with a Loupedeck CT.
Let me know if additional validation or cleanup is needed.