### PR TITLE
Add MCP Server for AI-Powered Final Cut Pro Automation

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "commandpost": {
+      "command": "node",
+      "args": ["/Users/briantate/Documents/GitHub/CommandPost/src/mcp-server/dist/index.js"]
+    }
+  }
+}

--- a/src/extensions/cp/apple/finalcutpro/import/MediaImport.lua
+++ b/src/extensions/cp/apple/finalcutpro/import/MediaImport.lua
@@ -10,9 +10,15 @@ local strings                       = require "cp.apple.finalcutpro.strings"
 local axutils                       = require "cp.ui.axutils"
 local Button                        = require "cp.ui.Button"
 local Dialog                        = require "cp.ui.Dialog"
+local GoToPrompt                    = require "cp.apple.finalcutpro.export.GoToPrompt"
 
 local cache                         = axutils.cache
 local childWith                     = axutils.childWith
+
+local GO_TO_PROMPT_TIMEOUT          = 5
+local IMPORT_WINDOW_TIMEOUT         = 5
+local IMPORT_BUTTON_TIMEOUT         = 5
+local IMPORT_START_TIMEOUT          = 15
 
 local MediaImport = Dialog:subclass("cp.apple.finalcutpro.import.MediaImport")
 
@@ -119,6 +125,97 @@ end
 function MediaImport:hide()
     self:close()
     return self
+end
+
+--- cp.apple.finalcutpro.import.MediaImport:setPath(path) -> boolean, string
+--- Method
+--- Uses the "Go to Folder" prompt to select a file or folder path in the Media Import window.
+---
+--- Parameters:
+---  * path - The file or folder path.
+---
+--- Returns:
+---  * `true` if the path was selected.
+---  * An error message when the path could not be selected.
+function MediaImport:setPath(path)
+    if not self:isShowing() then
+        return false, "Media Import window is not showing"
+    end
+
+    local prompt = self.goToPrompt
+    prompt:show()
+    if not just.doUntil(function() return prompt:isShowing() end, GO_TO_PROMPT_TIMEOUT) then
+        return false, "Go to Folder prompt did not appear"
+    end
+
+    prompt:value(path)
+    if prompt:isShowing() then
+        local _, success = prompt.go:press()
+        if not success then
+            return false, "Unable to confirm Go to Folder prompt"
+        end
+    end
+
+    if not just.doUntil(function() return not prompt:isShowing() end, GO_TO_PROMPT_TIMEOUT) then
+        return false, "Go to Folder prompt did not close"
+    end
+
+    return true
+end
+
+--- cp.apple.finalcutpro.import.MediaImport:importPath(path) -> boolean, string
+--- Method
+--- Opens the Media Import window, selects the supplied path, and presses "Import All".
+---
+--- Parameters:
+---  * path - The file or folder path to import.
+---
+--- Returns:
+---  * `true` if the import started successfully.
+---  * An error message when the import could not be started.
+function MediaImport:importPath(path)
+    self:show()
+    if not just.doUntil(function() return self:isShowing() end, IMPORT_WINDOW_TIMEOUT) then
+        return false, "Unable to open Media Import window"
+    end
+
+    local pathSelected, message = self:setPath(path)
+    if not pathSelected then
+        return false, message
+    end
+
+    local importAll = self.importAll
+    local importAllUI = just.doUntil(function()
+        local ui = importAll:UI()
+        if ui and ui:attributeValue("AXEnabled") == true then
+            return ui
+        end
+        return false
+    end, IMPORT_BUTTON_TIMEOUT)
+    if not importAllUI then
+        return false, "Import All button is unavailable for the selected path"
+    end
+
+    local _, success = importAll:press()
+    if not success then
+        return false, "Unable to press Import All"
+    end
+
+    local importStarted = just.doUntil(function()
+        return not self:isShowing() or self.stopImport:UI() ~= nil
+    end, IMPORT_START_TIMEOUT)
+    if not importStarted then
+        return false, "Import did not appear to start"
+    end
+
+    return true
+end
+
+--- cp.apple.finalcutpro.import.MediaImport.goToPrompt <GoToPrompt>
+--- Field
+--- The Go To Prompt object for the Media Import window.
+function MediaImport.lazy.value:goToPrompt()
+    return GoToPrompt(self)
 end
 
 return MediaImport

--- a/src/extensions/cp/apple/finalcutpro/main/PrimaryToolbar.lua
+++ b/src/extensions/cp/apple/finalcutpro/main/PrimaryToolbar.lua
@@ -109,11 +109,16 @@ end
 --- The `CheckBox` that will open the `KeywordEditor` dialog when checked.
 function PrimaryToolbar.lazy.value:keywordEditor()
     return CheckBox(self, self.UI:mutate(function(original)
-        -- for some reason some of these buttons are individually wrapped in an AXGroup
-        local group = childFromLeft(original(), 1, Group.matches)
+        local ui = original()
+        -- Legacy (pre-v12): checkboxes wrapped in AXGroup
+        local group = childFromLeft(ui, 1, Group.matches)
         if group then
             return childMatching(group, CheckBox.matches)
         end
+        -- FCP v12+: checkboxes are direct toolbar children, match by description
+        return childMatching(ui, function(e)
+            return CheckBox.matches(e) and (e:attributeValue("AXDescription") or ""):find("Keyword Editor")
+        end)
     end))
 end
 
@@ -122,11 +127,14 @@ end
 --- The `CheckBox` that will open the `BackgroundTasksWindow` dialog
 function PrimaryToolbar.lazy.value:backgroundTasksWindow()
     return CheckBox(self, self.UI:mutate(function(original)
-        -- for some reason CheckBoxes are individually wrapped in an AXGroup
-        local group = childFromLeft(original(), 2, Group.matches)
+        local ui = original()
+        -- Legacy (pre-v12): checkboxes wrapped in AXGroup
+        local group = childFromLeft(ui, 2, Group.matches)
         if group then
             return childMatching(group, CheckBox.matches)
         end
+        -- FCP v12+: second checkbox from left (index 4, no description)
+        return childFromLeft(ui, 2, CheckBox.matches)
     end))
 end
 
@@ -144,12 +152,16 @@ end
 --- The `CheckBox` indicating if the `Browser` is showing
 function PrimaryToolbar.lazy.value:browserShowing()
     return CheckBox(self, self.UI:mutate(function(original)
-        -- for some reason CheckBoxes are individually wrapped in an AXGroup
-        local group = childFromRight(original(), 4)
+        local ui = original()
+        -- Legacy (pre-v12): CheckBoxes individually wrapped in an AXGroup
+        local group = childFromRight(ui, 4)
         if Group.matches(group) then
             return childMatching(group, CheckBox.matches)
         end
-        return nil
+        -- FCP v12+: direct checkbox children, match by description
+        return childMatching(ui, function(e)
+            return CheckBox.matches(e) and (e:attributeValue("AXDescription") or ""):find("Browser")
+        end)
     end))
 end
 
@@ -158,12 +170,16 @@ end
 --- The `CheckBox` indicating if the `Timeline` is showing
 function PrimaryToolbar.lazy.value:timelineShowing()
     return CheckBox(self, function()
-        -- for some reason CheckBoxes are individually wrapped in an AXGroup
-        local group = childFromRight(self:UI(), 3)
+        local ui = self:UI()
+        -- Legacy (pre-v12): CheckBoxes individually wrapped in an AXGroup
+        local group = childFromRight(ui, 3)
         if Group.matches(group) then
             return childMatching(group, CheckBox.matches)
         end
-        return nil
+        -- FCP v12+: direct checkbox children, match by description
+        return childMatching(ui, function(e)
+            return CheckBox.matches(e) and (e:attributeValue("AXDescription") or ""):find("Timeline")
+        end)
     end)
 end
 
@@ -172,12 +188,16 @@ end
 --- The `CheckBox` indicating if the Inspector is showing
 function PrimaryToolbar.lazy.value:inspectorShowing()
     return CheckBox(self, function()
-        -- for some reason CheckBoxes are individually wrapped in an AXGroup
-        local group = childFromRight(self:UI(), 2)
+        local ui = self:UI()
+        -- Legacy (pre-v12): CheckBoxes individually wrapped in an AXGroup
+        local group = childFromRight(ui, 2)
         if Group.matches(group) then
             return childMatching(group, CheckBox.matches)
         end
-        return nil
+        -- FCP v12+: direct checkbox children, match by description
+        return childMatching(ui, function(e)
+            return CheckBox.matches(e) and (e:attributeValue("AXDescription") or ""):find("Inspector")
+        end)
     end)
 end
 

--- a/src/extensions/cp/apple/finalcutpro/menu.lua
+++ b/src/extensions/cp/apple/finalcutpro/menu.lua
@@ -90,9 +90,10 @@ menu:addMenuFinder(function(parentItem, path, childName, locale)
             ----------------------------------------------------------------------------------------
             -- Perform Pattern Matching with Tokens:
             ----------------------------------------------------------------------------------------
-            local itemChild = item.child:gsub("%%@", ".*")
-            if isEqual(path, item.path) and childName == itemChild then
-                local keyWithPattern = strings:find(item.key, locale):gsub("%%@", ".*")
+            local itemChild = type(item.child) == "string" and item.child:gsub("%%@", ".*") or nil
+            local keyTitle = type(item.key) == "string" and strings:find(item.key, locale, true) or nil
+            if itemChild and keyTitle and isEqual(path, item.path) and childName == itemChild then
+                local keyWithPattern = keyTitle:gsub("%%@", ".*")
                 return childMatching(parentItem, function(child)
                     local title = child:attributeValue("AXTitle")
                     return title and string.match(title, keyWithPattern)

--- a/src/extensions/cp/apple/finalcutpro/timeline/Contents.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Contents.lua
@@ -294,7 +294,7 @@ function Contents:clipsUI(expandGroups, filterFn)
         end)
         return self:_filterClips(clips, expandGroups, filterFn)
     end
-    return nil
+    return {}
 end
 
 --- cp.apple.finalcutpro.timeline.Contents:rangeSelectionUI() -> axuielements
@@ -331,12 +331,14 @@ end
 ---  * If `expandsGroups` is `true` any `AXGroup` items will be expanded to the list of contained `AXLayoutItems`.
 ---  * If `filterFn` is provided it will be called with a single argument to check if the provided clip should be included in the final table.
 function Contents:positionClipsUI(position, expandGroups, filterFn)
+    if type(position) ~= "number" then return {} end
+
     local clips = self:clipsUI(expandGroups, function(clip)
         local frame = clip.AXFrame
         return frame and position >= frame.x and position <= (frame.x + frame.w)
            and (filterFn == nil or filterFn(clip))
     end)
-    if not clips then return nil end
+    if not clips then return {} end
 
     table.sort(clips, function(a, b) return a.AXPosition.y < b.AXPosition.y end)
     return clips
@@ -357,7 +359,9 @@ end
 ---  * If `expandsGroups` is true any AXGroup items will be expanded to the list of contained `AXLayoutItems`.
 ---  * If `filterFn` is provided it will be called with a single argument to check if the provided clip should be included in the final table.
 function Contents:playheadClipsUI(expandGroups, filterFn)
-    return self:positionClipsUI(self.playhead:position(), expandGroups, filterFn)
+    local position = self.playhead and self.playhead:position()
+    if type(position) ~= "number" then return {} end
+    return self:positionClipsUI(position, expandGroups, filterFn)
 end
 
 --- cp.apple.finalcutpro.timeline.Contents:skimmingPlayheadClipsUI(expandedGroups, filterFn) -> table of axuielements
@@ -375,7 +379,9 @@ end
 ---  * If `expandsGroups` is true any AXGroup items will be expanded to the list of contained `AXLayoutItems`.
 ---  * If `filterFn` is provided it will be called with a single argument to check if the provided clip should be included in the final table.
 function Contents:skimmingPlayheadClipsUI(expandGroups, filterFn)
-    return self:positionClipsUI(self.skimmingPlayhead:position(), expandGroups, filterFn)
+    local position = self.skimmingPlayhead and self.skimmingPlayhead:position()
+    if type(position) ~= "number" then return {} end
+    return self:positionClipsUI(position, expandGroups, filterFn)
 end
 
 -- cp.apple.finalcutpro.timeline.Contents:_filterClips(clips, expandGroups, filterFn) -> table of axuielements
@@ -416,14 +422,25 @@ end
 -- Returns:
 --  * The table of axuielements that match the conditions
 function Contents:_expandClips(clips, filterFn)
+    if type(clips) ~= "table" then
+        return {}
+    end
+
     return fnutils.mapCat(clips, function(child)
+        if not child then
+            return {}
+        end
+
         local role = child:attributeValue("AXRole")
         if role == "AXLayoutItem" then
             if filterFn == nil or filterFn(child) then
                 return {child}
             end
         elseif role == "AXGroup" then
-            return self:_expandClips(child:attributeValue("AXChildren"), filterFn)
+            local children = child:attributeValue("AXChildren")
+            if type(children) == "table" then
+                return self:_expandClips(children, filterFn)
+            end
         end
         return {}
     end)

--- a/src/extensions/cp/apple/finalcutpro/timeline/Timeline.lua
+++ b/src/extensions/cp/apple/finalcutpro/timeline/Timeline.lua
@@ -149,10 +149,7 @@ end
 --- Field
 --- Checks if the Timeline is showing on either the Primary or Secondary display.
 function Timeline.lazy.prop:isShowing()
-    return self.UI:mutate(function(original)
-        local ui = original()
-        return ui ~= nil and #ui > 0
-    end)
+    return self.UI:ISNOT(nil):AND(self:app().isShowing)
 end
 
 --- cp.apple.finalcutpro.timeline.Timeline.mainUI <cp.prop: hs.axuielement; read-only>

--- a/src/mcp-server/.gitignore
+++ b/src/mcp-server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/src/mcp-server/README.md
+++ b/src/mcp-server/README.md
@@ -1,0 +1,462 @@
+# CommandPost MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that exposes the full power of [CommandPost](https://commandpost.io) and Final Cut Pro automation to AI assistants like Claude.
+
+**76 tools** covering everything from timeline editing and color correction to arbitrary Lua scripting and multi-step operation chaining.
+
+---
+
+## Architecture
+
+```
+Claude / AI Assistant
+        |
+        | stdio (JSON-RPC)
+        v
+  MCP Server (Node.js)
+        |
+        | WebSocket (port 27480)
+        v
+   CommandPost (Hammerspoon)
+        |
+        | Accessibility API + Lua scripting
+        v
+  Final Cut Pro / macOS
+```
+
+The MCP server connects to CommandPost's built-in WebSocket server, which provides access to the full Hammerspoon runtime and CommandPost plugin ecosystem. Operations are executed in CommandPost's Lua environment with direct access to Final Cut Pro via the accessibility API.
+
+---
+
+## Prerequisites
+
+- **macOS** (CommandPost is macOS-only)
+- **[CommandPost](https://commandpost.io)** installed and running
+- **Node.js** >= 18.0.0
+- **Final Cut Pro** (for FCP-specific tools)
+
+---
+
+## Setup
+
+### 1. Enable the CommandPost WebSocket Server
+
+Open CommandPost Preferences and enable the WebSocket control surface, or run:
+
+```bash
+defaults write org.latenitefilms.CommandPost "cp.websocket.enabled" -int 1
+```
+
+Then restart CommandPost. The WebSocket server listens on **port 27480** by default.
+
+### 2. Build the MCP Server
+
+```bash
+cd src/mcp-server
+npm install
+npm run build
+```
+
+### 3. Configure Claude Code
+
+Add to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "commandpost": {
+      "command": "node",
+      "args": ["/path/to/CommandPost/src/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Or set the `COMMANDPOST_WS_URL` environment variable if using a non-default port:
+
+```json
+{
+  "mcpServers": {
+    "commandpost": {
+      "command": "node",
+      "args": ["/path/to/CommandPost/src/mcp-server/dist/index.js"],
+      "env": {
+        "COMMANDPOST_WS_URL": "ws://localhost:27480"
+      }
+    }
+  }
+}
+```
+
+### 4. Restart Claude Code
+
+The MCP server loads at session start. After adding the configuration, restart your Claude Code session.
+
+---
+
+## Authentication
+
+The WebSocket connection is authenticated using a shared token. When CommandPost starts the WebSocket server, it generates a random SHA-256 token and writes it to:
+
+```
+~/Library/Application Support/CommandPost/mcp-auth-token
+```
+
+The MCP server reads this token automatically. The token is regenerated each time CommandPost's WebSocket server starts and is restricted to owner-only permissions (`chmod 600`).
+
+You can also set the token via the `COMMANDPOST_AUTH_TOKEN` environment variable.
+
+---
+
+## Tools Reference
+
+### System & Connection (9 tools)
+
+| Tool | Description |
+|------|-------------|
+| `commandpost_ping` | Check if CommandPost is running and the WebSocket connection is active |
+| `commandpost_list_handlers` | List all available action handlers registered in CommandPost |
+| `commandpost_get_handler_info` | Get detailed info about a specific action handler with paginated choices and optional params |
+| `commandpost_execute_lua` | Execute arbitrary Lua code in CommandPost's Hammerspoon environment |
+| `commandpost_execute_action` | Execute a registered action by handler ID and action ID |
+| `commandpost_chain` | Execute multiple operations sequentially with result passing between steps |
+| `commandpost_get_preference` | Get a CommandPost preference value |
+| `commandpost_set_preference` | Set a CommandPost preference value |
+| `commandpost_alert` | Show an on-screen alert/notification |
+
+### Final Cut Pro — Application (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_launch` | Launch Final Cut Pro (or bring to front) |
+| `fcp_quit` | Quit Final Cut Pro |
+| `fcp_restart` | Quit and relaunch Final Cut Pro |
+| `fcp_status` | Get running state, version, frontmost status, and active libraries |
+| `fcp_select_menu` | Select any FCP menu item by path (e.g., `["File", "Share", "Master File..."]`) |
+| `fcp_do_shortcut` | Execute a keyboard shortcut by command ID |
+
+### Final Cut Pro — Timeline (9 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_timeline_show` | Show/focus the timeline on primary or secondary display |
+| `fcp_timeline_playback` | Play, pause, or toggle playback |
+| `fcp_timeline_navigate` | Jump to beginning/end, next/previous frame or edit, or a specific timecode |
+| `fcp_timeline_select` | Select clips: all, none, at playhead, or by 1-based index |
+| `fcp_timeline_blade` | Blade (cut) at the current playhead position |
+| `fcp_timeline_delete` | Delete the selected clips or range (auto-selects at playhead if needed) |
+| `fcp_timeline_clipboard` | Copy, cut, or paste timeline content |
+| `fcp_timeline_zoom` | Zoom in, out, or fit to window |
+| `fcp_timeline_get_info` | Get timeline state: clip list, playhead timecode, undo text, and more |
+
+### Final Cut Pro — Effects & Plugins (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_apply_effect` | Apply a video or audio effect by name (e.g., `"Blur/Gaussian"`) |
+| `fcp_apply_transition` | Apply a transition between clips (e.g., `"Dissolves/Cross Dissolve"`) |
+| `fcp_apply_generator` | Apply a generator to the timeline (e.g., `"Solids/Custom"`) |
+| `fcp_apply_title` | Apply a title to the timeline (e.g., `"Basic Title"`) |
+
+### Final Cut Pro — Discovery (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_list_effects` | List all installed video effects |
+| `fcp_list_audio_effects` | List all installed audio effects |
+| `fcp_list_transitions` | List all installed transitions |
+| `fcp_list_generators` | List all installed generators |
+| `fcp_list_titles` | List all installed titles |
+| `fcp_list_markers` | List all markers in the current timeline |
+
+### Final Cut Pro — Browser & Libraries (3 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_browser_show` | Show the browser panel (libraries, media, or generators) |
+| `fcp_browser_list_libraries` | List all open libraries with paths |
+| `fcp_browser_select_library` | Select a library by name |
+
+### Final Cut Pro — Inspector & Viewer (2 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_inspector_show` | Show inspector and optionally select a tab (audio, video, info, color, etc.) |
+| `fcp_viewer_show` | Show the viewer on primary or secondary display |
+
+### Final Cut Pro — Color (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_color_board` | Adjust Color Board parameters (color/saturation/exposure for master/shadows/midtones/highlights) |
+
+### Final Cut Pro — Export & Import (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_export` | Export/share the current project with optional destination preset |
+| `fcp_export_xml` | Export FCPXML via File > Export XML |
+| `fcp_import_media` | Import a media file or folder |
+| `fcp_import_xml` | Import an FCPXML file |
+
+### Final Cut Pro — Projects & Playhead (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_open_project` | Open a project by name |
+| `fcp_project_properties` | Get project properties (resolution, frame rate, etc.) |
+| `fcp_get_playhead_position` | Get current playhead timecode |
+| `fcp_set_playhead_position` | Set the playhead to a specific timecode |
+| `fcp_get_project_settings` | Get full project settings (resolution, frame rate, color space, audio) |
+
+### Final Cut Pro — Markers & Keywords (2 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_add_marker` | Add a standard, to-do, or chapter marker (optionally named) |
+| `fcp_add_keyword` | Add a keyword to selected clips |
+
+### Final Cut Pro — Clip Operations (10 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_rename_clip` | Rename the selected clip |
+| `fcp_rate_clip` | Rate as favorite, reject, or unrate |
+| `fcp_get_selected_clips` | Get info about selected clips (names, positions, durations) |
+| `fcp_get_clip_properties` | Get transform/compositing properties (position, scale, rotation, opacity) |
+| `fcp_set_clip_properties` | Set transform or compositing properties on the selected clip |
+| `fcp_duplicate_clip` | Duplicate the selected clip(s) |
+| `fcp_enable_disable_clip` | Enable or disable the selected clip(s) |
+| `fcp_create_compound_clip` | Create a compound clip from selected clips |
+| `fcp_create_audition` | Create an audition from selected clips |
+| `fcp_break_apart_compound` | Break apart a compound clip |
+
+### Final Cut Pro — Speed & Retime (2 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_retime` | Apply speed presets (slow 50%/25%/10%, fast 2x-20x, normal, reverse, hold) |
+| `fcp_speed_custom` | Set a custom speed percentage |
+
+### Final Cut Pro — Advanced (9 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_split_at_timecode` | Blade at a specific timecode position |
+| `fcp_set_range` | Set timeline in/out range selection |
+| `fcp_clear_range` | Clear the range selection |
+| `fcp_captions` | Add, extract, or import captions |
+| `fcp_multicam_switch_angle` | Switch multicam angle (video, audio, or both) |
+| `fcp_assign_role` | Assign a role to selected clips |
+| `fcp_stabilization` | Toggle stabilization on the selected clip |
+| `fcp_proxy_toggle` | Toggle proxy/optimized/original media |
+| `fcp_batch_apply_transition` | Apply a transition to all edit points in a selection |
+
+### Final Cut Pro — Window & Undo (3 tools)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_window_layout` | Show/hide browser, inspector, timeline, viewer, or toggle fullscreen |
+| `fcp_undo_redo` | Undo or redo (with optional count for multiple undos) |
+| `fcp_pasteboard` | Access CommandPost's clipboard history for timeline content |
+
+### Final Cut Pro — Workflow (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `fcp_assemble_rough_cut` | Assemble a rough cut from a sequence of operations in one call |
+
+---
+
+## Verification
+
+Editing tools return **verification data** so you can confirm operations actually succeeded:
+
+```json
+{
+  "action": "blade",
+  "before": { "clipCount": 12, "timecode": "00:00:05:00" },
+  "after": {
+    "clipCount": 13,
+    "timecode": "00:00:05:00",
+    "undoText": "Undo Blade",
+    "clips": [
+      { "description": "Generator:Placeholder", "duration": "00:00:01:20" },
+      { "description": "Generator:Placeholder", "duration": "00:00:01:10" }
+    ]
+  },
+  "verified": {
+    "undoText": "Undo Blade",
+    "clipDelta": 1,
+    "tcChanged": false
+  }
+}
+```
+
+**Three verification signals:**
+
+| Signal | What it tells you |
+|--------|-------------------|
+| `verified.undoText` | FCP's own name for the last action (e.g., `"Undo Blade"`, `"Undo Add Cross Dissolve"`) |
+| `verified.clipDelta` | Change in clip count (`+1` = clip added, `-1` = clip removed) |
+| `verified.tcChanged` | Whether the playhead moved (key for navigation verification) |
+
+Navigation tools return **timecode verification**:
+
+```json
+{
+  "navigated": "next_edit",
+  "beforeTimecode": "00:00:05:00",
+  "afterTimecode": "00:00:10:00",
+  "timecodeChanged": true
+}
+```
+
+### Dialog Handling
+
+When FCP presents a modal dialog (e.g., "not enough extra media beyond clip edges" when applying a transition), the server automatically detects and handles it. The `handleFCPDialog` helper scans for AXSheets and modal windows, reads their text, and clicks the appropriate button. This is integrated into both the `withVerification` wrapper and the `fcp_apply_transition` tool.
+
+---
+
+## Chaining Operations
+
+The `commandpost_chain` tool executes multiple steps sequentially, passing results between them via the `_prev` variable:
+
+```json
+{
+  "operations": [
+    { "type": "execute", "code": "require('cp.apple.finalcutpro'):doShortcut('JumpToStart'):Now() return 'at_start'" },
+    { "type": "execute", "code": "require('cp.apple.finalcutpro'):doShortcut('NextEdit'):Now() return 'at_edit_1'" },
+    { "type": "command", "handler": "fcpx_transition", "actionId": "Cross Dissolve" },
+    { "type": "delay", "seconds": 0.5 },
+    { "type": "execute", "code": "require('cp.apple.finalcutpro'):doShortcut('AddMarker'):Now() return 'marker_added'" }
+  ]
+}
+```
+
+**Operation types:**
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `execute` | `code` | Run Lua code; result available as `_prev` in next step |
+| `command` | `handler`, `actionId` | Execute a registered action handler |
+| `query` | `query` | Query handler information |
+| `delay` | `seconds` | Pause between operations (max 10s) |
+
+---
+
+## Lua Execution
+
+The `commandpost_execute_lua` tool is the escape hatch — it can do **anything** CommandPost can do:
+
+```lua
+-- Get FCP timeline info
+local fcp = require("cp.apple.finalcutpro")
+return {
+  running = fcp:isRunning(),
+  version = tostring(fcp:version()),
+  timeline_showing = fcp.timeline:isShowing(),
+}
+```
+
+```lua
+-- Show an alert and play a sound
+hs.alert.show("Hello from MCP!")
+hs.sound.getByName("Funk"):play()
+return true
+```
+
+The code runs with full access to:
+- `hs` — Hammerspoon API (windows, keyboard, mouse, audio, network, etc.)
+- `require("cp.*")` — CommandPost modules (FCP automation, plugins, config)
+- All standard Lua 5.4 libraries
+
+---
+
+## FCP v12 Compatibility
+
+This fork includes fixes for Final Cut Pro v12 (version 12.0+):
+
+- **Toolbar checkbox detection**: FCP v12 no longer wraps toolbar checkboxes in `AXGroup` elements. The `PrimaryToolbar.lua` module now falls back to description-based matching for the Keyword Editor, Browser, Timeline, and Inspector checkboxes.
+- **Menu item relocation**: "Rename Clip" moved from the Modify menu to the Clip menu in v12. The MCP server tries both locations.
+- **Lua pattern safety**: All `selectMenu` calls use `{plain = true}` to prevent crashes from special characters (`%`, `.`, `(`, `)`) in menu item names.
+- **Plugin name-only matching**: The `findFCPXPluginBySimplifiedPath` function now supports name-only matching as a fallback (e.g., `"Cross Dissolve"` without requiring `"Dissolves/Cross Dissolve"`).
+
+---
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Watch mode (rebuild on changes)
+npm run dev
+
+# Run tests (offline — protocol only)
+node test.mjs
+
+# Run tests (live — requires running CommandPost with WebSocket enabled)
+node test.mjs --live
+```
+
+### Project Structure
+
+```
+src/mcp-server/
+  src/
+    index.ts          # MCP server, tool definitions, and handlers
+    commandpost.ts    # WebSocket client for CommandPost
+  dist/               # Compiled JavaScript (git-ignored)
+  test.mjs            # Test suite
+  package.json
+  tsconfig.json
+```
+
+### Adding New Tools
+
+1. Add the tool definition to the `TOOLS` array in `src/index.ts` (name, description, inputSchema)
+2. Add the handler in the `handleTool` switch statement
+3. Use `withVerification()` for editing operations or `withUndoCheck()` for lighter verification
+4. Rebuild with `npm run build`
+
+---
+
+## How It Works
+
+### WebSocket Protocol
+
+The MCP server communicates with CommandPost via a JSON WebSocket protocol:
+
+| Message Type | Description |
+|-------------|-------------|
+| `ping` | Health check |
+| `command` | Execute a registered action handler |
+| `query` | Query handler info |
+| `execute` | Run arbitrary Lua code |
+| `batch` | Run multiple operations sequentially |
+
+Every message includes an `auth` field with the session token. Messages without valid authentication are rejected.
+
+### Lua-Side Changes
+
+This fork adds the following to CommandPost's WebSocket message handler (`src/plugins/core/websocket/manager/message-handler.lua`):
+
+1. **`execute` message type** — Compiles and runs Lua code via `load()`, with safe serialization of results (handles tables, userdata, circular references)
+2. **`batch` message type** — Runs multiple operations sequentially, passing results between steps via the `_prev` global
+3. **Authentication** — Token-based auth with SHA-256 tokens written to a well-known file path
+4. **Audit logging** — All incoming messages are logged with timestamps for debugging
+5. **Plugin name-only matching** — Fallback matching for transitions and other plugins that lack filesystem paths
+
+### Focus Management
+
+FCP keyboard shortcuts require the app to be frontmost. The `activateFinalCutPro()` helper ensures FCP is active before operations. Menu reads (`getMenuItems()`) are only performed **after** operations to avoid stealing focus. The `withVerification` wrapper captures before/after state including clip counts and undo text via AX-based reads instead of menu reads where possible.
+
+---
+
+## License
+
+MIT — Same as CommandPost.

--- a/src/mcp-server/package-lock.json
+++ b/src/mcp-server/package-lock.json
@@ -1,0 +1,1213 @@
+{
+  "name": "@commandpost/mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@commandpost/mcp-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "commandpost-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.0",
+        "@types/ws": "^8.18.0",
+        "typescript": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/src/mcp-server/package.json
+++ b/src/mcp-server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@commandpost/mcp-server",
+  "version": "1.0.0",
+  "description": "MCP (Model Context Protocol) server for CommandPost — exposes full automation capabilities for Final Cut Pro and macOS workflows",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "commandpost-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch",
+    "test:edit-workflow": "node test-edit-workflow.mjs",
+    "test:edit-workflow:mini": "node test-edit-workflow-mini.mjs",
+    "test:edit-workflow:storm": "node test-edit-workflow-storm.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "@types/ws": "^8.18.0",
+    "typescript": "^5.8.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/src/mcp-server/src/commandpost.ts
+++ b/src/mcp-server/src/commandpost.ts
@@ -1,0 +1,408 @@
+/**
+ * CommandPost WebSocket Client
+ *
+ * Manages the WebSocket connection to CommandPost's built-in server.
+ * Handles message correlation via IDs, automatic reconnection,
+ * and serialization.
+ */
+
+import WebSocket from "ws";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+export interface CommandPostResponse {
+  type: string;
+  id?: string;
+  timestamp?: number;
+  status?: "success" | "error";
+  result?: unknown;
+  error?: string;
+}
+
+export interface ExecuteResult {
+  result: unknown;
+}
+
+export interface BatchResult {
+  results: Array<{
+    index: number;
+    status: "success" | "error";
+    result?: unknown;
+    error?: string;
+  }>;
+  totalOperations: number;
+  completedOperations: number;
+}
+
+export interface HandlerInfo {
+  id: string;
+  group: string;
+  label: string;
+}
+
+export class CommandPostClient {
+  private ws: WebSocket | null = null;
+  private connectPromise: Promise<void> | null = null;
+  private pendingRequests: Map<string, PendingRequest> = new Map();
+  private messageCounter = 0;
+  private url: string;
+  private reconnecting = false;
+  private authToken: string | null = null;
+  private authTokenLoadedAt = 0;
+  /** How long (ms) to cache the auth token before re-reading from disk */
+  private static readonly AUTH_TOKEN_TTL_MS = 60000;
+  /** Ring buffer for deduplication: stores recent message IDs with O(1) add and bounded memory. */
+  private seenIds: Map<string, number> = new Map();
+  private static readonly SEEN_IDS_MAX = 5000;
+
+  /** Well-known paths where CommandPost writes the auth token */
+  private static readonly AUTH_TOKEN_PATHS = [
+    path.join(os.homedir(), "Library", "Application Support", "CommandPost", "mcp-auth-token"),
+    path.join(os.homedir(), ".CommandPost", "mcp-auth-token"),
+  ];
+
+  constructor(url?: string) {
+    this.url = url || process.env.COMMANDPOST_WS_URL || "ws://localhost:27480";
+    this.loadAuthToken();
+  }
+
+  /** Load auth token from env var or well-known file path (cached with TTL) */
+  private loadAuthToken(force = false): void {
+    // Use cached token if within TTL unless forced
+    if (!force && this.authToken && (Date.now() - this.authTokenLoadedAt) < CommandPostClient.AUTH_TOKEN_TTL_MS) {
+      return;
+    }
+
+    // Check env var first
+    if (process.env.COMMANDPOST_AUTH_TOKEN) {
+      this.authToken = process.env.COMMANDPOST_AUTH_TOKEN;
+      this.authTokenLoadedAt = Date.now();
+      return;
+    }
+
+    // Try well-known file paths
+    for (const tokenPath of CommandPostClient.AUTH_TOKEN_PATHS) {
+      try {
+        const token = fs.readFileSync(tokenPath, "utf-8").trim();
+        if (token) {
+          this.authToken = token;
+          this.authTokenLoadedAt = Date.now();
+          return;
+        }
+      } catch {
+        // File doesn't exist, try next path
+      }
+    }
+  }
+
+  isConnected(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+  }
+
+  async connect(): Promise<void> {
+    if (this.isConnected()) return;
+    if (this.connectPromise) return this.connectPromise;
+
+    this.connectPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.connectPromise = null;
+        if (this.ws && this.ws.readyState === WebSocket.CONNECTING) {
+          this.ws.terminate();
+        }
+        reject(
+          new Error(
+            `Connection to CommandPost timed out. Ensure CommandPost is running and WebSocket is enabled at ${this.url}.`
+          )
+        );
+      }, 10000);
+
+      let settled = false;
+
+      const resolveConnection = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        this.connectPromise = null;
+        this.reconnecting = false;
+        resolve();
+      };
+
+      const rejectConnection = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        this.connectPromise = null;
+        reject(error);
+      };
+
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(this.url);
+        this.ws = socket;
+      } catch (err) {
+        clearTimeout(timeout);
+        this.connectPromise = null;
+        reject(
+          new Error(
+            `Failed to create WebSocket: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+        return;
+      }
+
+      socket.on("open", () => {
+        // Reload auth token on new connection in case CommandPost restarted
+        this.loadAuthToken();
+        resolveConnection();
+      });
+
+      socket.on("message", (data: WebSocket.Data) => {
+        this.handleIncomingMessage(data);
+      });
+
+      socket.on("error", (err: Error) => {
+        if (!this.reconnecting) {
+          rejectConnection(
+            new Error(
+              `WebSocket error: ${err.message}. Is CommandPost running with WebSocket enabled?`
+            )
+          );
+        }
+      });
+
+      socket.on("close", () => {
+        if (this.ws === socket) {
+          this.ws = null;
+        }
+
+        rejectConnection(
+          new Error("Connection to CommandPost closed before it became ready.")
+        );
+
+        // Reject all pending requests
+        for (const [id, pending] of this.pendingRequests) {
+          clearTimeout(pending.timeout);
+          pending.reject(new Error("Connection closed"));
+          this.pendingRequests.delete(id);
+        }
+      });
+    });
+
+    return this.connectPromise;
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connectPromise = null;
+    for (const [id, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error("Disconnected from CommandPost"));
+      this.pendingRequests.delete(id);
+    }
+    this.pendingRequests.clear();
+    this.seenIds.clear();
+  }
+
+  async ensureConnected(): Promise<void> {
+    if (!this.isConnected()) {
+      await this.connect();
+    }
+  }
+
+  private nextId(): string {
+    return `mcp-${++this.messageCounter}-${Date.now()}`;
+  }
+
+  private handleIncomingMessage(data: WebSocket.Data): void {
+    const text = data.toString();
+    if (!text || text === "") return;
+
+    let message: CommandPostResponse;
+    try {
+      message = JSON.parse(text);
+    } catch {
+      return; // Ignore non-JSON messages
+    }
+
+    // Match response to pending request by ID
+    if (message.id) {
+      // Deduplicate (response may arrive via both callback return and broadcast)
+      if (this.seenIds.has(message.id)) return;
+      this.seenIds.set(message.id, this.messageCounter);
+
+      // Evict oldest entries when limit is reached (Map iterates in insertion order)
+      if (this.seenIds.size > CommandPostClient.SEEN_IDS_MAX) {
+        const deleteCount = this.seenIds.size - CommandPostClient.SEEN_IDS_MAX;
+        let deleted = 0;
+        for (const key of this.seenIds.keys()) {
+          if (deleted >= deleteCount) break;
+          this.seenIds.delete(key);
+          deleted++;
+        }
+      }
+
+      const pending = this.pendingRequests.get(message.id);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        this.pendingRequests.delete(message.id);
+
+        if (message.status === "error") {
+          // If auth failed, force-reload token for next request
+          if (message.error && message.error.includes("Authentication failed")) {
+            this.loadAuthToken(true);
+          }
+          pending.reject(
+            new Error(message.error || "Unknown error from CommandPost")
+          );
+        } else {
+          pending.resolve(message);
+        }
+      }
+    }
+  }
+
+  private static readonly MAX_PENDING_REQUESTS = 100;
+
+  private async sendRaw(
+    messageObj: Record<string, unknown>,
+    timeoutMs = 30000
+  ): Promise<CommandPostResponse> {
+    await this.ensureConnected();
+
+    // Refresh auth token if TTL expired or missing
+    this.loadAuthToken();
+
+    if (this.pendingRequests.size >= CommandPostClient.MAX_PENDING_REQUESTS) {
+      throw new Error(
+        `Too many pending requests (${this.pendingRequests.size}). CommandPost may be unresponsive.`
+      );
+    }
+
+    // Inject auth token into every message
+    const authenticatedMsg = this.authToken
+      ? { ...messageObj, auth: this.authToken }
+      : messageObj;
+
+    const id = messageObj.id as string;
+    const messageStr = JSON.stringify(authenticatedMsg);
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        const socket = this.ws;
+        this.ws = null;
+        this.connectPromise = null;
+        if (socket) {
+          try {
+            socket.terminate();
+          } catch {
+            // Ignore socket teardown failures on timeout.
+          }
+        }
+        reject(
+          new Error(
+            `Request timed out after ${timeoutMs}ms. CommandPost may be busy or unresponsive.`
+          )
+        );
+      }, timeoutMs);
+
+      this.pendingRequests.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timeout,
+      });
+
+      this.ws!.send(messageStr, (err) => {
+        if (err) {
+          clearTimeout(timeout);
+          this.pendingRequests.delete(id);
+          const socket = this.ws;
+          this.ws = null;
+          this.connectPromise = null;
+          if (socket) {
+            try {
+              socket.terminate();
+            } catch {
+              // Ignore socket teardown failures after send errors.
+            }
+          }
+          reject(new Error(`Failed to send message: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  // ── High-level API methods ──────────────────────────────────────────
+
+  /** Ping CommandPost to check connectivity */
+  async ping(): Promise<CommandPostResponse> {
+    const id = this.nextId();
+    return this.sendRaw({ type: "ping", id });
+  }
+
+  /** Execute arbitrary Lua code in CommandPost's environment */
+  async executeLua(
+    code: string,
+    timeoutMs = 30000
+  ): Promise<CommandPostResponse> {
+    const id = this.nextId();
+    return this.sendRaw(
+      { type: "execute", id, payload: { code } },
+      timeoutMs
+    );
+  }
+
+  /** Execute a registered action handler */
+  async executeAction(
+    handler: string,
+    actionId?: string,
+    parameters?: Record<string, unknown>
+  ): Promise<CommandPostResponse> {
+    const id = this.nextId();
+    return this.sendRaw({
+      type: "command",
+      id,
+      payload: { handler, actionId, parameters },
+    });
+  }
+
+  /** Query for available handlers or handler info */
+  async query(
+    queryType: string,
+    payload?: Record<string, unknown>
+  ): Promise<CommandPostResponse> {
+    const id = this.nextId();
+    return this.sendRaw({
+      type: "query",
+      id,
+      payload: { query: queryType, ...payload },
+    });
+  }
+
+  /** Execute a batch of operations sequentially */
+  async executeBatch(
+    operations: Array<Record<string, unknown>>,
+    stopOnError = true,
+    timeoutMs = 60000
+  ): Promise<CommandPostResponse> {
+    const id = this.nextId();
+    return this.sendRaw(
+      {
+        type: "batch",
+        id,
+        payload: { operations, stopOnError },
+      },
+      timeoutMs
+    );
+  }
+}

--- a/src/mcp-server/src/index.ts
+++ b/src/mcp-server/src/index.ts
@@ -1,0 +1,6337 @@
+#!/usr/bin/env node
+
+/**
+ * CommandPost MCP Server
+ *
+ * A comprehensive Model Context Protocol server that exposes CommandPost's
+ * full automation capabilities — Final Cut Pro control, macOS workflow
+ * automation, Lua scripting, action handlers, and operation chaining.
+ *
+ * Communicates with CommandPost via its built-in WebSocket server.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { CommandPostClient } from "./commandpost.js";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Logging (stderr to avoid polluting MCP JSON-RPC on stdout)
+// ═══════════════════════════════════════════════════════════════════════════
+
+function log(level: "info" | "warn" | "error" | "debug", message: string, data?: unknown): void {
+  const timestamp = new Date().toISOString();
+  const prefix = `[${timestamp}] [commandpost-mcp] [${level.toUpperCase()}]`;
+  if (data !== undefined) {
+    console.error(`${prefix} ${message}`, typeof data === "string" ? data : JSON.stringify(data));
+  } else {
+    console.error(`${prefix} ${message}`);
+  }
+}
+
+const client = new CommandPostClient();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Lua Preamble & Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Standard Lua preamble injected before tool scripts.
+ * Provides commonly-used requires and safe helper functions so individual
+ * tool handlers don't need to repeat them.
+ */
+const LUA_PREAMBLE = `
+local fcp = require("cp.apple.finalcutpro")
+
+--- Safely read a value; returns nil on error instead of throwing.
+local function safeGet(fn)
+  local ok, val = pcall(fn)
+  if ok then return val end
+  return nil
+end
+
+--- Detect and handle FCP modal dialogs (sheets/alerts).
+--- Returns a table describing what was found and handled, or nil if no dialog.
+--- By default clicks the primary (default) button to proceed.
+--- @param preferCancel boolean  If true, click Cancel instead of the default button.
+local function handleFCPDialog(preferCancel)
+  local result = nil
+  pcall(function()
+    local app = fcp:application()
+    if not app then return end
+    local axApp = hs.axuielement.applicationElement(app)
+    local windows = axApp:attributeValue("AXWindows") or {}
+    for _, w in ipairs(windows) do
+      -- Check sheets attached to each window
+      local sheets = w:attributeValue("AXSheets") or {}
+      for _, sheet in ipairs(sheets) do
+        local children = sheet:attributeValue("AXChildren") or {}
+        local texts, buttons = {}, {}
+        for _, c in ipairs(children) do
+          local role = c:attributeValue("AXRole") or ""
+          if role == "AXStaticText" then
+            table.insert(texts, c:attributeValue("AXValue") or c:attributeValue("AXTitle") or "")
+          elseif role == "AXButton" then
+            table.insert(buttons, {title = c:attributeValue("AXTitle") or "", element = c})
+          end
+        end
+        if #buttons > 0 then
+          result = {dialogType = "sheet", texts = texts, buttonTitles = {}}
+          for _, b in ipairs(buttons) do table.insert(result.buttonTitles, b.title) end
+          -- Click the appropriate button
+          local clicked = false
+          if preferCancel then
+            for _, b in ipairs(buttons) do
+              if b.title == "Cancel" then
+                b.element:performAction("AXPress")
+                result.clicked = "Cancel"
+                clicked = true
+                break
+              end
+            end
+          end
+          if not clicked then
+            -- Click first non-Cancel button (the primary action)
+            for _, b in ipairs(buttons) do
+              if b.title ~= "Cancel" then
+                b.element:performAction("AXPress")
+                result.clicked = b.title
+                clicked = true
+                break
+              end
+            end
+            -- Fallback: click first button
+            if not clicked and buttons[1] then
+              buttons[1].element:performAction("AXPress")
+              result.clicked = buttons[1].title
+            end
+          end
+          return
+        end
+      end
+      -- Also check for modal windows (not sheets)
+      local modal = w:attributeValue("AXModal")
+      local subrole = w:attributeValue("AXSubrole") or ""
+      if modal or subrole == "AXDialog" or subrole == "AXSystemDialog" then
+        local children = w:attributeValue("AXChildren") or {}
+        local texts, buttons = {}, {}
+        for _, c in ipairs(children) do
+          local role = c:attributeValue("AXRole") or ""
+          if role == "AXStaticText" then
+            table.insert(texts, c:attributeValue("AXValue") or c:attributeValue("AXTitle") or "")
+          elseif role == "AXButton" then
+            table.insert(buttons, {title = c:attributeValue("AXTitle") or "", element = c})
+          elseif role == "AXGroup" then
+            for _, gc in ipairs(c:attributeValue("AXChildren") or {}) do
+              if gc:attributeValue("AXRole") == "AXButton" then
+                table.insert(buttons, {title = gc:attributeValue("AXTitle") or "", element = gc})
+              end
+            end
+          end
+        end
+        if #buttons > 0 then
+          result = {dialogType = "modal", title = w:attributeValue("AXTitle"), buttonTitles = {}}
+          for _, b in ipairs(buttons) do table.insert(result.buttonTitles, b.title) end
+          local clicked = false
+          if preferCancel then
+            for _, b in ipairs(buttons) do
+              if b.title == "Cancel" then
+                b.element:performAction("AXPress")
+                result.clicked = "Cancel"
+                clicked = true
+                break
+              end
+            end
+          end
+          if not clicked then
+            for _, b in ipairs(buttons) do
+              if b.title ~= "Cancel" then
+                b.element:performAction("AXPress")
+                result.clicked = b.title
+                clicked = true
+                break
+              end
+            end
+            if not clicked and buttons[1] then
+              buttons[1].element:performAction("AXPress")
+              result.clicked = buttons[1].title
+            end
+          end
+          return
+        end
+      end
+    end
+  end)
+  return result
+end
+`;
+
+/**
+ * Wrap a Lua script with the standard preamble and pcall error handling.
+ * Returns JSON with { success = true/false, ... } shape.
+ */
+function safeLua(code: string): string {
+  return `${LUA_PREAMBLE}
+local __ok, __result = pcall(function()
+  ${code}
+end)
+if not __ok then
+  return {success = false, error = tostring(__result)}
+end
+if type(__result) == "table" then
+  __result.success = true
+  return __result
+end
+return {success = true, value = __result}
+`;
+}
+
+const FCP_STATUS_LUA = safeLua(`
+  local result = {
+    running = fcp:isRunning(),
+    frontmost = safeGet(function() return fcp:isFrontmost() end),
+    installed = safeGet(function() return fcp:isInstalled() end),
+    version = safeGet(function() return fcp:version() and tostring(fcp:version()) end),
+    path = safeGet(function() return fcp:getPath() end),
+  }
+  result.activeLibraries = safeGet(function() return fcp:activeLibraryNames() end)
+  result.activeLibraryPaths = safeGet(function() return fcp:activeLibraryPaths() end)
+  result.currentTimecode = safeGet(function() return fcp.viewer:timecode() end)
+  result.playing = safeGet(function() return fcp.viewer:isPlaying() end)
+  return result
+`);
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tool Definitions
+// ═══════════════════════════════════════════════════════════════════════════
+
+const TOOLS = [
+  // ── System & Connection ─────────────────────────────────────────────
+  {
+    name: "commandpost_ping",
+    description:
+      "Check if CommandPost is running and the WebSocket connection is active. Use this to verify connectivity before performing operations.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "commandpost_list_handlers",
+    description:
+      "List all available action handlers registered in CommandPost. Returns handler IDs, groups, and labels. Use this to discover what actions can be executed via commandpost_execute_action.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "commandpost_get_handler_info",
+    description:
+      "Get detailed information about a specific action handler. Choices are paginated and params are omitted unless explicitly requested.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        handler: {
+          type: "string",
+          description:
+            'The handler ID (e.g., "fcpx_videoEffect", "global_shortcuts")',
+        },
+        includeChoices: {
+          type: "boolean",
+          description:
+            "Include action choices in the response (default: true).",
+        },
+        includeParams: {
+          type: "boolean",
+          description:
+            "Include serialized choice params for each returned choice (default: false).",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of choices to return (default: 200, max: 1000).",
+        },
+        offset: {
+          type: "number",
+          description:
+            "Zero-based choice offset for pagination (default: 0).",
+        },
+      },
+      required: ["handler"],
+    },
+  },
+
+  // ── Lua Execution ───────────────────────────────────────────────────
+  {
+    name: "commandpost_execute_lua",
+    description:
+      "Execute arbitrary Lua code in CommandPost's Hammerspoon environment. This is the most powerful tool — it can do ANYTHING CommandPost can do. The code runs with full access to the `hs` (Hammerspoon) API, `cp` (CommandPost) modules, and all loaded plugins. For expressions, the result is returned automatically. For statements, use explicit `return`. Examples: 'hs.alert.show(\"Hello\")' or 'local fcp = require(\"cp.apple.finalcutpro\") return fcp:isRunning()'.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        code: {
+          type: "string",
+          description:
+            'Lua code to execute. Expressions auto-return (e.g., "1+1" returns 2). For statements, use explicit return.',
+        },
+      },
+      required: ["code"],
+    },
+  },
+
+  // ── Action System ───────────────────────────────────────────────────
+  {
+    name: "commandpost_execute_action",
+    description:
+      "Execute a registered CommandPost action by handler ID and optional action ID. Handlers include: global_shortcuts, global_menuactions, fcpx_videoEffect, fcpx_audioEffect, fcpx_generator, fcpx_title, fcpx_transition, and more. Use commandpost_list_handlers to discover available handlers.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        handler: {
+          type: "string",
+          description:
+            'The action handler ID (e.g., "fcpx_videoEffect", "global_shortcuts")',
+        },
+        actionId: {
+          type: "string",
+          description:
+            'Optional action ID within the handler. For FCPX plugins, can be a simplified path like "Blur/Prism" or full path.',
+        },
+        parameters: {
+          type: "object",
+          description: "Optional parameters to pass to the action",
+        },
+      },
+      required: ["handler"],
+    },
+  },
+
+  // ── Chaining / Batch ───────────────────────────────────────────────
+  {
+    name: "commandpost_chain",
+    description:
+      'Execute multiple operations sequentially with optional result passing between steps. Each operation can be: {"type":"execute","code":"..."} for Lua, {"type":"command","handler":"...","actionId":"..."} for actions, {"type":"delay","seconds":N} for pauses. The result of each step is available as `_prev` in subsequent Lua execute steps. Great for complex workflows like: apply effect → adjust parameters → add marker.',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        operations: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              type: {
+                type: "string",
+                enum: ["execute", "command", "query", "delay"],
+              },
+              code: { type: "string" },
+              handler: { type: "string" },
+              actionId: { type: "string" },
+              seconds: { type: "number" },
+            },
+            required: ["type"],
+          },
+          description: "Array of operations to execute in sequence",
+        },
+        stopOnError: {
+          type: "boolean",
+          description:
+            "Stop executing if any operation fails (default: true)",
+        },
+      },
+      required: ["operations"],
+    },
+  },
+
+  // ── Preferences ─────────────────────────────────────────────────────
+  {
+    name: "commandpost_get_preference",
+    description:
+      "Get a CommandPost preference/setting value by key. CommandPost stores preferences using cp.config.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        key: {
+          type: "string",
+          description: 'The preference key (e.g., "websocket.enabled")',
+        },
+      },
+      required: ["key"],
+    },
+  },
+  {
+    name: "commandpost_set_preference",
+    description: "Set a CommandPost preference/setting value.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        key: {
+          type: "string",
+          description: "The preference key",
+        },
+        value: {
+          description:
+            "The value to set (string, number, boolean, or null to clear)",
+        },
+      },
+      required: ["key", "value"],
+    },
+  },
+
+  // ── Final Cut Pro — Application ─────────────────────────────────────
+  {
+    name: "fcp_launch",
+    description:
+      "Launch Final Cut Pro. If already running, brings it to the front.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_quit",
+    description: "Quit Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_restart",
+    description:
+      "Restart Final Cut Pro by quitting and relaunching it.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_status",
+    description:
+      "Get the current status of Final Cut Pro — whether it's running, frontmost, installed, version info, and active library/project details.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_select_menu",
+    description:
+      'Select a Final Cut Pro menu item by its path. The path is an array of menu item names from top-level menu to the specific item. Example: ["Edit", "Select All"] or ["File", "Share", "Master File..."].',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        path: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            'Menu path as array of strings, e.g., ["Clip", "Solo Animation"]',
+        },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "fcp_do_shortcut",
+    description:
+      'Execute a Final Cut Pro keyboard shortcut by its command ID. Examples: "SelectAll", "Paste", "PlayPause", "Blade", etc.',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        command: {
+          type: "string",
+          description:
+            'The FCP command ID (e.g., "SelectAll", "Blade", "PlayPause")',
+        },
+      },
+      required: ["command"],
+    },
+  },
+
+  // ── Final Cut Pro — Timeline ────────────────────────────────────────
+  {
+    name: "fcp_timeline_show",
+    description:
+      "Show or focus the Final Cut Pro timeline. Can show on primary or secondary display.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        display: {
+          type: "string",
+          enum: ["primary", "secondary"],
+          description: "Which display to show the timeline on (default: primary)",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_timeline_playback",
+    description:
+      "Control timeline playback — play, pause, or toggle play/pause.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["play", "pause", "toggle"],
+          description: "Playback action (default: toggle)",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_timeline_navigate",
+    description:
+      "Navigate the timeline — go to beginning, end, next/previous frame, next/previous edit point, or a specific timecode.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: [
+            "beginning",
+            "end",
+            "next_frame",
+            "previous_frame",
+            "next_edit",
+            "previous_edit",
+            "timecode",
+          ],
+          description: "Navigation action",
+        },
+        timecode: {
+          type: "string",
+          description:
+            'Timecode to navigate to (only used with "timecode" action), e.g., "00:01:30:00"',
+        },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_timeline_select",
+    description:
+      "Select or deselect clips in the timeline. Use 'at_playhead' to select the clip under the playhead, 'by_index' to select by clip index (1-based), 'all' to select all, or 'none' to deselect.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["all", "none", "at_playhead", "by_index"],
+          description:
+            "Selection action: 'all' to select all, 'none' to deselect, 'at_playhead' to select clip under playhead, 'by_index' to select by clip index",
+        },
+        index: {
+          type: "number",
+          description:
+            "1-based clip index (only used with 'by_index' action). Counts only actual clips, not transitions.",
+        },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_timeline_blade",
+    description:
+      "Blade (cut) the clip at the current playhead position in the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_timeline_delete",
+    description:
+      "Delete the currently selected clips or range in the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_timeline_clipboard",
+    description: "Copy, cut, or paste timeline content.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["copy", "cut", "paste"],
+          description: "Clipboard action",
+        },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_timeline_zoom",
+    description: "Zoom the timeline in, out, or to fit the entire project.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["in", "out", "fit"],
+          description: "Zoom action",
+        },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_timeline_get_info",
+    description:
+      "Get information about the current timeline state — playhead position, whether it's playing, showing, focused, etc.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Final Cut Pro — Effects & Plugins ──────────────────────────────
+  {
+    name: "fcp_apply_effect",
+    description:
+      'Apply a video or audio effect to the selected clip(s). Use a simplified path like "Blur/Gaussian" or "Color/Color Wheels" or the full plugin path.',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description:
+            'Effect name or path (e.g., "Blur/Gaussian", "Stylize/Comic Book")',
+        },
+        type: {
+          type: "string",
+          enum: ["video", "audio"],
+          description: "Effect type (default: video)",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fcp_apply_transition",
+    description:
+      'Apply a transition between clips. Use a simplified path like "Dissolves/Cross Dissolve".',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description:
+            'Transition name or path (e.g., "Dissolves/Cross Dissolve")',
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fcp_apply_generator",
+    description:
+      'Apply a generator to the timeline. Use a simplified path like "Backgrounds/Gradient".',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description:
+            'Generator name or path (e.g., "Solids/Custom", "Backgrounds/Gradient")',
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fcp_apply_title",
+    description:
+      'Apply a title to the timeline. Use a simplified path like "Build In/Build Out/Typewriter".',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description:
+            'Title name or path (e.g., "Bumper/Opener/Basic Title")',
+        },
+      },
+      required: ["name"],
+    },
+  },
+
+  // ── Final Cut Pro — Browser ────────────────────────────────────────
+  {
+    name: "fcp_browser_show",
+    description: "Show or hide the Final Cut Pro browser panel.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        panel: {
+          type: "string",
+          enum: ["libraries", "media", "generators"],
+          description: "Which browser panel to show (default: libraries)",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_browser_list_libraries",
+    description:
+      "List all open Final Cut Pro libraries and their paths.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_browser_select_library",
+    description: "Select an open library by its title/name.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        title: {
+          type: "string",
+          description: "The library title/name to select",
+        },
+      },
+      required: ["title"],
+    },
+  },
+
+  // ── Final Cut Pro — Inspector ─────────────────────────────────────
+  {
+    name: "fcp_inspector_show",
+    description:
+      "Show the inspector panel and optionally select a specific tab.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tab: {
+          type: "string",
+          enum: [
+            "audio",
+            "video",
+            "info",
+            "color",
+            "effect",
+            "generator",
+            "share",
+            "text",
+            "title",
+            "transition",
+          ],
+          description: "Inspector tab to select (optional)",
+        },
+      },
+    },
+  },
+
+  // ── Final Cut Pro — Viewer ─────────────────────────────────────────
+  {
+    name: "fcp_viewer_show",
+    description: "Show the viewer on the primary or secondary display.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        display: {
+          type: "string",
+          enum: ["primary", "secondary"],
+          description: "Which display (default: primary)",
+        },
+      },
+    },
+  },
+
+  // ── Final Cut Pro — Color ──────────────────────────────────────────
+  {
+    name: "fcp_color_board",
+    description:
+      "Adjust the Color Board in Final Cut Pro. Controls color, saturation, and exposure with master, shadows, midtones, and highlights pucks.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        aspect: {
+          type: "string",
+          enum: ["color", "saturation", "exposure"],
+          description: "Which color board aspect to adjust",
+        },
+        puck: {
+          type: "string",
+          enum: ["master", "shadows", "midtones", "highlights"],
+          description: "Which puck to adjust",
+        },
+        value: {
+          type: "number",
+          description: "Value to set (range depends on aspect: typically -100 to 100)",
+        },
+        property: {
+          type: "string",
+          enum: ["percentage", "angle"],
+          description:
+            "Which property to set. 'percentage' for saturation/exposure, 'angle' for color hue (default: percentage)",
+        },
+      },
+      required: ["aspect", "puck", "value"],
+    },
+  },
+
+  // ── Final Cut Pro — Export/Import ──────────────────────────────────
+  {
+    name: "fcp_export",
+    description:
+      "Export/share the current Final Cut Pro project. Opens the export dialog with an optional destination preset.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        destination: {
+          type: "string",
+          description:
+            'Optional share destination name (e.g., "Master File", "Apple Devices 1080p")',
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_import_media",
+    description:
+      "Import a media file or folder into Final Cut Pro from a file path using the Media Import window.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        path: {
+          type: "string",
+          description: "File or folder path to import",
+        },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "fcp_import_xml",
+    description: "Import an FCPXML file into Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the FCPXML file",
+        },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "fcp_export_xml",
+    description:
+      "Export the current project/event as FCPXML via the File > Export XML menu.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Final Cut Pro — Projects & Libraries ──────────────────────────
+  {
+    name: "fcp_open_project",
+    description: "Open a project by name in the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Project name (or pattern) to open",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fcp_project_properties",
+    description:
+      "Get properties of the current project — resolution, frame rate, codec, etc.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Final Cut Pro — Markers & Keywords ────────────────────────────
+  {
+    name: "fcp_add_marker",
+    description:
+      "Add a marker at the current playhead position in the timeline, optionally naming it or setting a To Do marker as completed.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: {
+          type: "string",
+          enum: ["standard", "todo", "chapter"],
+          description: "Marker type (default: standard)",
+        },
+        name: {
+          type: "string",
+          description: "Optional marker name",
+        },
+        completed: {
+          type: "boolean",
+          description:
+            "For todo markers, whether the marker should be marked completed",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_add_keyword",
+    description: "Add a keyword to the currently selected clip(s).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        keyword: {
+          type: "string",
+          description: "The keyword to add",
+        },
+      },
+      required: ["keyword"],
+    },
+  },
+  {
+    name: "fcp_list_markers",
+    description:
+      "List all markers in the current timeline/project. Returns marker names, types, positions, and notes.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Final Cut Pro — Clip Operations ───────────────────────────────
+  {
+    name: "fcp_rename_clip",
+    description: "Rename the currently selected clip.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "New name for the clip",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fcp_rate_clip",
+    description:
+      "Rate the currently selected clip as favorite, rejected, or unrated.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        rating: {
+          type: "string",
+          enum: ["favorite", "reject", "unrate"],
+          description: "Rating to apply",
+        },
+      },
+      required: ["rating"],
+    },
+  },
+
+  // ── Final Cut Pro — Window Management ─────────────────────────────
+  {
+    name: "fcp_window_layout",
+    description:
+      "Control Final Cut Pro window layout — toggle fullscreen, show/hide panels.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: [
+            "show_timeline",
+            "show_browser",
+            "show_inspector",
+            "show_viewer",
+            "hide_browser",
+            "hide_inspector",
+            "fullscreen_toggle",
+          ],
+          description: "Window layout action",
+        },
+      },
+      required: ["action"],
+    },
+  },
+
+  // ── Final Cut Pro — Undo/Redo ─────────────────────────────────────
+  {
+    name: "fcp_undo_redo",
+    description: "Undo or redo the last action in Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["undo", "redo"],
+          description: "Undo or redo",
+        },
+        count: {
+          type: "number",
+          description: "Number of times to undo/redo (default: 1)",
+        },
+      },
+      required: ["action"],
+    },
+  },
+
+  // ── Final Cut Pro — Speed/Retime ──────────────────────────────────
+  {
+    name: "fcp_retime",
+    description: "Change the speed/retime of the selected clip.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        speed: {
+          type: "string",
+          enum: [
+            "slow_50",
+            "slow_25",
+            "slow_10",
+            "fast_2x",
+            "fast_4x",
+            "fast_8x",
+            "fast_20x",
+            "normal",
+            "reverse",
+            "hold",
+          ],
+          description: "Speed preset to apply",
+        },
+      },
+      required: ["speed"],
+    },
+  },
+
+  // ── Final Cut Pro — Captions ──────────────────────────────────────
+  {
+    name: "fcp_captions",
+    description: "Manage captions — add, extract, or import captions.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["add", "extract", "import"],
+          description: "Caption action",
+        },
+        path: {
+          type: "string",
+          description: "File path for import/export operations",
+        },
+      },
+      required: ["action"],
+    },
+  },
+
+  // ── Final Cut Pro — Multicam ──────────────────────────────────────
+  {
+    name: "fcp_multicam_switch_angle",
+    description: "Switch the multicam angle for the selected clip.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        angle: {
+          type: "number",
+          description: "Angle number to switch to (1-based)",
+        },
+        type: {
+          type: "string",
+          enum: ["video", "audio", "both"],
+          description: "Switch video, audio, or both (default: both)",
+        },
+      },
+      required: ["angle"],
+    },
+  },
+
+  // ── Final Cut Pro — Pasteboard History ────────────────────────────
+  {
+    name: "fcp_pasteboard",
+    description:
+      "Access Final Cut Pro timeline pasteboard content. `copy` and `paste` use the normal clipboard by default; when `slot` is provided they use CommandPost's pasteboard buffer. `history` returns populated buffer slots.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["copy", "paste", "history"],
+          description:
+            "Action: 'copy' to copy the current selection, 'paste' to paste, or 'history' to list populated pasteboard buffer slots",
+        },
+        slot: {
+          type: "number",
+          description:
+            "Optional buffer slot number (1-50). When provided, copy/paste use CommandPost's pasteboard buffer instead of the system clipboard.",
+        },
+      },
+      required: ["action"],
+    },
+  },
+
+  // ── Color Wheels / Video Inspector / Audio Inspector ────────────
+  {
+    name: "fcp_color_wheels",
+    description:
+      "Adjust color using Final Cut Pro's Color Wheels — temperature, tint, hue, mix, saturation, brightness, contrast. Much more capable than the basic Color Board.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        control: { type: "string", enum: ["temperature", "tint", "hue", "mix", "saturation", "brightness", "contrast"], description: "Which control to adjust" },
+        value: { type: "number", description: "Value to set" },
+        reset: { type: "boolean", description: "If true, reset the control to default" },
+      },
+      required: ["control"],
+    },
+  },
+  {
+    name: "fcp_video_inspector",
+    description:
+      "Read or adjust video properties in the Inspector — transform (position, scale, rotation), crop, compositing (blend mode, opacity). Uses the native VideoInspector API.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: { type: "string", enum: ["get", "set"], description: "Read or write" },
+        section: { type: "string", enum: ["transform", "crop", "compositing", "stabilization", "spatial"], description: "Inspector section" },
+        property: { type: "string", description: 'Property name (e.g., "positionX", "scale", "rotation", "opacity")' },
+        value: { description: "Value to set (for action=set)" },
+      },
+      required: ["action", "section"],
+    },
+  },
+  {
+    name: "fcp_audio_inspector",
+    description: "Read or adjust audio properties in the Inspector — volume, pan.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: { type: "string", enum: ["get", "set"], description: "Read or write" },
+        property: { type: "string", enum: ["volume", "pan"], description: "Audio property" },
+        value: { type: "number", description: "Value to set (for action=set)" },
+      },
+      required: ["action"],
+    },
+  },
+
+  // ── Timeline Toolbar / Appearance / Viewer Config ───────────────
+  {
+    name: "fcp_toolbar_state",
+    description: "Read or set timeline toolbar toggles (snapping, skimming, solo) and the active editing tool.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: { type: "string", enum: ["get", "set"], description: "Read or write" },
+        toggle: { type: "string", enum: ["snapping", "skimming", "audioSkimming", "solo"], description: "Toggle to get/set" },
+        enabled: { type: "boolean", description: "Enable or disable (for set)" },
+        tool: { type: "string", enum: ["select", "trim", "position", "range", "blade", "zoom", "hand"], description: "Set active editing tool" },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_timeline_appearance",
+    description: "Read or configure timeline appearance — clip height, names, roles, lane headers.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: { type: "string", enum: ["get", "set"], description: "Read or write" },
+        clipHeight: { type: "number", description: "Clip height (0-100)" },
+        clipNames: { type: "boolean", description: "Show clip names" },
+        clipRoles: { type: "boolean", description: "Show clip roles" },
+        laneHeaders: { type: "boolean", description: "Show lane headers" },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_viewer_config",
+    description: "Read or configure the Viewer — playback quality, background color, proxy mode.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: { type: "string", enum: ["get", "set"], description: "Read or write" },
+        background: { type: "string", enum: ["black", "white", "checkerboard"], description: "Viewer background" },
+        quality: { type: "string", enum: ["better_quality", "better_performance", "proxy_preferred", "proxy_only", "original_better_quality", "original_better_performance"], description: "Playback quality" },
+      },
+      required: ["action"],
+    },
+  },
+
+  // ── CSV Export / Match Frame / Transcode ────────────────────────
+  {
+    name: "fcp_export_csv",
+    description: "Export browser contents or timeline index to CSV for external analysis.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        source: { type: "string", enum: ["browser", "timeline"], description: "What to export" },
+        path: { type: "string", description: "Output file path (optional — returns data if omitted)" },
+      },
+      required: ["source"],
+    },
+  },
+  {
+    name: "fcp_match_frame",
+    description: "Match frame — locate the source clip in the browser for the current playhead position.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        multicam: { type: "boolean", description: "If true, perform multicam match frame" },
+      },
+    },
+  },
+  {
+    name: "fcp_transcode",
+    description: "Transcode selected clips — create optimized or proxy media.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        mode: { type: "string", enum: ["optimize", "proxy", "both"], description: "Transcoding mode" },
+      },
+      required: ["mode"],
+    },
+  },
+
+  // ── Find/Replace Titles / Keywords / Text-to-Markers ───────────
+  {
+    name: "fcp_find_replace_titles",
+    description: "Find and replace text in titles across the timeline via FCP's Edit > Find and Replace Title Text.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        find: { type: "string", description: "Text to search for" },
+        replace: { type: "string", description: "Replacement text" },
+      },
+      required: ["find", "replace"],
+    },
+  },
+  {
+    name: "fcp_keyword_presets",
+    description: "Save or restore keyword preset configurations (9 slots).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: { type: "string", enum: ["save", "restore", "list"], description: "Action" },
+        preset: { type: "number", description: "Preset slot (1-9)" },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "fcp_text_to_markers",
+    description: "Convert formatted text with timecodes into timeline markers. Each line: 'HH:MM:SS:FF marker text'.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        text: { type: "string", description: "Timecoded text (one marker per line)" },
+        type: { type: "string", enum: ["marker", "todo"], description: "Marker type (default: marker)" },
+      },
+      required: ["text"],
+    },
+  },
+
+  // ── Notifications ─────────────────────────────────────────────────
+  {
+    name: "commandpost_alert",
+    description:
+      "Show an on-screen alert/notification via Hammerspoon's alert system.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        message: {
+          type: "string",
+          description: "The message to display",
+        },
+        duration: {
+          type: "number",
+          description: "How long to show the alert in seconds (default: 2)",
+        },
+      },
+      required: ["message"],
+    },
+  },
+
+  // ── Discovery / Introspection ─────────────────────────────────────
+  {
+    name: "fcp_list_effects",
+    description:
+      "List all available video effects installed in Final Cut Pro. Returns effect names and categories.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        category: {
+          type: "string",
+          description:
+            'Optional category filter (e.g., "Blur", "Color", "Stylize"). If omitted, lists all.',
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_list_audio_effects",
+    description:
+      "List all available audio effects installed in Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        category: {
+          type: "string",
+          description: "Optional category filter. If omitted, lists all.",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_list_transitions",
+    description:
+      "List all available transitions installed in Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        category: {
+          type: "string",
+          description: "Optional category filter. If omitted, lists all.",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_list_generators",
+    description:
+      "List all available generators installed in Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        category: {
+          type: "string",
+          description: "Optional category filter. If omitted, lists all.",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_list_titles",
+    description: "List all available titles installed in Final Cut Pro.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        category: {
+          type: "string",
+          description: "Optional category filter. If omitted, lists all.",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_get_selected_clips",
+    description:
+      "Get information about the currently selected clips in the timeline, including their names, positions, and durations.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_get_playhead_position",
+    description:
+      "Get the current playhead (CTI) position in the timeline as timecode.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_set_playhead_position",
+    description:
+      "Set the playhead to a specific timecode position in the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        timecode: {
+          type: "string",
+          description:
+            'Timecode to navigate to (e.g., "00:01:30:00" or "01:00:00:00")',
+        },
+      },
+      required: ["timecode"],
+    },
+  },
+  {
+    name: "fcp_get_project_settings",
+    description:
+      "Get the current project settings — resolution, frame rate, color space, audio settings, etc.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Clip Properties ───────────────────────────────────────────────
+  {
+    name: "fcp_get_clip_properties",
+    description:
+      "Get the transform and compositing properties (position, scale, rotation, opacity, etc.) of the currently selected clip via the Video Inspector.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_set_clip_properties",
+    description:
+      "Set transform or compositing properties on the selected clip. Adjusts values via the Video Inspector.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        positionX: {
+          type: "number",
+          description: "X position in pixels",
+        },
+        positionY: {
+          type: "number",
+          description: "Y position in pixels",
+        },
+        scaleAll: {
+          type: "number",
+          description: "Uniform scale percentage (100 = normal)",
+        },
+        rotation: {
+          type: "number",
+          description: "Rotation in degrees",
+        },
+        opacity: {
+          type: "number",
+          description: "Opacity percentage (0-100)",
+        },
+      },
+    },
+  },
+
+  // ── Additional Clip Operations ────────────────────────────────────
+  {
+    name: "fcp_duplicate_clip",
+    description:
+      "Duplicate the currently selected clip(s) in the timeline (Option-drag equivalent).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_enable_disable_clip",
+    description: "Enable or disable the currently selected clip(s).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        enabled: {
+          type: "boolean",
+          description: "true to enable, false to disable (toggles if omitted)",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_split_at_timecode",
+    description:
+      "Split/blade the clip at a specific timecode position. Moves the playhead to the timecode first, then blades.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        timecode: {
+          type: "string",
+          description: 'Timecode position to split at (e.g., "00:01:30:00")',
+        },
+      },
+      required: ["timecode"],
+    },
+  },
+  {
+    name: "fcp_speed_custom",
+    description:
+      "Set a custom speed percentage for the selected clip using the retime editor.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        percentage: {
+          type: "number",
+          description:
+            "Speed percentage (e.g., 50 for half speed, 200 for double speed)",
+        },
+      },
+      required: ["percentage"],
+    },
+  },
+
+  // ── Range Selection / Work Area ───────────────────────────────────
+  {
+    name: "fcp_set_range",
+    description:
+      "Set the timeline range selection (in/out points) using timecodes.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        start: {
+          type: "string",
+          description: 'Start timecode (e.g., "00:00:10:00")',
+        },
+        end: {
+          type: "string",
+          description: 'End timecode (e.g., "00:00:20:00")',
+        },
+      },
+      required: ["start", "end"],
+    },
+  },
+  {
+    name: "fcp_clear_range",
+    description: "Clear the current range selection in the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Compound Clips & Auditions ────────────────────────────────────
+  {
+    name: "fcp_create_compound_clip",
+    description:
+      "Create a compound clip from the currently selected clips in the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Optional name for the compound clip",
+        },
+      },
+    },
+  },
+  {
+    name: "fcp_break_apart_compound",
+    description:
+      "Break apart a selected compound clip into its individual components.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "fcp_create_audition",
+    description:
+      "Create an audition from the currently selected clips. Auditions let you group alternative clips and switch between them.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Roles ─────────────────────────────────────────────────────────
+  {
+    name: "fcp_assign_role",
+    description:
+      "Assign a role (video, audio, or custom) to the selected clip(s) via the Modify > Assign Roles menu.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        role: {
+          type: "string",
+          description:
+            'Role name to assign (e.g., "Dialogue", "Music", "Effects", "Video", or a custom role name)',
+        },
+      },
+      required: ["role"],
+    },
+  },
+
+  // ── Stabilization ─────────────────────────────────────────────────
+  {
+    name: "fcp_stabilization",
+    description:
+      "Toggle stabilization on the selected clip via the Video Inspector.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        enabled: {
+          type: "boolean",
+          description:
+            "true to enable stabilization, false to disable (default: true)",
+        },
+        method: {
+          type: "string",
+          enum: ["automatic", "inertiaCam", "smoothCam"],
+          description: "Stabilization method (default: automatic)",
+        },
+      },
+    },
+  },
+
+  // ── Proxy Management ──────────────────────────────────────────────
+  {
+    name: "fcp_proxy_toggle",
+    description:
+      "Toggle between proxy and optimized/original media for playback.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["proxy", "optimized", "original"],
+          description:
+            "Media mode to switch to (default: toggles between proxy and optimized/original)",
+        },
+      },
+    },
+  },
+
+  // ── Batch Operations ──────────────────────────────────────────────
+  {
+    name: "fcp_batch_apply_transition",
+    description:
+      "Apply Final Cut Pro's current default transition across the active timeline by selecting all clips first.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+
+  // ── Composite Workflow ────────────────────────────────────────────
+  {
+    name: "fcp_assemble_rough_cut",
+    description:
+      'Batch-import media files for rough-cut preparation. Accepts a "clipPlan" array of media paths and can optionally open an existing project first. This tool currently imports media only; it does not trim clips or place them on the timeline.',
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        projectName: {
+          type: "string",
+          description: "Optional existing project to open before importing",
+        },
+        clipPlan: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              mediaPath: {
+                type: "string",
+                description: "Path to the media file to import",
+              },
+            },
+            required: ["mediaPath"],
+          },
+          description: "Array of media files to import in order",
+        },
+      },
+      required: ["clipPlan"],
+    },
+  },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tool Handlers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Format a tool response as JSON string.
+ * Ensures the result always contains a `success` field for consistency.
+ * Creates a shallow copy to avoid mutating the original object.
+ */
+function formatResult(response: unknown): string {
+  if (typeof response === "string") {
+    try {
+      const parsed = JSON.parse(response);
+      if (typeof parsed === "object" && parsed !== null && !("success" in parsed)) {
+        parsed.success = !("error" in parsed) ? true : false;
+      }
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return response;
+    }
+  }
+  if (typeof response === "object" && response !== null) {
+    const copy = { ...(response as Record<string, unknown>) };
+    if (!("success" in copy)) {
+      copy.success = !("error" in copy) ? true : false;
+    }
+    return JSON.stringify(copy, null, 2);
+  }
+  return JSON.stringify(response, null, 2);
+}
+
+function extractResult(response: { result?: unknown }): unknown {
+  return response?.result ?? response;
+}
+
+function unwrapNestedResult(response: unknown): unknown {
+  let value = extractResult(response as { result?: unknown });
+
+  while (
+    value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && hasOwn(value as Record<string, unknown>, "result")
+  ) {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length > 2 || (keys.length === 2 && !hasOwn(obj, "success"))) {
+      break;
+    }
+    value = obj.result;
+  }
+
+  return value;
+}
+
+async function activateFinalCutPro(timeoutMs = 30000): Promise<void> {
+  const resp = await client.executeLua(
+    `
+      local fcp = require("cp.apple.finalcutpro")
+
+      -- Guard: FCP must be running
+      if not fcp:isRunning() then
+        return {error = "Final Cut Pro is not running. Launch it first.", fcpNotRunning = true}
+      end
+
+      fcp:launch()
+      hs.timer.usleep(200000)
+
+      -- Check for modal dialogs blocking interaction
+      local app = fcp:application()
+      if app then
+        local windows = app:allWindows()
+        if windows then
+          for _, w in ipairs(windows) do
+            local role = w:role()
+            local subrole = w:subrole()
+            if role == "AXWindow" and (subrole == "AXDialog" or subrole == "AXSheet" or subrole == "AXSystemDialog") then
+              return {error = "A modal dialog is open in FCP. Dismiss it before proceeding.", modalDialog = true, dialogTitle = w:title() or "unknown"}
+            end
+          end
+        end
+      end
+
+      -- Dismiss any open speed popover that might block subsequent operations
+      pcall(function()
+        local sp = fcp.timeline.speedPopover
+        if sp:isShowing() then
+          sp:hide()
+          local just = require("cp.just")
+          just.doUntil(function() return not sp:isShowing() end, 2)
+          hs.timer.usleep(200000)
+        end
+      end)
+
+      return true
+    `,
+    timeoutMs
+  );
+  // If FCP returned an error (not running, modal dialog), throw so callers can handle
+  const result = unwrapNestedResult(resp) as Record<string, unknown> | undefined;
+  if (result && typeof result === "object" && result.error) {
+    throw new Error(String(result.error));
+  }
+}
+
+const INSPECTOR_TAB_MAP: Record<string, string> = {
+  audio: "Audio",
+  color: "Color",
+  effect: "Effect",
+  generator: "Generator",
+  info: "Info",
+  share: "Share",
+  text: "Text",
+  title: "Title",
+  transition: "Transition",
+  video: "Video",
+};
+
+const KNOWN_TOOLS = new Set(TOOLS.map((t) => t.name));
+const TIMELINE_NAVIGATION_ACTIONS = new Set([
+  "beginning",
+  "end",
+  "next_frame",
+  "previous_frame",
+  "next_edit",
+  "previous_edit",
+  "timecode",
+]);
+const PASTEBOARD_ACTIONS = new Set(["copy", "paste", "history"]);
+
+// ── Verification Helpers ──────────────────────────────────────────────
+// These use a TWO-PHASE approach:
+//   1. Capture lightweight "before" state (clip count + timecode — NO menu reads)
+//   2. Run the operation
+//   3. Capture "after" state INCLUDING undo text (menu read is safe AFTER the op)
+//
+// IMPORTANT: getMenuItems() steals focus from FCP, which breaks keyboard
+// shortcuts in the same Lua chunk. That's why we only read menus AFTER
+// the operation, never before.
+
+/**
+ * Wrap a Lua operation with before/after timeline state capture.
+ * Returns: .before, .after, .verified with undoText, clipDelta, tcChanged
+ */
+function withVerification(operationCode: string): string {
+  return `${LUA_PREAMBLE}
+-- Guard: FCP must be running
+do
+  local __fcp = require("cp.apple.finalcutpro")
+  if not __fcp:isRunning() then
+    return {error = "Final Cut Pro is not running. Launch it first.", fcpNotRunning = true}
+  end
+  __fcp:launch()
+  hs.timer.usleep(300000)
+
+  -- Check for modal dialogs blocking interaction
+  local __app = __fcp:application()
+  if __app then
+    local __windows = __app:allWindows()
+    if __windows then
+      for _, w in ipairs(__windows) do
+        local __role = w:role()
+        local __subrole = w:subrole()
+        if __role == "AXWindow" and (__subrole == "AXDialog" or __subrole == "AXSheet" or __subrole == "AXSystemDialog") then
+          return {error = "A modal dialog is open in FCP. Dismiss it before proceeding.", modalDialog = true, dialogTitle = w:title() or "unknown"}
+        end
+      end
+    end
+  end
+end
+
+-- Dismiss any open speed popover that might block operations
+pcall(function()
+  local __fcp = require("cp.apple.finalcutpro")
+  local __sp = __fcp.timeline.speedPopover
+  if __sp:isShowing() then
+    __sp:hide()
+    local __just = require("cp.just")
+    __just.doUntil(function() return not __sp:isShowing() end, 2)
+    hs.timer.usleep(200000)
+  end
+end)
+
+-- Phase 1: lightweight before-state (NO menu read — preserves FCP focus)
+local __before = {}
+pcall(function() __before.timecode = tostring(require("cp.apple.finalcutpro").viewer:timecode()) end)
+pcall(function()
+  local contents = require("cp.apple.finalcutpro").timeline.contents:UI()
+  if contents then
+    local children = contents:attributeValue("AXChildren")
+    if children then
+      __before.clipCount = 0
+      for _, c in ipairs(children) do
+        local desc = c:attributeValue("AXDescription")
+        if desc and desc ~= "Playhead" then __before.clipCount = __before.clipCount + 1 end
+      end
+    end
+  end
+end)
+
+-- Phase 2: execute the operation
+local __opResult = (function()
+  ${operationCode}
+end)()
+
+-- Phase 2.5: check for and handle any FCP dialogs that appeared
+local __dialogResult = handleFCPDialog(false)
+if __dialogResult then
+  hs.timer.usleep(500000)
+end
+
+-- Phase 3: after-state WITH menu read (safe now that operation is done)
+hs.timer.usleep(500000)
+local __after = {}
+pcall(function() __after.timecode = tostring(require("cp.apple.finalcutpro").viewer:timecode()) end)
+pcall(function()
+  local contents = require("cp.apple.finalcutpro").timeline.contents:UI()
+  if contents then
+    local children = contents:attributeValue("AXChildren")
+    if children then
+      __after.clipCount = 0
+      __after.clips = {}
+      for _, c in ipairs(children) do
+        local desc = c:attributeValue("AXDescription")
+        if desc and desc ~= "Playhead" then
+          __after.clipCount = __after.clipCount + 1
+          if __after.clipCount <= 30 then
+            table.insert(__after.clips, {description = desc, duration = c:attributeValue("AXValue")})
+          end
+        end
+      end
+    end
+  end
+end)
+pcall(function()
+  local app = require("cp.apple.finalcutpro"):application()
+  if app then
+    local menus = app:getMenuItems()
+    if menus then
+      for _, m in ipairs(menus) do
+        if m.AXTitle == "Edit" then
+          __after.undoText = m.AXChildren[1][1].AXTitle
+          break
+        end
+      end
+    end
+  end
+end)
+
+if type(__opResult) ~= "table" then __opResult = {value = __opResult} end
+__opResult.before = {clipCount = __before.clipCount, timecode = __before.timecode}
+__opResult.after  = {clipCount = __after.clipCount, timecode = __after.timecode, undoText = __after.undoText, clips = __after.clips}
+__opResult.verified = {
+  undoText = __after.undoText,
+  clipDelta = (__after.clipCount or 0) - (__before.clipCount or 0),
+  tcChanged = __after.timecode ~= __before.timecode,
+}
+if __dialogResult then
+  __opResult.dialogHandled = __dialogResult
+end
+return __opResult
+`;
+}
+
+/**
+ * Lighter wrapper for navigation — captures timecode before/after.
+ * No menu reads needed — timecode change IS the verification.
+ */
+function withTimecodeCheck(operationCode: string): string {
+  return `
+do
+  local __fcp = require("cp.apple.finalcutpro")
+  if __fcp:isRunning() then __fcp:launch() end
+  hs.timer.usleep(300000)
+end
+local __tcBefore
+pcall(function() __tcBefore = tostring(require("cp.apple.finalcutpro").viewer:timecode()) end)
+local __opResult = (function()
+  ${operationCode}
+end)()
+local __tcAfter
+pcall(function() __tcAfter = tostring(require("cp.apple.finalcutpro").viewer:timecode()) end)
+if type(__opResult) ~= "table" then __opResult = {value = __opResult} end
+__opResult.beforeTimecode = __tcBefore
+__opResult.afterTimecode = __tcAfter
+__opResult.timecodeChanged = __tcBefore ~= __tcAfter
+return __opResult
+`;
+}
+
+// ── Reusable Lua Snippets for Pre/Post Checks ──────────────────────
+// These are Lua code fragments that can be interpolated into tool Lua strings.
+
+/**
+ * Lua snippet that returns a table with FCP readiness info.
+ * Call this at the start of operations to check preconditions.
+ * Returns: { timelineShowing, selectedClipCount, speedPopoverOpen, playheadTimecode }
+ */
+const LUA_PRECHECK = `
+(function()
+  local fcp = require("cp.apple.finalcutpro")
+  local just = require("cp.just")
+  local pre = {}
+
+  -- Dismiss any open speed popover
+  pcall(function()
+    local sp = fcp.timeline.speedPopover
+    if sp:isShowing() then
+      pre.speedPopoverWasOpen = true
+      sp:hide()
+      just.doUntil(function() return not sp:isShowing() end, 2)
+      hs.timer.usleep(200000)
+    end
+  end)
+
+  -- Check timeline is showing
+  pcall(function()
+    pre.timelineShowing = fcp.timeline:isShowing()
+  end)
+
+  -- Check selection state
+  pcall(function()
+    local contents = fcp.timeline.contents
+    if contents and contents:isShowing() then
+      local selected = contents:selectedClipsUI() or {}
+      pre.selectedClipCount = #selected
+      if #selected > 0 then
+        pre.selectedClipDesc = selected[1]:attributeValue("AXDescription") or "unknown"
+      end
+    end
+  end)
+
+  -- Read playhead timecode
+  pcall(function()
+    pre.playheadTimecode = tostring(fcp.viewer:timecode())
+  end)
+
+  return pre
+end)()
+`;
+
+/**
+ * Lua snippet that reads the current undo/redo text from the Edit menu.
+ * Returns: { undoText, redoText }
+ * NOTE: This reads menus which steals FCP focus — only use AFTER operations.
+ */
+const LUA_READ_UNDO_STATE = `
+(function()
+  local fcp = require("cp.apple.finalcutpro")
+  local state = {}
+  pcall(function()
+    local app = fcp:application()
+    local menus = app and app:getMenuItems()
+    if menus then
+      for _, menu in ipairs(menus) do
+        if menu.AXTitle == "Edit" then
+          local group = menu.AXChildren and menu.AXChildren[1]
+          if group then
+            state.undoText = group[1] and group[1].AXTitle or nil
+            state.redoText = group[2] and group[2].AXTitle or nil
+          end
+          break
+        end
+      end
+    end
+  end)
+  return state
+end)()
+`;
+
+/**
+ * Wrap a Lua operation with undo-text verification.
+ * Captures undo text AFTER the operation (not before, to preserve FCP focus),
+ * and compares against a pre-captured undo text passed as a parameter.
+ * Returns: { result, afterUndoText }
+ */
+function withUndoCheck(operationCode: string): string {
+  return `
+-- Guard: FCP must be running
+do
+  local fcp = require("cp.apple.finalcutpro")
+  if not fcp:isRunning() then
+    return {error = "Final Cut Pro is not running. Launch it first.", fcpNotRunning = true}
+  end
+  fcp:launch()
+  hs.timer.usleep(300000)
+
+  -- Check for modal dialogs blocking interaction
+  local __app = fcp:application()
+  if __app then
+    local __windows = __app:allWindows()
+    if __windows then
+      for _, w in ipairs(__windows) do
+        local __role = w:role()
+        local __subrole = w:subrole()
+        if __role == "AXWindow" and (__subrole == "AXDialog" or __subrole == "AXSheet" or __subrole == "AXSystemDialog") then
+          return {error = "A modal dialog is open in FCP. Dismiss it before proceeding.", modalDialog = true, dialogTitle = w:title() or "unknown"}
+        end
+      end
+    end
+  end
+end
+
+-- Dismiss any open speed popover
+pcall(function()
+  local fcp = require("cp.apple.finalcutpro")
+  local sp = fcp.timeline.speedPopover
+  if sp:isShowing() then
+    sp:hide()
+    local just = require("cp.just")
+    just.doUntil(function() return not sp:isShowing() end, 2)
+    hs.timer.usleep(200000)
+  end
+end)
+
+-- Capture before undo text (safe here since we haven't done the operation yet
+-- and we already ensured FCP focus above)
+local __beforeUndo
+pcall(function()
+  local app = require("cp.apple.finalcutpro"):application()
+  local menus = app and app:getMenuItems()
+  if menus then
+    for _, m in ipairs(menus) do
+      if m.AXTitle == "Edit" then
+        __beforeUndo = m.AXChildren[1][1].AXTitle
+        break
+      end
+    end
+  end
+end)
+
+-- Re-activate FCP since getMenuItems may have stolen focus
+do
+  local fcp = require("cp.apple.finalcutpro")
+  fcp:launch()
+  hs.timer.usleep(300000)
+end
+
+-- Execute the operation
+local __opResult = (function()
+  ${operationCode}
+end)()
+
+-- Capture after undo text
+hs.timer.usleep(300000)
+local __afterUndo
+pcall(function()
+  local app = require("cp.apple.finalcutpro"):application()
+  local menus = app and app:getMenuItems()
+  if menus then
+    for _, m in ipairs(menus) do
+      if m.AXTitle == "Edit" then
+        __afterUndo = m.AXChildren[1][1].AXTitle
+        break
+      end
+    end
+  end
+end)
+
+if type(__opResult) ~= "table" then __opResult = {value = __opResult} end
+__opResult.beforeUndoText = __beforeUndo
+__opResult.afterUndoText = __afterUndo
+__opResult.undoChanged = __beforeUndo ~= __afterUndo
+return __opResult
+`;
+}
+
+// ── Per-Tool Rate Limiting ──────────────────────────────────────────
+// Prevents rapid-fire commands that can race against FCP's UI state.
+
+/** Minimum interval (ms) between calls to the same tool */
+const TOOL_COOLDOWNS: Record<string, number> = {
+  // Destructive timeline operations
+  fcp_timeline_blade: 200,
+  fcp_timeline_delete: 300,
+  fcp_split_at_timecode: 200,
+  // Speed/retime (popover interactions need settling time)
+  fcp_speed_custom: 500,
+  fcp_retime: 300,
+  // Effects and transitions (FCP needs UI time to apply)
+  fcp_apply_effect: 400,
+  fcp_apply_transition: 500,
+  fcp_batch_apply_transition: 1000,
+  // Clipboard operations
+  fcp_timeline_clipboard: 200,
+  fcp_duplicate_clip: 300,
+  // Clip modifications
+  fcp_set_clip_properties: 300,
+  fcp_rename_clip: 300,
+  fcp_enable_disable_clip: 200,
+  fcp_rate_clip: 200,
+  // Navigation (fast but still shouldn't be spammed)
+  fcp_set_playhead_position: 100,
+  // Inspector operations (UI needs settling)
+  fcp_color_wheels: 300,
+  fcp_video_inspector: 300,
+  fcp_audio_inspector: 300,
+  // Toolbar/appearance (popover interactions)
+  fcp_timeline_appearance: 500,
+  // Transcode (heavy operation)
+  fcp_transcode: 1000,
+  // Find/replace (dialog interaction)
+  fcp_find_replace_titles: 1000,
+  // Text to markers (sequential operations)
+  fcp_text_to_markers: 500,
+};
+
+/** Default cooldown for tools not in the map (0 = no limit) */
+const DEFAULT_COOLDOWN_MS = 0;
+
+/** Tracks the last execution time for each tool */
+const lastToolExecution: Map<string, number> = new Map();
+
+/**
+ * Check if a tool call is within its cooldown period.
+ * Returns null if OK, or an error message string if rate-limited.
+ */
+function checkRateLimit(toolName: string): string | null {
+  const cooldown = TOOL_COOLDOWNS[toolName] ?? DEFAULT_COOLDOWN_MS;
+  if (cooldown <= 0) return null;
+
+  const now = Date.now();
+  const lastExec = lastToolExecution.get(toolName);
+  if (lastExec && now - lastExec < cooldown) {
+    const waitMs = cooldown - (now - lastExec);
+    return `Rate limited: ${toolName} was called ${now - lastExec}ms ago (minimum interval: ${cooldown}ms). Wait ${waitMs}ms before retrying.`;
+  }
+  lastToolExecution.set(toolName, now);
+  return null;
+}
+
+async function handleTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  // Check for unknown tool before attempting connection
+  if (!KNOWN_TOOLS.has(name)) {
+    log("warn", `Unknown tool requested: ${name}`);
+    return JSON.stringify({ success: false, error: `Unknown tool: ${name}` });
+  }
+
+  log("debug", `Executing tool: ${name}`, args);
+
+  // Rate limit check
+  const rateLimitError = checkRateLimit(name);
+  if (rateLimitError) {
+    log("warn", `Rate limited: ${name}`);
+    return JSON.stringify({ success: false, error: rateLimitError, rateLimited: true });
+  }
+
+  const validationError = validateToolArgs(name, args);
+  if (validationError) {
+    log("warn", `Validation failed for tool ${name}: ${validationError}`);
+    return JSON.stringify({ success: false, error: validationError });
+  }
+
+  try {
+    await client.ensureConnected();
+  } catch (err) {
+    log("error", `Connection failed for tool ${name}`, err instanceof Error ? err.message : String(err));
+    return JSON.stringify({
+      success: false,
+      error: `Cannot connect to CommandPost: ${err instanceof Error ? err.message : String(err)}`,
+      help: "Make sure CommandPost is running and the WebSocket server is enabled (CommandPost > Preferences > WebSocket).",
+    });
+  }
+
+  switch (name) {
+    // ── System & Connection ─────────────────────────────────────────
+    case "commandpost_ping": {
+      const resp = await client.ping();
+      return formatResult({ status: "connected", ...resp });
+    }
+
+    case "commandpost_list_handlers": {
+      const resp = await client.query("handlers");
+      return formatResult(extractResult(resp));
+    }
+
+    case "commandpost_get_handler_info": {
+      const resp = await client.query("handlerInfo", {
+        handler: args.handler as string,
+        includeChoices: (args.includeChoices as boolean | undefined) ?? true,
+        includeParams: (args.includeParams as boolean | undefined) ?? false,
+        limit: (args.limit as number | undefined) ?? 200,
+        offset: (args.offset as number | undefined) ?? 0,
+      });
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Lua Execution ───────────────────────────────────────────────
+    case "commandpost_execute_lua": {
+      // Validation already handled by validateToolArgs above
+      const resp = await client.executeLua(args.code as string);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Action System ───────────────────────────────────────────────
+    case "commandpost_execute_action": {
+      const resp = await client.executeAction(
+        args.handler as string,
+        args.actionId as string | undefined,
+        args.parameters as Record<string, unknown> | undefined
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Chaining / Batch ────────────────────────────────────────────
+    case "commandpost_chain": {
+      const resp = await client.executeBatch(
+        args.operations as Array<Record<string, unknown>>,
+        (args.stopOnError as boolean) ?? true
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Preferences ─────────────────────────────────────────────────
+    case "commandpost_get_preference": {
+      const key = args.key as string;
+      const resp = await client.executeLua(
+        `return require("cp.config").get("${escapeLua(key)}")`
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    case "commandpost_set_preference": {
+      const key = args.key as string;
+      const value = args.value;
+      const luaValue = toLuaLiteral(value);
+      const resp = await client.executeLua(
+        `require("cp.config").set("${escapeLua(key)}", ${luaValue}) return true`
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Application ─────────────────────────────────────────────
+    case "fcp_launch": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:launch()
+        return {launched = true}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_quit": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:quit()
+        return {quit = true}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_restart": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:quit()
+        hs.timer.doAfter(3, function() fcp:launch() end)
+        return {restarting = true}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_status": {
+      const resp = await client.executeLua(FCP_STATUS_LUA);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_select_menu": {
+      const path = args.path as string[];
+      const luaPath = path.map((s) => `"${escapeLua(s)}"`).join(", ");
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+        local result = fcp:selectMenu({${luaPath}}, {plain = true})
+        return {menuPath = {${luaPath}}, menuResult = result ~= nil}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      return formatResult({
+        ...result,
+        success: result?.menuResult === true || result?.undoChanged === true,
+        ...(!result?.menuResult ? {
+          warning: "selectMenu returned nil. The menu item may be disabled or the path may be incorrect.",
+        } : {}),
+      });
+    }
+
+    case "fcp_do_shortcut": {
+      const command = args.command as string;
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:doShortcut("${escapeLua(command)}"):Now()
+        return {command = "${escapeLua(command)}"}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      return formatResult({
+        ...result,
+        executed: true,
+        ...(!result?.undoChanged ? {
+          warning: "Shortcut executed but undo state did not change. The command may have had no effect in the current context.",
+        } : {}),
+      });
+    }
+
+    // ── FCP Timeline ────────────────────────────────────────────────
+    case "fcp_timeline_show": {
+      const display = (args.display as string) || "primary";
+      const method =
+        display === "secondary" ? "showOnSecondary" : "showOnPrimary";
+      const resp = await client.executeLua(safeLua(`
+        local just = require("cp.just")
+        local fcp = require("cp.apple.finalcutpro")
+        local timeline = fcp.timeline
+
+        fcp:launch()
+        local app = fcp:application()
+        if app then
+          pcall(function() app:activate() end)
+          hs.timer.usleep(300000)
+        end
+
+        timeline:${method}()
+        hs.timer.usleep(300000)
+
+        if not timeline:isShowing() then
+          timeline:show()
+          hs.timer.usleep(300000)
+        end
+
+        local shown = just.doUntil(function()
+          return timeline:isShowing()
+        end, 5)
+        local isShown = shown and true or false
+
+        local result = {
+          shown = isShown,
+          display = "${escapeLua(display)}",
+          loaded = safeGet(function() return timeline:isLoaded() end),
+        }
+        if not isShown then
+          result.error = "Timeline did not become visible"
+        end
+        return result
+      `), 45000);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_playback": {
+      const action = (args.action as string) || "toggle";
+      let code: string;
+      if (action === "play") {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          local wasPlaying = fcp.viewer:isPlaying()
+          -- Use the native viewer API instead of doShortcut("PlayPause")
+          fcp.viewer:doPlay():Now()
+          return {action = "play", changed = not wasPlaying, playing = true}
+        `;
+      } else if (action === "pause") {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          local wasPlaying = fcp.viewer:isPlaying()
+          -- Use the native viewer API instead of doShortcut("PlayPause")
+          fcp.viewer:doPause():Now()
+          return {action = "pause", changed = wasPlaying, playing = false}
+        `;
+      } else {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          local wasPlaying = fcp.viewer:isPlaying()
+          -- Use the native viewer isPlaying property toggle
+          fcp.viewer.isPlaying:toggle()
+          return {action = "toggle", previouslyPlaying = wasPlaying}
+        `;
+      }
+      const resp = await client.executeLua(code);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_navigate": {
+      const action = args.action as string;
+      const timecode = args.timecode as string | undefined;
+      let code: string;
+      switch (action) {
+        case "beginning":
+          code = `require("cp.apple.finalcutpro"):doShortcut("JumpToStart"):Now() return {navigated = "beginning"}`;
+          break;
+        case "end":
+          code = `require("cp.apple.finalcutpro"):doShortcut("JumpToEnd"):Now() return {navigated = "end"}`;
+          break;
+        case "next_frame":
+          code = `require("cp.apple.finalcutpro"):doShortcut("JumpToNextFrame"):Now() return {navigated = "next_frame"}`;
+          break;
+        case "previous_frame":
+          code = `require("cp.apple.finalcutpro"):doShortcut("JumpToPreviousFrame"):Now() return {navigated = "previous_frame"}`;
+          break;
+        case "next_edit":
+          code = `require("cp.apple.finalcutpro"):doShortcut("NextEdit"):Now() return {navigated = "next_edit"}`;
+          break;
+        case "previous_edit":
+          code = `require("cp.apple.finalcutpro"):doShortcut("PreviousEdit"):Now() return {navigated = "previous_edit"}`;
+          break;
+        case "timecode":
+          code = `
+            local fcp = require("cp.apple.finalcutpro")
+            local result = fcp.viewer:timecode("${escapeLua(timecode || "00:00:00:00")}")
+            return {navigated = "timecode", timecode = result}
+          `;
+          break;
+        default:
+          return JSON.stringify({ error: `Unknown navigation action: ${action}` });
+      }
+      const resp = await client.executeLua(withTimecodeCheck(code));
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_select": {
+      const action = args.action as string;
+      const clipIndex = args.index as number | undefined;
+      const resp = await client.executeLua(safeLua(`
+        local contents = fcp.timeline.contents
+        if not contents:isShowing() then
+          return {selected = "${escapeLua(action)}", changed = false, count = 0, error = "Timeline is not showing"}
+        end
+
+        pcall(function() contents:doFocus(true):Now() end)
+        hs.timer.usleep(200000)
+
+        -- Helper: get only real clips (not transitions, playhead, accessories)
+        local function getActualClips()
+          local all = contents:clipsUI(true) or {}
+          local actual = {}
+          for _, c in ipairs(all) do
+            local desc = c:attributeValue("AXDescription") or ""
+            if not desc:find("Transition") and not desc:find("Playhead") and not desc:find("accessory") then
+              table.insert(actual, c)
+            end
+          end
+          return actual
+        end
+
+        local beforeSelection = contents:selectedClipsUI(true) or {}
+
+        if "${escapeLua(action)}" == "all" then
+          local clips = contents:clipsUI(true)
+          if not clips or #clips == 0 then
+            return {selected = "all", changed = false, count = 0, totalClips = 0, error = "No timeline clips available to select"}
+          end
+
+          contents:selectClips(clips)
+          hs.timer.usleep(250000)
+
+          local afterSelection = contents:selectedClipsUI(true) or {}
+          if #afterSelection == 0 then
+            return {selected = "all", changed = false, count = 0, totalClips = #clips, error = "Timeline selection did not change"}
+          end
+
+          return {
+            selected = "all",
+            changed = #afterSelection ~= #beforeSelection,
+            count = #afterSelection,
+            totalClips = #clips,
+          }
+
+        elseif "${escapeLua(action)}" == "at_playhead" then
+          local playheadClips = contents:playheadClipsUI(true) or {}
+          if #playheadClips == 0 then
+            return {selected = "at_playhead", changed = false, count = 0, error = "No clip under playhead"}
+          end
+          -- Select the first (primary storyline) clip at playhead
+          contents:selectClip(playheadClips[1])
+          hs.timer.usleep(250000)
+          local afterSelection = contents:selectedClipsUI(true) or {}
+          local desc = playheadClips[1]:attributeValue("AXDescription") or "unknown"
+          return {
+            selected = "at_playhead",
+            changed = true,
+            count = #afterSelection,
+            clipDescription = desc,
+          }
+
+        elseif "${escapeLua(action)}" == "by_index" then
+          local idx = ${clipIndex ?? 1}
+          local actualClips = getActualClips()
+          if idx < 1 or idx > #actualClips then
+            return {selected = "by_index", changed = false, count = 0, error = "Index " .. idx .. " out of range (1-" .. #actualClips .. ")", totalClips = #actualClips}
+          end
+          contents:selectClip(actualClips[idx])
+          hs.timer.usleep(250000)
+          local afterSelection = contents:selectedClipsUI(true) or {}
+          local desc = actualClips[idx]:attributeValue("AXDescription") or "unknown"
+          return {
+            selected = "by_index",
+            index = idx,
+            changed = true,
+            count = #afterSelection,
+            clipDescription = desc,
+            totalClips = #actualClips,
+          }
+
+        else
+          -- "none"
+          contents:selectNone()
+          hs.timer.usleep(250000)
+
+          local afterSelection = contents:selectedClipsUI(true) or {}
+          if #afterSelection ~= 0 then
+            return {
+              selected = "none",
+              changed = #beforeSelection > 0 and #afterSelection < #beforeSelection,
+              count = #afterSelection,
+              error = "Timeline selection did not clear",
+            }
+          end
+
+          return {
+            selected = "none",
+            changed = #beforeSelection > 0,
+            count = 0,
+          }
+        end
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_blade": {
+      const resp = await client.executeLua(safeLua(`
+        local contents = fcp.timeline.contents
+        if not contents:isShowing() then
+          return {action = "blade", cut = false, error = "Timeline is not showing"}
+        end
+
+        pcall(function() contents:doFocus(true):Now() end)
+        hs.timer.usleep(200000)
+
+        local playheadPosition = contents.playhead and contents.playhead:position()
+        local clipsAtPlayhead = contents:playheadClipsUI(true) or {}
+        if #clipsAtPlayhead == 0 then
+          return {action = "blade", cut = false, error = "No clip under playhead"}
+        end
+
+        local function isUndoBlade(title)
+          return type(title) == "string" and string.match(title, "^Undo Blade") ~= nil
+        end
+
+        local function clipSignature(clips)
+          local parts = {}
+          for i, clip in ipairs(clips or {}) do
+            if i > 60 then break end
+            local desc = clip:attributeValue("AXDescription") or ""
+            local value = clip:attributeValue("AXValue") or ""
+            local pos = clip:attributeValue("AXPosition") or {}
+            local size = clip:attributeValue("AXSize") or {}
+            parts[#parts + 1] = table.concat({
+              desc,
+              value,
+              tostring(pos.x or ""),
+              tostring(pos.y or ""),
+              tostring(size.w or ""),
+              tostring(size.h or ""),
+            }, "|")
+          end
+          return table.concat(parts, "||")
+        end
+
+        local function editMenuUndoTitle()
+          local undoTitle = nil
+          local app = require("cp.apple.finalcutpro"):application()
+          local menus = app and app:getMenuItems()
+          if menus then
+            for _, menu in ipairs(menus) do
+              if menu.AXTitle == "Edit" then
+                undoTitle = menu.AXChildren and menu.AXChildren[1] and menu.AXChildren[1][1] and menu.AXChildren[1][1].AXTitle
+                break
+              end
+            end
+          end
+          return undoTitle
+        end
+
+        local function captureState()
+          local function readState()
+            local clips = contents:clipsUI(true) or {}
+            return {
+              clips = clips,
+              count = #clips,
+              signature = clipSignature(clips),
+              undoTitle = editMenuUndoTitle(),
+            }
+          end
+
+          local state = readState()
+          if state.count == 0 then
+            hs.timer.usleep(300000)
+            state = readState()
+          end
+          return state
+        end
+
+        local function stateChanged(beforeState, afterState)
+          local clipDelta = (afterState.count or 0) - (beforeState.count or 0)
+          local undoChanged = beforeState.undoTitle ~= afterState.undoTitle
+          local undoIndicatesBlade = isUndoBlade(afterState.undoTitle)
+          local changed = clipDelta > 0
+            or afterState.signature ~= beforeState.signature
+            or (undoChanged and undoIndicatesBlade)
+          return changed, clipDelta
+        end
+
+        local function attemptBlade(mode, menuPath, shortcut, beforeState)
+          local okMenu, menuResult = pcall(function()
+            return fcp:doSelectMenu(menuPath):Now()
+          end)
+          hs.timer.usleep(300000)
+
+          local afterMenu = captureState()
+          local changedAfterMenu = stateChanged(beforeState, afterMenu)
+          if changedAfterMenu then
+            return true, "menu", afterMenu, okMenu and menuResult or nil
+          end
+
+          local okShortcut, shortcutErr = pcall(function()
+            fcp:doShortcut(shortcut):Now()
+            return true
+          end)
+          hs.timer.usleep(300000)
+
+          local afterShortcut = captureState()
+          local changedAfterShortcut = stateChanged(beforeState, afterShortcut)
+          if changedAfterShortcut then
+            return true, "shortcut", afterShortcut, okShortcut and true or shortcutErr
+          end
+
+          local detail = nil
+          if not okMenu then
+            detail = tostring(menuResult)
+          elseif not okShortcut then
+            detail = tostring(shortcutErr)
+          end
+
+          return false, detail or mode, afterShortcut, okShortcut and true or shortcutErr
+        end
+
+        local beforeState = captureState()
+        local beforeCount = beforeState.count
+        local selectedAtPlayhead = {}
+        if type(playheadPosition) == "number" then
+          for _, clip in ipairs(contents:selectedClipsUI(true) or {}) do
+            local frame = clip:attributeValue("AXFrame")
+            if frame and playheadPosition >= frame.x and playheadPosition <= (frame.x + frame.w) then
+              selectedAtPlayhead[#selectedAtPlayhead + 1] = clip
+            end
+          end
+        end
+
+        local mode = (#selectedAtPlayhead == 1 or #clipsAtPlayhead == 1) and "single" or "all"
+        local trigger = nil
+        local afterState = beforeState
+        local commandDetail = nil
+
+        local success, sourceOrDetail, attemptState, detail = attemptBlade(
+          mode,
+          mode == "all" and {"Trim", "Blade All"} or {"Trim", "Blade"},
+          mode == "all" and "BladeAll" or "BladeAtPlayhead",
+          beforeState
+        )
+        trigger = success and sourceOrDetail or nil
+        commandDetail = detail
+        afterState = attemptState
+
+        local changed, clipDelta = stateChanged(beforeState, afterState)
+        if not success and mode ~= "all" then
+          local fallbackSuccess, fallbackSourceOrDetail, fallbackState, fallbackDetail = attemptBlade(
+            "all",
+            {"Trim", "Blade All"},
+            "BladeAll",
+            beforeState
+          )
+          if fallbackSuccess then
+            mode = "all"
+            trigger = fallbackSourceOrDetail
+            commandDetail = fallbackDetail
+            afterState = fallbackState
+            changed, clipDelta = stateChanged(beforeState, afterState)
+          else
+            commandDetail = fallbackDetail or sourceOrDetail
+            afterState = fallbackState
+            changed, clipDelta = stateChanged(beforeState, afterState)
+          end
+        end
+
+        if not changed then
+          return {
+            action = "blade",
+            cut = false,
+            mode = mode,
+            beforeCount = beforeCount,
+            afterCount = afterState.count,
+            clipDelta = clipDelta,
+            trigger = trigger,
+            undoText = afterState.undoTitle,
+            detail = commandDetail,
+            error = "Blade command did not change the timeline",
+          }
+        end
+
+        return {
+          action = "blade",
+          cut = true,
+          mode = mode,
+          beforeCount = beforeCount,
+          afterCount = afterState.count,
+          clipDelta = clipDelta,
+          trigger = trigger,
+          undoText = afterState.undoTitle,
+        }
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_delete": {
+      const resp = await client.executeLua(withVerification(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          -- Try selecting clip at playhead
+          local playheadClips = contents:playheadClipsUI(true) or {}
+          if #playheadClips == 0 then
+            return {action = "delete", error = "No clip selected and no clip under playhead."}
+          end
+          contents:selectClip(playheadClips[1])
+          hs.timer.usleep(200000)
+        end
+
+        -- Use menu Delete which is more reliable than doShortcut
+        fcp:selectMenu({"Edit", "Delete"}, {plain = true})
+        hs.timer.usleep(300000)
+        return {action = "delete"}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_clipboard": {
+      const action = args.action as string;
+      const shortcutMap: Record<string, string> = {
+        copy: "Copy",
+        cut: "Cut",
+        paste: "Paste",
+      };
+      const resp = await client.executeLua(withVerification(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:doShortcut("${shortcutMap[action]}"):Now()
+        return {action = "${action}"}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_zoom": {
+      const action = args.action as string;
+      let code: string;
+      if (action === "in") {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          local appearance = fcp.timeline.toolbar.appearance
+          appearance:show()
+          local zoom = appearance.zoomAmount
+          if zoom then
+            zoom:shiftValue(1)
+          end
+          appearance:hide()
+          return {zoomed = "in"}
+        `;
+      } else if (action === "out") {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          local appearance = fcp.timeline.toolbar.appearance
+          appearance:show()
+          local zoom = appearance.zoomAmount
+          if zoom then
+            zoom:shiftValue(-1)
+          end
+          appearance:hide()
+          return {zoomed = "out"}
+        `;
+      } else {
+        code = `require("cp.apple.finalcutpro"):doShortcut("ZoomToFit"):Now() return {zoomed = "fit"}`;
+      }
+      const resp = await client.executeLua(code);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_timeline_get_info": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local timeline = fcp.timeline
+        local result = {
+          showing = timeline:isShowing(),
+          onPrimary = timeline:isOnPrimary(),
+          onSecondary = timeline:isOnSecondary(),
+          playing = timeline:isPlaying(),
+          focused = timeline:isFocused(),
+        }
+        -- Read playhead timecode
+        pcall(function()
+          result.timecode = tostring(fcp.viewer:timecode())
+        end)
+        -- Read clip list from AX tree
+        pcall(function()
+          local contents = timeline.contents:UI()
+          if contents then
+            local children = contents:attributeValue("AXChildren")
+            if children then
+              result.clips = {}
+              result.clipCount = 0
+              for _, c in ipairs(children) do
+                local desc = c:attributeValue("AXDescription")
+                if desc and desc ~= "Playhead" then
+                  result.clipCount = result.clipCount + 1
+                  table.insert(result.clips, {
+                    description = desc,
+                    duration = c:attributeValue("AXValue"),
+                  })
+                end
+              end
+            end
+          end
+        end)
+        -- Read undo state via CommandPost's app reference
+        pcall(function()
+          local app = fcp:application()
+          if app then
+            local menus = app:getMenuItems()
+            if menus then
+              for _, m in ipairs(menus) do
+                if m.AXTitle == "Edit" then
+                  result.undoText = m.AXChildren[1][1].AXTitle
+                  break
+                end
+              end
+            end
+          end
+        end)
+        return result
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Effects & Plugins ───────────────────────────────────────
+    case "fcp_apply_effect": {
+      const effectName = args.name as string;
+      const effectType = (args.type as string) || "video";
+      const handler =
+        effectType === "audio" ? "fcpx_audioEffect" : "fcpx_videoEffect";
+
+      // Pre-check: verify clip is selected and capture before-state
+      const beforeState = (unwrapNestedResult(await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local result = {}
+        pcall(function()
+          local contents = fcp.timeline.contents
+          if contents and contents:isShowing() then
+            local selected = contents:selectedClipsUI() or {}
+            result.selectedClipCount = #selected
+          end
+        end)
+        pcall(function()
+          local app = fcp:application()
+          local menus = app and app:getMenuItems()
+          if menus then
+            for _, m in ipairs(menus) do
+              if m.AXTitle == "Edit" then
+                result.undoText = m.AXChildren[1][1].AXTitle
+                break
+              end
+            end
+          end
+        end)
+        return result
+      `)) ?? {}) as Record<string, unknown>;
+
+      if (Number(beforeState?.selectedClipCount ?? 0) === 0) {
+        return formatResult({
+          action: "apply_effect",
+          name: effectName,
+          type: effectType,
+          success: false,
+          error: "No clip selected. Select a clip in the timeline before applying an effect.",
+        });
+      }
+
+      await activateFinalCutPro();
+      const resp = await client.executeAction(handler, effectName);
+      await delay(800);
+
+      // Post-check: verify undo text changed
+      const afterState = (unwrapNestedResult(await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local result = {}
+        pcall(function()
+          local app = fcp:application()
+          local menus = app and app:getMenuItems()
+          if menus then
+            for _, m in ipairs(menus) do
+              if m.AXTitle == "Edit" then
+                result.undoText = m.AXChildren[1][1].AXTitle
+                break
+              end
+            end
+          end
+        end)
+        return result
+      `)) ?? {}) as Record<string, unknown>;
+
+      const undoChanged = beforeState?.undoText !== afterState?.undoText;
+      return formatResult({
+        action: "apply_effect",
+        name: effectName,
+        type: effectType,
+        applied: undoChanged,
+        result: extractResult(resp),
+        ...(!undoChanged ? {
+          error: `Effect "${effectName}" may not have been applied. The undo state did not change. Check that the effect name is correct and a clip is selected.`,
+        } : {}),
+      });
+    }
+
+    case "fcp_apply_transition": {
+      const transName = args.name as string;
+
+      // Pre-check: ensure a clip is selected (auto-select at playhead if not)
+      const preCheckResp = await client.executeLua(safeLua(`
+        local contents = fcp.timeline.contents
+        if not contents:isShowing() then
+          return {error = "Timeline is not showing"}
+        end
+
+        local selected = contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          -- Auto-select clip at playhead
+          local playheadClips = contents:playheadClipsUI(true) or {}
+          if #playheadClips > 0 then
+            contents:selectClip(playheadClips[1])
+            hs.timer.usleep(200000)
+            selected = contents:selectedClipsUI() or {}
+          end
+        end
+
+        -- Count transitions before
+        local transitionCount = 0
+        local clipCount = 0
+        local allClips = contents:clipsUI(true) or {}
+        for _, clip in ipairs(allClips) do
+          local desc = clip:attributeValue("AXDescription") or ""
+          if string.sub(desc, 1, 11) == "Transition:" then
+            transitionCount = transitionCount + 1
+          end
+          clipCount = clipCount + 1
+        end
+
+        -- Read undo text via AX (more reliable than getMenuItems)
+        local undoText = nil
+        pcall(function()
+          local editMenu = fcp:menu():findMenuUI({"Edit"})
+          if editMenu then
+            local items = editMenu:attributeValue("AXChildren")
+            if items and items[1] then
+              local undoItems = items[1]:attributeValue("AXChildren")
+              if undoItems and undoItems[1] then
+                undoText = undoItems[1]:attributeValue("AXTitle")
+              end
+            end
+          end
+        end)
+
+        return {
+          selectedCount = #selected,
+          transitionCount = transitionCount,
+          clipCount = clipCount,
+          undoText = undoText,
+        }
+      `));
+      const beforeState = (unwrapNestedResult(preCheckResp) ?? {}) as Record<string, unknown>;
+
+      if (beforeState?.error) {
+        return formatResult({ action: "apply_transition", name: transName, applied: false, ...beforeState });
+      }
+
+      await activateFinalCutPro();
+      const actionResult = extractResult(await client.executeAction("fcpx_transition", transName));
+      await delay(1200);
+
+      // Check for and handle FCP dialogs (e.g., "not enough media handles" prompt)
+      const dialogResp = await client.executeLua(safeLua(`
+        -- Check for media handles dialog and auto-accept "Create Transition"
+        local dialogResult = handleFCPDialog(false)
+        if dialogResult then
+          hs.timer.usleep(800000)
+        end
+        return {dialog = dialogResult}
+      `));
+      const dialogState = (unwrapNestedResult(dialogResp) ?? {}) as Record<string, unknown>;
+      const dialogHandled = dialogState?.dialog as Record<string, unknown> | undefined;
+      if (dialogHandled) {
+        // Dialog was present — wait extra time for transition to finalize
+        await delay(800);
+      }
+
+      // Read after-state
+      const afterResp = await client.executeLua(safeLua(`
+        local contents = fcp.timeline.contents
+        local transitionCount = 0
+        local clipCount = 0
+        local allClips = contents:clipsUI(true) or {}
+        for _, clip in ipairs(allClips) do
+          local desc = clip:attributeValue("AXDescription") or ""
+          if string.sub(desc, 1, 11) == "Transition:" then
+            transitionCount = transitionCount + 1
+          end
+          clipCount = clipCount + 1
+        end
+
+        local undoText = nil
+        pcall(function()
+          local editMenu = fcp:menu():findMenuUI({"Edit"})
+          if editMenu then
+            local items = editMenu:attributeValue("AXChildren")
+            if items and items[1] then
+              local undoItems = items[1]:attributeValue("AXChildren")
+              if undoItems and undoItems[1] then
+                undoText = undoItems[1]:attributeValue("AXTitle")
+              end
+            end
+          end
+        end)
+
+        return {
+          transitionCount = transitionCount,
+          clipCount = clipCount,
+          undoText = undoText,
+        }
+      `));
+      const afterState = (unwrapNestedResult(afterResp) ?? {}) as Record<string, unknown>;
+
+      const beforeUndoText = beforeState?.undoText as string | undefined;
+      const afterUndoText = afterState?.undoText as string | undefined;
+      const beforeTransitionCount = Number(beforeState?.transitionCount ?? 0);
+      const afterTransitionCount = Number(afterState?.transitionCount ?? 0);
+      const undoChanged = beforeUndoText !== afterUndoText;
+      const transitionCountChanged = afterTransitionCount > beforeTransitionCount;
+      const undoSaysTransition = typeof afterUndoText === "string" && afterUndoText.includes("Transition");
+      const applied = undoChanged || transitionCountChanged || undoSaysTransition;
+
+      if (!applied) {
+        return formatResult({
+          action: "apply_transition",
+          name: transName,
+          applied: false,
+          beforeUndoText,
+          afterUndoText,
+          beforeTransitionCount,
+          afterTransitionCount,
+          error: Number(beforeState?.selectedCount ?? 0) === 0
+            ? "No clips are selected. Select a clip or position the playhead on a clip first."
+            : "Transition may not have applied. Ensure the clip has sufficient media handles at the edit point.",
+        });
+      }
+
+      return formatResult({
+        action: "apply_transition",
+        name: transName,
+        applied: true,
+        ...(dialogHandled ? { mediaHandlesDialog: true, dialogAction: dialogHandled.clicked } : {}),
+        verifiedBy: transitionCountChanged ? "transition_count" : (undoSaysTransition ? "undo_text" : "undo_changed"),
+        beforeTransitionCount,
+        afterTransitionCount,
+      });
+    }
+
+    case "fcp_apply_generator": {
+      const genName = args.name as string;
+      await activateFinalCutPro();
+      const resp = await client.executeAction("fcpx_generator", genName);
+      return formatResult({
+        action: "apply_generator",
+        name: genName,
+        result: extractResult(resp),
+      });
+    }
+
+    case "fcp_apply_title": {
+      const titleName = args.name as string;
+      await activateFinalCutPro();
+      const resp = await client.executeAction("fcpx_title", titleName);
+      return formatResult({
+        action: "apply_title",
+        name: titleName,
+        result: extractResult(resp),
+      });
+    }
+
+    // ── FCP Browser ─────────────────────────────────────────────────
+    case "fcp_browser_show": {
+      const panel = (args.panel as string) || "libraries";
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local browser = fcp.browser
+        browser:showOnPrimary()
+        if "${escapeLua(panel)}" == "media" then
+          browser.showMedia:checked(true)
+        elseif "${escapeLua(panel)}" == "generators" then
+          browser.showGenerators:checked(true)
+        else
+          browser.showLibraries:checked(true)
+        end
+        return {shown = true, panel = "${escapeLua(panel)}"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_browser_list_libraries": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local names = fcp:activeLibraryNames() or {}
+        local paths = fcp:activeLibraryPaths() or {}
+        local libs = {}
+        for i, name in ipairs(names) do
+          table.insert(libs, {name = name, path = paths[i] or "unknown"})
+        end
+        return libs
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_browser_select_library": {
+      const title = args.title as string;
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local result = fcp:selectLibrary("${escapeLua(title)}")
+        return {selected = result ~= nil, library = "${escapeLua(title)}"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Inspector ───────────────────────────────────────────────
+    case "fcp_inspector_show": {
+      const tabArg = args.tab as string | undefined;
+      const tab = tabArg ? INSPECTOR_TAB_MAP[tabArg] : undefined;
+      if (tabArg && !tab) {
+        return JSON.stringify({ error: `Unknown inspector tab: ${tabArg}` });
+      }
+      let code: string;
+      if (tab) {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          fcp.inspector:show("${escapeLua(tab)}")
+          return {shown = true, tab = "${escapeLua(tab)}"}
+        `;
+      } else {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          fcp.inspector:show()
+          return {shown = true}
+        `;
+      }
+      const resp = await client.executeLua(code);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Viewer ──────────────────────────────────────────────────
+    case "fcp_viewer_show": {
+      const display = (args.display as string) || "primary";
+      const method =
+        display === "secondary" ? "showOnSecondary" : "showOnPrimary";
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp.viewer:${method}()
+        return {shown = true, display = "${escapeLua(display)}"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Color ───────────────────────────────────────────────────
+    case "fcp_color_board": {
+      const aspect = args.aspect as string;
+      const puck = args.puck as string;
+      const value = args.value as number;
+      const property = ((args.property as string) || "percentage") === "angle"
+        ? "angle"
+        : "percent";
+
+      // Allowlist to prevent Lua injection via property access
+      const validAspects = new Set(["color", "saturation", "exposure"]);
+      const validPucks = new Set(["master", "shadows", "midtones", "highlights"]);
+      if (!validAspects.has(aspect)) {
+        return JSON.stringify({ success: false, error: `Invalid aspect: ${aspect}` });
+      }
+      if (!validPucks.has(puck)) {
+        return JSON.stringify({ success: false, error: `Invalid puck: ${puck}` });
+      }
+
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local colorBoard = fcp.colorBoard
+        colorBoard:show()
+        local aspectPanel = colorBoard.${aspect}
+        local puckControl = aspectPanel.${puck}
+        puckControl:show()
+        puckControl:${property}(${value})
+        return {adjusted = true, aspect = "${escapeLua(aspect)}", puck = "${escapeLua(puck)}", value = ${value}}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Export/Import ───────────────────────────────────────────
+    case "fcp_export": {
+      const destination = args.destination as string | undefined;
+      let code: string;
+      if (destination) {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          fcp:selectMenu({"File", "Share", "${escapeLua(destination)}"}, {plain = true})
+          return {exporting = true, destination = "${escapeLua(destination)}"}
+        `;
+      } else {
+        code = `
+          local fcp = require("cp.apple.finalcutpro")
+          fcp:selectMenu({"File", "Share", "Master File..."}, {plain = true})
+          return {exporting = true, destination = "Master File"}
+        `;
+      }
+      const resp = await client.executeLua(code);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_import_media": {
+      const path = args.path as string;
+      const pathErr = validateFilePath(path);
+      if (pathErr) return JSON.stringify({ error: pathErr });
+      const resp = await client.executeLua(`
+        local fs = require("hs.fs")
+        local fcp = require("cp.apple.finalcutpro")
+        local mediaImport = fcp.mediaImport
+        local path = fs.pathToAbsolute("${escapeLua(path)}") or "${escapeLua(path)}"
+        local attributes = fs.attributes(path)
+
+        if not attributes then
+          return {imported = false, path = path, error = "Path does not exist"}
+        end
+
+        local imported, message = mediaImport:importPath(path)
+        if not imported then
+          return {
+            imported = false,
+            path = path,
+            kind = attributes.mode,
+            error = message,
+          }
+        end
+
+        return {imported = true, path = path, kind = attributes.mode}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_import_xml": {
+      const path = args.path as string;
+      const pathErr = validateFilePath(path);
+      if (pathErr) return JSON.stringify({ error: pathErr });
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:importXML("${escapeLua(path)}")
+        return {imported = true, path = "${escapeLua(path)}"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_export_xml": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:selectMenu({"File", "Export XML..."}, {plain = true})
+        return {exporting = true}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Projects & Libraries ────────────────────────────────────
+    case "fcp_open_project": {
+      const projectName = args.name as string;
+      const resp = await client.executeLua(safeLua(`
+        local just = require("cp.just")
+        local fcp = require("cp.apple.finalcutpro")
+        local projectName = "${escapeLua(projectName)}"
+
+        fcp:launch()
+        local app = fcp:application()
+        if app then
+          pcall(function() app:activate() end)
+          hs.timer.usleep(300000)
+        end
+
+        local function currentProjectTitle()
+          return safeGet(function() return fcp.timeline.toolbar.title:title() end)
+            or safeGet(function() return fcp.timeline.toolbar.title:value() end)
+        end
+
+        local function waitUntilReady(seconds)
+          return just.doUntil(function()
+            return fcp.timeline:isLoaded() and fcp.timeline:isShowing()
+          end, seconds)
+        end
+
+        local showing = safeGet(function() return fcp.timeline:isShowing() end)
+        local loaded = safeGet(function() return fcp.timeline:isLoaded() end)
+        local currentProject = currentProjectTitle()
+
+        if currentProject == projectName then
+          pcall(function() fcp.timeline:show() end)
+          local ready = waitUntilReady(20)
+          local isReady = ready and true or false
+          local result = {
+            opened = projectName,
+            ready = isReady,
+            alreadyOpen = true,
+            showing = safeGet(function() return fcp.timeline:isShowing() end),
+            loaded = safeGet(function() return fcp.timeline:isLoaded() end),
+            currentProject = currentProject,
+            currentTimecode = safeGet(function() return fcp.viewer:timecode() end),
+          }
+          if not isReady then
+            result.error = "Project is already selected but the timeline did not become visible"
+          end
+          return result
+        end
+
+        fcp.timeline:doOpenProject(projectName):Now()
+        pcall(function() fcp.timeline:show() end)
+
+        local ready = waitUntilReady(20)
+        local isReady = ready and true or false
+
+        local finalProject = currentProjectTitle()
+        local finalShowing = safeGet(function() return fcp.timeline:isShowing() end)
+        local finalLoaded = safeGet(function() return fcp.timeline:isLoaded() end)
+
+        if not isReady then
+          return {
+            opened = projectName,
+            ready = false,
+            showing = finalShowing,
+            loaded = finalLoaded,
+            currentProject = finalProject,
+            currentTimecode = safeGet(function() return fcp.viewer:timecode() end),
+            error = "Project did not become ready with a visible timeline",
+          }
+        end
+
+        return {
+          opened = projectName,
+          ready = isReady,
+          alreadyOpen = finalProject == projectName,
+          showing = finalShowing,
+          loaded = finalLoaded,
+          currentProject = finalProject,
+          currentTimecode = safeGet(function() return fcp.viewer:timecode() end),
+        }
+      `), 90000);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_project_properties": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:selectMenu({"Window", "Project Properties"}, {plain = true})
+        return {showing = true}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Markers & Keywords ──────────────────────────────────────
+    case "fcp_add_marker": {
+      const markerType = (args.type as string) || "standard";
+      const markerName = typeof args.name === "string" ? args.name.trim() : "";
+      const hasMarkerName = markerName.length > 0;
+      const completed =
+        typeof args.completed === "boolean" ? args.completed : undefined;
+
+      if (completed !== undefined && markerType !== "todo") {
+        return JSON.stringify({
+          error: "'completed' is only supported for todo markers",
+        });
+      }
+
+      let code: string;
+      if (!hasMarkerName && completed === undefined) {
+        const shortcutMap: Record<string, string> = {
+          standard: "AddMarker",
+          todo: "AddToDoMarker",
+          chapter: "AddChapterMarker",
+        };
+        code = `
+          local just = require("cp.just")
+          local fcp = require("cp.apple.finalcutpro")
+          fcp.timeline:show()
+          if not just.doUntil(function() return fcp.timeline:isLoaded() end, 2) then
+            return {marker = "${escapeLua(markerType)}", added = false, error = "No open timeline"}
+          end
+
+          if not fcp.timeline:isFocused() then
+            fcp.timeline.contents:focus()
+            just.doUntil(function() return fcp.timeline:isFocused() end, 1)
+          end
+
+          fcp:doShortcut("${shortcutMap[markerType]}"):Now()
+          return {marker = "${escapeLua(markerType)}", added = true}
+        `;
+      } else if (markerType === "standard" && completed === undefined) {
+        code = `
+          local just = require("cp.just")
+          local axutils = require("cp.ui.axutils")
+          local childrenWithRole = axutils.childrenWithRole
+          local fcp = require("cp.apple.finalcutpro")
+
+          local function focusedElement()
+            return hs.axuielement.systemWideElement():attributeValue("AXFocusedUIElement")
+          end
+
+          local function focusedTextField()
+            local focused = focusedElement()
+            if focused and focused:attributeValue("AXRole") == "AXTextField" then
+              return focused
+            end
+            return nil
+          end
+
+          local function ancestorWithRole(element, role)
+            local current = element
+            local depth = 0
+            while current and depth < 12 do
+              if current:attributeValue("AXRole") == role then
+                return current
+              end
+              current = current:attributeValue("AXParent")
+              depth = depth + 1
+            end
+            return nil
+          end
+
+          local function doneButtonFor(popover)
+            if not popover then return nil end
+            for _, button in ipairs(childrenWithRole(popover, "AXButton") or {}) do
+              if button:attributeValue("AXTitle") == "Done" then
+                return button
+              end
+            end
+            return nil
+          end
+
+          fcp.timeline:show()
+          if not just.doUntil(function() return fcp.timeline:isLoaded() end, 2) then
+            return {marker = "standard", added = false, error = "No open timeline"}
+          end
+
+          if not fcp.timeline:isFocused() then
+            pcall(function() fcp.timeline.contents:doFocus(true):Now() end)
+            just.doUntil(function() return fcp.timeline:isFocused() end, 1)
+          end
+
+          local triggered = false
+          pcall(function()
+            triggered = fcp:doSelectMenu({"Mark", "Markers", "Add Marker and Modify"}):Now() == true
+          end)
+          if not triggered then
+            fcp:doShortcut("AddAndEditMarker"):Now()
+          end
+
+          local nameField = nil
+          if not just.doUntil(function()
+            nameField = focusedTextField()
+            return nameField ~= nil
+          end, 2) then
+            local focused = focusedElement()
+            return {
+              marker = "standard",
+              added = false,
+              error = "Marker name field did not appear",
+              focusedRole = focused and focused:attributeValue("AXRole") or nil,
+            }
+          end
+
+          nameField:setAttributeValue("AXValue", "${escapeLua(markerName)}")
+          hs.timer.usleep(100000)
+
+          local actualName = nameField:attributeValue("AXValue")
+          if actualName ~= "${escapeLua(markerName)}" then
+            return {
+              marker = "standard",
+              added = false,
+              error = "Unable to set marker name",
+              requestedName = "${escapeLua(markerName)}",
+              actualName = actualName,
+            }
+          end
+
+          local popover = ancestorWithRole(nameField, "AXPopover")
+          local doneButton = doneButtonFor(popover)
+          local pressed = doneButton and doneButton:performAction("AXPress") == true
+          if not pressed then
+            pcall(function() nameField:performAction("AXConfirm") end)
+          end
+
+          local closed = just.doUntil(function()
+            local focused = focusedElement()
+            return ancestorWithRole(focused, "AXPopover") == nil
+          end, 2)
+
+          if not closed then
+            return {
+              marker = "standard",
+              added = false,
+              error = "Marker editor did not close",
+              name = actualName,
+            }
+          end
+
+          return {
+            marker = "standard",
+            added = true,
+            name = actualName,
+          }
+        `;
+      } else {
+        code = `
+          local just = require("cp.just")
+          local axutils = require("cp.ui.axutils")
+          local childrenWithRole = axutils.childrenWithRole
+          local fcp = require("cp.apple.finalcutpro")
+
+          local function focusedElement()
+            return hs.axuielement.systemWideElement():attributeValue("AXFocusedUIElement")
+          end
+
+          local function focusedTextField()
+            local focused = focusedElement()
+            if focused and focused:attributeValue("AXRole") == "AXTextField" then
+              return focused
+            end
+            return nil
+          end
+
+          local function ancestorWithRole(element, role)
+            local current = element
+            local depth = 0
+            while current and depth < 12 do
+              if current:attributeValue("AXRole") == role then
+                return current
+              end
+              current = current:attributeValue("AXParent")
+              depth = depth + 1
+            end
+            return nil
+          end
+
+          local function firstChildWithRole(element, role)
+            local matches = childrenWithRole(element, role)
+            return matches and matches[1] or nil
+          end
+
+          local function radioButtonsFor(popover)
+            local group = firstChildWithRole(popover, "AXRadioGroup")
+            return group and group:attributeValue("AXChildren") or {}
+          end
+
+          local function completedCheckboxFor(popover)
+            for _, checkbox in ipairs(childrenWithRole(popover, "AXCheckBox") or {}) do
+              if checkbox:attributeValue("AXTitle") == "Completed" then
+                return checkbox
+              end
+            end
+            return nil
+          end
+
+          local function doneButtonFor(popover)
+            for _, button in ipairs(childrenWithRole(popover, "AXButton") or {}) do
+              if button:attributeValue("AXTitle") == "Done" then
+                return button
+              end
+            end
+            return nil
+          end
+
+          fcp.timeline:show()
+          if not just.doUntil(function() return fcp.timeline:isLoaded() end, 2) then
+            return {marker = "${escapeLua(markerType)}", added = false, error = "No open timeline"}
+          end
+
+          if not fcp.timeline:isFocused() then
+            pcall(function() fcp.timeline.contents:doFocus(true):Now() end)
+            just.doUntil(function() return fcp.timeline:isFocused() end, 1)
+          end
+
+          local triggered = false
+          pcall(function()
+            triggered = fcp:doSelectMenu({"Mark", "Markers", "Add Marker and Modify"}):Now() == true
+          end)
+          if not triggered then
+            fcp:doShortcut("AddAndEditMarker"):Now()
+          end
+
+          local nameField = nil
+          if not just.doUntil(function()
+            nameField = focusedTextField()
+            return nameField ~= nil
+          end, 2) then
+            return {marker = "${escapeLua(markerType)}", added = false, error = "Marker editor did not appear"}
+          end
+
+          local popover = ancestorWithRole(nameField, "AXPopover")
+          if not popover then
+            return {marker = "${escapeLua(markerType)}", added = false, error = "Marker editor popover not found"}
+          end
+
+          local radioButtons = radioButtonsFor(popover)
+          local markerIndex = 1
+          if "${escapeLua(markerType)}" == "todo" then
+            markerIndex = 2
+          elseif "${escapeLua(markerType)}" == "chapter" then
+            markerIndex = 3
+          end
+
+          local targetRadio = radioButtons[markerIndex]
+          if not targetRadio then
+            return {marker = "${escapeLua(markerType)}", added = false, error = "Marker type control not found"}
+          end
+
+          if targetRadio:attributeValue("AXValue") ~= 1 then
+            targetRadio:performAction("AXPress")
+            hs.timer.usleep(200000)
+          end
+
+          if "${escapeLua(markerName)}" ~= "" then
+            nameField = firstChildWithRole(popover, "AXTextField") or focusedTextField()
+            if not nameField then
+              return {marker = "${escapeLua(markerType)}", added = false, error = "Marker name field did not appear"}
+            end
+            nameField:setAttributeValue("AXValue", "${escapeLua(markerName)}")
+            hs.timer.usleep(100000)
+
+            local appliedName = nameField:attributeValue("AXValue")
+            if appliedName ~= "${escapeLua(markerName)}" then
+              return {
+                marker = "${escapeLua(markerType)}",
+                added = false,
+                error = "Unable to set marker name",
+                requestedName = "${escapeLua(markerName)}",
+                actualName = appliedName,
+              }
+            end
+          end
+
+          local completed = ${toLuaLiteral(completed)}
+          if completed ~= nil and "${escapeLua(markerType)}" == "todo" then
+            local completedCheckbox = completedCheckboxFor(popover)
+            if not completedCheckbox then
+              return {marker = "${escapeLua(markerType)}", added = false, error = "Completed checkbox did not appear"}
+            end
+            local currentValue = completedCheckbox:attributeValue("AXValue")
+            local desiredValue = completed and 1 or 0
+            if currentValue ~= desiredValue then
+              completedCheckbox:performAction("AXPress")
+              hs.timer.usleep(150000)
+            end
+          end
+
+          local doneButton = doneButtonFor(popover)
+          local pressed = doneButton and doneButton:performAction("AXPress") == true
+          if not pressed then
+            pcall(function() nameField:performAction("AXConfirm") end)
+          end
+
+          local closed = just.doUntil(function()
+            local focused = focusedElement()
+            return ancestorWithRole(focused, "AXPopover") == nil
+          end, 2)
+          if not closed then
+            return {marker = "${escapeLua(markerType)}", added = false, error = "Marker editor did not close"}
+          end
+
+          return {
+            marker = "${escapeLua(markerType)}",
+            added = true,
+            name = ${toLuaLiteral(hasMarkerName ? markerName : undefined)},
+            completed = completed,
+          }
+        `;
+      }
+      const resp = await client.executeLua(code);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_add_keyword": {
+      const keyword = args.keyword as string;
+      await activateFinalCutPro();
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Ensure a clip is selected; auto-select at playhead if needed
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          local playheadClips = contents:playheadClipsUI(true) or {}
+          if #playheadClips == 0 then
+            return {keyword = "${escapeLua(keyword)}", added = false, error = "No clip selected and no clip under playhead."}
+          end
+          contents:selectClip(playheadClips[1])
+          hs.timer.usleep(300000)
+        end
+
+        -- Use CommandPost's KeywordEditor API
+        local keywordEditor = fcp.keywordEditor
+        local wasShowing = keywordEditor:isShowing()
+        if not wasShowing then
+          keywordEditor:show()
+          hs.timer.usleep(1000000)
+        end
+
+        if not keywordEditor:isShowing() then
+          return {keyword = "${escapeLua(keyword)}", added = false, error = "Could not open Keyword Editor."}
+        end
+
+        local ok, err = pcall(function()
+          keywordEditor.keywords:addKeyword("${escapeLua(keyword)}")
+        end)
+
+        -- Close the keyword editor if we opened it
+        if not wasShowing then
+          keywordEditor:hide()
+          hs.timer.usleep(300000)
+        end
+
+        if not ok then
+          return {keyword = "${escapeLua(keyword)}", added = false, error = "Failed to add keyword: " .. tostring(err)}
+        end
+
+        return {keyword = "${escapeLua(keyword)}", added = true}
+      `, 30000);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_list_markers": {
+      const resp = await client.executeLua(safeLua(`
+        local timeline = fcp.timeline
+        if not timeline:isShowing() then
+          return {error = "Timeline is not showing"}
+        end
+
+        -- Access the timeline contents to find marker elements
+        local contents = timeline.contents
+        local contentsUI = contents:UI()
+        if not contentsUI then
+          return {markers = {}, count = 0, note = "Could not access timeline contents"}
+        end
+
+        local markers = {}
+        local children = contentsUI:attributeValue("AXChildren")
+        if children then
+          for _, child in ipairs(children) do
+            local role = child:attributeValue("AXRole")
+            local desc = child:attributeValue("AXDescription") or ""
+            -- Markers typically appear as specific AX elements
+            if role and (string.find(desc, "Marker") or string.find(desc, "marker") or role == "AXMarker") then
+              local marker = {
+                description = desc,
+                position = child:attributeValue("AXPosition") or {},
+                value = child:attributeValue("AXValue") or "",
+              }
+              table.insert(markers, marker)
+            end
+          end
+        end
+
+        -- Also try to get markers via FCPXML export if available
+        -- For now, return what we can from the AX tree
+        return {markers = markers, count = #markers}
+      `), 60000);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Clip Operations ─────────────────────────────────────────
+    case "fcp_rename_clip": {
+      const newName = args.name as string;
+      await activateFinalCutPro();
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local just = require("cp.just")
+
+        -- Dismiss any blocking popovers first
+        pcall(function()
+          local sp = fcp.timeline.speedPopover
+          if sp:isShowing() then
+            sp:hide()
+            just.doUntil(function() return not sp:isShowing() end, 2)
+            hs.timer.usleep(200000)
+          end
+        end)
+
+        -- Ensure FCP is frontmost (required for menu and text field interaction)
+        fcp:launch()
+        hs.timer.usleep(300000)
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {renamed = false, error = "No clip selected. Select a clip before renaming."}
+        end
+
+        -- FCP v12 moved "Rename Clip" from Modify to Clip menu; try both
+        local result = fcp:selectMenu({"Clip", "Rename Clip"}, {plain = true})
+        if not result then
+          result = fcp:selectMenu({"Modify", "Rename Clip"}, {plain = true})
+        end
+        if not result then
+          return {renamed = false, error = "Could not open Rename Clip dialog. The menu item may be disabled or no clip is selected in the browser/timeline."}
+        end
+        hs.timer.usleep(500000)
+
+        -- Wait for the inline text field to become focused
+        local textField = just.doUntil(function()
+          local focused = hs.axuielement.systemWideElement():attributeValue("AXFocusedUIElement")
+          if focused then
+            local role = focused:attributeValue("AXRole")
+            if role == "AXTextField" or role == "AXTextArea" then
+              return focused
+            end
+          end
+          return false
+        end, 3)
+        if not textField then
+          -- Try pressing Escape to dismiss any partial state
+          hs.eventtap.keyStroke({}, "escape")
+          return {renamed = false, error = "Rename text field did not appear. FCP may not be focused or the clip type does not support renaming."}
+        end
+        -- Set the value directly via accessibility instead of simulating keystrokes
+        textField:setAttributeValue("AXValue", "${escapeLua(newName)}")
+        hs.timer.usleep(100000)
+        textField:performAction("AXConfirm")
+        hs.timer.usleep(300000)
+
+        -- Read back the clip name to verify
+        local verifiedName
+        pcall(function()
+          local sel = fcp.timeline.contents:selectedClipsUI() or {}
+          if #sel > 0 then
+            verifiedName = sel[1]:attributeValue("AXDescription") or nil
+          end
+        end)
+
+        local nameInDesc = verifiedName and string.find(verifiedName, "${escapeLua(newName)}", 1, true)
+        return {
+          renamed = true,
+          name = "${escapeLua(newName)}",
+          verifiedDescription = verifiedName,
+          verified = nameInDesc ~= nil
+        }
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_rate_clip": {
+      const rating = args.rating as string;
+      const ratingMap: Record<string, string> = {
+        favorite: "Favorite",
+        reject: "Reject",
+        unrate: "Unfavorite",
+      };
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {error = "No clip selected. Select a clip before rating."}
+        end
+
+        fcp:doShortcut("${ratingMap[rating]}"):Now()
+        return {rating = "${rating}"}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, rated: false, success: false });
+      }
+      return formatResult({
+        ...result,
+        rated: result?.undoChanged === true ? "${rating}" : false,
+        ...(!result?.undoChanged ? {
+          warning: "Rating shortcut executed but undo state did not change. The clip may already have this rating.",
+        } : {}),
+      });
+    }
+
+    // ── FCP Window Management ───────────────────────────────────────
+    case "fcp_window_layout": {
+      const action = args.action as string;
+      const actionMap: Record<string, string> = {
+        show_timeline: `require("cp.apple.finalcutpro").timeline:show()`,
+        show_browser: `require("cp.apple.finalcutpro").browser:showOnPrimary()`,
+        show_inspector: `require("cp.apple.finalcutpro").inspector:show()`,
+        show_viewer: `require("cp.apple.finalcutpro").viewer:showOnPrimary()`,
+        hide_browser: `require("cp.apple.finalcutpro").browser:hide()`,
+        hide_inspector: `require("cp.apple.finalcutpro").inspector:hide()`,
+        fullscreen_toggle: `require("cp.apple.finalcutpro").primaryWindow.isFullScreen:toggle()`,
+      };
+      const luaCode = actionMap[action];
+      if (!luaCode) {
+        return JSON.stringify({ error: `Unknown layout action: ${action}` });
+      }
+      const resp = await client.executeLua(
+        `${luaCode} return {action = "${escapeLua(action)}"}`
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Undo/Redo ───────────────────────────────────────────────
+    case "fcp_undo_redo": {
+      const action = args.action as string;
+      const count = (args.count as number) ?? 1;
+      const menuPattern = action === "undo" ? "Undo" : "Redo";
+      const titleKey = action === "undo" ? "undoTitle" : "redoTitle";
+      const shortcutCommand = action === "undo" ? "UndoChanges" : "RedoChanges";
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        local function editMenuState()
+          local state = {}
+          local app = fcp:application()
+          local menus = app and app:getMenuItems()
+          if not menus then return state end
+
+          for _, menu in ipairs(menus) do
+            if menu.AXTitle == "Edit" then
+              local group = menu.AXChildren and menu.AXChildren[1]
+              if group then
+                local undoItem = group[1]
+                local redoItem = group[2]
+                state.undoTitle = undoItem and undoItem.AXTitle or nil
+                state.redoTitle = redoItem and redoItem.AXTitle or nil
+              end
+              break
+            end
+          end
+
+          return state
+        end
+
+        local function startsWith(value, prefix)
+          return type(value) == "string" and string.sub(value, 1, string.len(prefix)) == prefix
+        end
+
+        fcp:launch()
+        hs.timer.usleep(300000)
+        local app = fcp:application()
+        if app then
+          pcall(function() app:activate() end)
+          hs.timer.usleep(150000)
+        end
+
+        local before = editMenuState()
+        local initialTitle = before.${titleKey}
+        if not startsWith(initialTitle, "${menuPattern}") then
+          return {
+            action = "${action}",
+            countRequested = ${count},
+            countApplied = 0,
+            before = before,
+            error = "No ${action} item is currently available in the Edit menu",
+          }
+        end
+
+        local countApplied = 0
+        for i = 1, ${count} do
+          local state = editMenuState()
+          local currentTitle = state.${titleKey}
+          if not startsWith(currentTitle, "${menuPattern}") then
+            break
+          end
+
+          local ok, result = pcall(function()
+            fcp:doShortcut("${shortcutCommand}"):Now()
+            return editMenuState()
+          end)
+          if not ok or type(result) ~= "table" then
+            return {
+              action = "${action}",
+              countRequested = ${count},
+              countApplied = countApplied,
+              before = before,
+              error = "Failed to invoke ${shortcutCommand}",
+            }
+          end
+
+          countApplied = countApplied + 1
+          hs.timer.usleep(300000)
+        end
+
+        local after = editMenuState()
+        local changed = before.undoTitle ~= after.undoTitle or before.redoTitle ~= after.redoTitle
+
+        if countApplied ~= ${count} then
+          return {
+            action = "${action}",
+            countRequested = ${count},
+            countApplied = countApplied,
+            before = before,
+            after = after,
+            changed = changed,
+            error = "Only applied " .. tostring(countApplied) .. " of " .. tostring(${count}) .. " requested ${action} operations",
+          }
+        end
+
+        if not changed then
+          return {
+            action = "${action}",
+            countRequested = ${count},
+            countApplied = countApplied,
+            before = before,
+            after = after,
+            changed = false,
+            error = "${menuPattern} did not change the Edit menu state",
+          }
+        end
+
+        return {
+          action = "${action}",
+          countRequested = ${count},
+          countApplied = countApplied,
+          before = before,
+          after = after,
+          changed = true,
+        }
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Speed/Retime ────────────────────────────────────────────
+    case "fcp_retime": {
+      const speed = args.speed as string;
+      // Use plain text matching (no Lua patterns) to avoid issues with '%' in menu items
+      const speedMenuMap: Record<string, string[]> = {
+        slow_50: ["Modify", "Retime", "Slow", "50%"],
+        slow_25: ["Modify", "Retime", "Slow", "25%"],
+        slow_10: ["Modify", "Retime", "Slow", "10%"],
+        fast_2x: ["Modify", "Retime", "Fast", "2x"],
+        fast_4x: ["Modify", "Retime", "Fast", "4x"],
+        fast_8x: ["Modify", "Retime", "Fast", "8x"],
+        fast_20x: ["Modify", "Retime", "Fast", "20x"],
+        normal: ["Modify", "Retime", "Normal (100%)"],
+        reverse: ["Modify", "Retime", "Reverse Clip"],
+        hold: ["Modify", "Retime", "Hold"],
+      };
+      const menuPath = speedMenuMap[speed];
+      if (!menuPath) {
+        return JSON.stringify({ error: `Unknown speed preset: ${speed}` });
+      }
+      const luaPath = menuPath.map((s) => `"${escapeLua(s)}"`).join(", ");
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check if a clip is selected
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {error = "No clip selected. Select a clip before changing speed.", speed = "${escapeLua(speed)}"}
+        end
+
+        local result = fcp:selectMenu({${luaPath}}, {plain = true})
+        return {speed = "${escapeLua(speed)}", menuResult = result ~= nil}
+      `));
+      const result = extractResult(resp) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, success: false });
+      }
+      if (result?.undoChanged === false) {
+        return formatResult({
+          ...result,
+          success: false,
+          error: "Speed change did not take effect. The menu item may be disabled or unavailable for the selected clip.",
+        });
+      }
+      return formatResult(result);
+    }
+
+    // ── FCP Captions ────────────────────────────────────────────────
+    case "fcp_captions": {
+      const action = args.action as string;
+      let code: string;
+      switch (action) {
+        case "add":
+          code = `
+            local fcp = require("cp.apple.finalcutpro")
+            fcp:selectMenu({"Edit", "Captions", "Add Caption"}, {plain = true})
+            return {action = "add"}
+          `;
+          break;
+        case "extract":
+          code = `
+            local fcp = require("cp.apple.finalcutpro")
+            fcp:selectMenu({"Edit", "Captions", "Extract Captions"}, {plain = true})
+            return {action = "extract"}
+          `;
+          break;
+        case "import":
+          code = `
+            local fcp = require("cp.apple.finalcutpro")
+            fcp:selectMenu({"File", "Import", "Captions..."}, {plain = true})
+            return {action = "import"}
+          `;
+          break;
+        default:
+          return JSON.stringify({ error: `Unknown caption action: ${action}` });
+      }
+      const resp = await client.executeLua(code);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Multicam ────────────────────────────────────────────────
+    case "fcp_multicam_switch_angle": {
+      const angle = args.angle as number;
+      const switchType = (args.type as string) || "both";
+      if (angle < 1 || angle > 16) {
+        return JSON.stringify({ error: `Angle must be between 1 and 16: ${angle}` });
+      }
+      let modeShortcut: string;
+      if (switchType === "video") {
+        modeShortcut = "MultiAngleEditStyleVideo";
+      } else if (switchType === "audio") {
+        modeShortcut = "MultiAngleEditStyleAudio";
+      } else {
+        modeShortcut = "MultiAngleEditStyleAudioVideo";
+      }
+      const angleShortcut = `CutSwitchAngle${String(angle).padStart(2, "0")}`;
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp:doShortcut("${modeShortcut}"):Now()
+        fcp:doShortcut("${angleShortcut}"):Now()
+        return {angle = ${angle}, type = "${switchType}"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── FCP Pasteboard ──────────────────────────────────────────────
+    case "fcp_pasteboard": {
+      const action = args.action as string;
+      const slot = typeof args.slot === "number" ? args.slot : undefined;
+      const slotLiteral = slot !== undefined ? `"${slot}"` : "nil";
+      if (action === "copy") {
+        const resp = await client.executeLua(safeLua(`
+          local slot = ${slotLiteral}
+          if slot then
+            local pasteboardManager = require("cp.plugins")("finalcutpro.pasteboard.manager")
+            if not pasteboardManager then
+              return {action = "copied", buffered = false, slot = tonumber(slot), error = "Pasteboard manager not available"}
+            end
+            local ok, err = pcall(function()
+              pasteboardManager.doSaveToBuffer(slot):Now()
+            end)
+            if not ok then
+              return {action = "copied", buffered = false, slot = tonumber(slot), error = tostring(err)}
+            end
+            return {action = "copied", buffered = true, slot = tonumber(slot)}
+          end
+
+          fcp:doShortcut("Copy"):Now()
+          return {action = "copied", buffered = false}
+        `));
+        return formatResult(extractResult(resp));
+      } else if (action === "paste") {
+        const resp = await client.executeLua(safeLua(`
+          local slot = ${slotLiteral}
+          if slot then
+            local pasteboardManager = require("cp.plugins")("finalcutpro.pasteboard.manager")
+            if not pasteboardManager then
+              return {action = "pasted", buffered = false, slot = tonumber(slot), error = "Pasteboard manager not available"}
+            end
+            local ok, err = pcall(function()
+              pasteboardManager.doRestoreFromBuffer(slot):Now()
+            end)
+            if not ok then
+              return {action = "pasted", buffered = false, slot = tonumber(slot), error = tostring(err)}
+            end
+            return {action = "pasted", buffered = true, slot = tonumber(slot)}
+          end
+
+          fcp:doShortcut("Paste"):Now()
+          return {action = "pasted", buffered = false}
+        `));
+        return formatResult(extractResult(resp));
+      } else {
+        const resp = await client.executeLua(safeLua(`
+          local base64 = require("hs.base64")
+          local pasteboardManager = require("cp.plugins")("finalcutpro.pasteboard.manager")
+          if not pasteboardManager or not pasteboardManager.buffer then
+            return {action = "history", items = {}, count = 0, error = "Pasteboard manager not available"}
+          end
+
+          local buffer = pasteboardManager.buffer() or {}
+          local items = {}
+          for key, encodedData in pairs(buffer) do
+            if encodedData and encodedData ~= "" then
+              local decoded = base64.decode(encodedData)
+              local label = nil
+              local clipCount = 0
+              if decoded then
+                local ok, foundLabel, foundCount = pcall(function()
+                  return pasteboardManager.findClipName(decoded, "Unknown")
+                end)
+                if ok then
+                  label = foundLabel
+                  clipCount = foundCount or 0
+                end
+              end
+
+              table.insert(items, {
+                slot = tonumber(key) or key,
+                label = label,
+                clipCount = clipCount,
+                populated = decoded ~= nil,
+              })
+            end
+          end
+
+          table.sort(items, function(a, b)
+            return (tonumber(a.slot) or 999999) < (tonumber(b.slot) or 999999)
+          end)
+
+          return {action = "history", items = items, count = #items}
+        `));
+        return formatResult(extractResult(resp));
+      }
+    }
+
+    // ── Notifications/Alerts ────────────────────────────────────────
+    case "commandpost_alert": {
+      const message = args.message as string;
+      const duration = (args.duration as number) || 2;
+      const resp = await client.executeLua(
+        `hs.alert.show("${escapeLua(message)}", ${duration}) return {alerted = true}`
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Discovery / Introspection ──────────────────────────────────
+    case "fcp_list_effects":
+    case "fcp_list_audio_effects":
+    case "fcp_list_transitions":
+    case "fcp_list_generators":
+    case "fcp_list_titles": {
+      const handlerMap: Record<string, string> = {
+        fcp_list_effects: "fcpx_videoEffect",
+        fcp_list_audio_effects: "fcpx_audioEffect",
+        fcp_list_transitions: "fcpx_transition",
+        fcp_list_generators: "fcpx_generator",
+        fcp_list_titles: "fcpx_title",
+      };
+      const labelMap: Record<string, string> = {
+        fcp_list_effects: "video effects",
+        fcp_list_audio_effects: "audio effects",
+        fcp_list_transitions: "transitions",
+        fcp_list_generators: "generators",
+        fcp_list_titles: "titles",
+      };
+      const handlerId = handlerMap[name];
+      const label = labelMap[name];
+      const category = args.category as string | undefined;
+      const filterCode = category
+        ? `
+        local filtered = {}
+        for _, item in ipairs(items) do
+          if item.category and string.find(string.lower(item.category), string.lower("${escapeLua(category)}")) then
+            table.insert(filtered, item)
+          end
+        end
+        return filtered`
+        : "return items";
+      const resp = await client.executeLua(`
+        local actionManager = require("cp.plugins")("core.action.manager")
+        if not actionManager then
+          return {error = "Action manager not available"}
+        end
+        local handler = actionManager.getHandler("${handlerId}")
+        if not handler then
+          return {error = "${label} handler not available"}
+        end
+        local choices = handler:choices()
+        if not choices then
+          return {error = "Could not retrieve ${label} choices"}
+        end
+        local items = {}
+        for _, choice in ipairs(choices:getChoices()) do
+          table.insert(items, {
+            name = choice.text or "",
+            category = choice.subText or "",
+          })
+        end
+        ${filterCode}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_get_selected_clips": {
+      const resp = await client.executeLua(safeLua(`
+        local timeline = fcp.timeline
+        local contents = timeline.contents
+
+        if not timeline:isShowing() then
+          return {error = "Timeline is not showing"}
+        end
+
+        local clips = contents:selectedClipsUI()
+        if not clips or #clips == 0 then
+          return {clips = {}, count = 0, note = "No clips selected"}
+        end
+
+        local result = {}
+        for i, clip in ipairs(clips) do
+          local info = {
+            index = i,
+            role = safeGet(function() return clip:attributeValue("AXRole") end) or "unknown",
+            description = safeGet(function() return clip:attributeValue("AXDescription") end) or "",
+            position = safeGet(function() return clip:attributeValue("AXPosition") end) or {},
+            size = safeGet(function() return clip:attributeValue("AXSize") end) or {},
+            value = safeGet(function() return clip:attributeValue("AXValue") end),
+          }
+          table.insert(result, info)
+        end
+        return {clips = result, count = #result}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_get_playhead_position": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local viewer = fcp.viewer
+        local tc = viewer:timecode()
+        return {
+          timecode = tc or "unknown",
+          playing = viewer:isPlaying(),
+        }
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_set_playhead_position": {
+      const timecode = args.timecode as string;
+      const validErr = validateStringInput(timecode, "timecode");
+      if (validErr) return JSON.stringify({ error: validErr });
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Read before timecode
+        local beforeTC
+        pcall(function() beforeTC = tostring(fcp.viewer:timecode()) end)
+
+        -- Set playhead
+        fcp.viewer:timecode("${escapeLua(timecode)}")
+        hs.timer.usleep(200000)
+
+        -- Read back actual timecode to verify
+        local afterTC
+        pcall(function() afterTC = tostring(fcp.viewer:timecode()) end)
+
+        local moved = beforeTC ~= afterTC
+        return {
+          navigated = moved,
+          timecode = afterTC or "${escapeLua(timecode)}",
+          requestedTimecode = "${escapeLua(timecode)}",
+          previousTimecode = beforeTC,
+          error = not moved and "Playhead did not move. The timecode may be out of range or the timeline may not be focused." or nil
+        }
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_get_project_settings": {
+      const resp = await client.executeLua(safeLua(`
+        local result = {
+          running = fcp:isRunning(),
+          version = safeGet(function() return fcp:version() and tostring(fcp:version()) end),
+        }
+
+        result.currentTimecode = safeGet(function() return fcp.viewer:timecode() end)
+        result.playing = safeGet(function() return fcp.viewer:isPlaying() end)
+
+        local timeline = fcp.timeline
+        result.timelineShowing = safeGet(function() return timeline:isShowing() end)
+        result.timelineFocused = safeGet(function() return timeline:isFocused() end)
+
+        result.project = safeGet(function()
+          local proj = fcp.timeline:contents()
+          return {
+            description = proj and tostring(proj) or "unavailable",
+          }
+        end)
+
+        result.activeLibraries = safeGet(function() return fcp:activeLibraryNames() end)
+
+        return result
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Clip Properties ──────────────────────────────────────────────
+    case "fcp_get_clip_properties": {
+      const resp = await client.executeLua(safeLua(`
+        local inspector = fcp.inspector
+        inspector:show()
+
+        local videoInspector = inspector.video
+        if not videoInspector then
+          return {error = "Video inspector not available"}
+        end
+        videoInspector:show()
+
+        local result = {
+          available = safeGet(function() return videoInspector:isShowing() end),
+        }
+
+        -- Transform properties (graceful degradation per field)
+        result.transform = {
+          position = safeGet(function()
+            local t = videoInspector:transform()
+            return t and t:position() or nil
+          end),
+          rotation = safeGet(function()
+            local t = videoInspector:transform()
+            return t and t:rotation() or nil
+          end),
+          scale = safeGet(function()
+            local t = videoInspector:transform()
+            return t and t:scaleAll() or nil
+          end),
+          anchor = safeGet(function()
+            local t = videoInspector:transform()
+            return t and t:anchor() or nil
+          end),
+        }
+
+        -- Compositing properties
+        result.compositing = {
+          opacity = safeGet(function()
+            local c = videoInspector:compositing()
+            return c and c:opacity() or nil
+          end),
+          blendMode = safeGet(function()
+            local c = videoInspector:compositing()
+            return c and c:blendMode() or nil
+          end),
+        }
+
+        -- Crop properties
+        result.crop = safeGet(function()
+          local crop = videoInspector:crop()
+          if not crop then return nil end
+          return {
+            type = crop:type() or nil,
+          }
+        end)
+
+        return result
+      `), 60000);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_set_clip_properties": {
+      const posX = args.positionX as number | undefined;
+      const posY = args.positionY as number | undefined;
+      const scaleAll = args.scaleAll as number | undefined;
+      const rotation = args.rotation as number | undefined;
+      const opacity = args.opacity as number | undefined;
+
+      if (opacity !== undefined) {
+        const rangeErr = validateRange(opacity, 0, 100, "opacity");
+        if (rangeErr) return JSON.stringify({ error: rangeErr });
+      }
+
+      const setStatements: string[] = [];
+      if (posX !== undefined || posY !== undefined) {
+        setStatements.push(`
+          local pos = transform:position()
+          ${posX !== undefined ? `if pos then pos:x(${posX}) end` : ""}
+          ${posY !== undefined ? `if pos then pos:y(${posY}) end` : ""}
+        `);
+      }
+      if (scaleAll !== undefined) {
+        setStatements.push(`transform:scaleAll(${scaleAll})`);
+      }
+      if (rotation !== undefined) {
+        setStatements.push(`transform:rotation(${rotation})`);
+      }
+      if (opacity !== undefined) {
+        setStatements.push(`
+          local compositing = videoInspector:compositing()
+          if compositing then compositing:opacity(${opacity}) end
+        `);
+      }
+
+      if (setStatements.length === 0) {
+        return JSON.stringify({
+          error:
+            "No properties specified. Provide at least one of: positionX, positionY, scaleAll, rotation, opacity",
+        });
+      }
+
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local inspector = fcp.inspector
+        inspector:show()
+        local videoInspector = inspector.video
+        if not videoInspector then
+          return {error = "Video inspector not available"}
+        end
+        videoInspector:show()
+        local transform = videoInspector:transform()
+        if not transform then
+          return {error = "Transform controls not available — is a clip selected?"}
+        end
+        ${setStatements.join("\n")}
+        return {
+          set = true,
+          positionX = ${posX !== undefined ? posX : "nil"},
+          positionY = ${posY !== undefined ? posY : "nil"},
+          scaleAll = ${scaleAll !== undefined ? scaleAll : "nil"},
+          rotation = ${rotation !== undefined ? rotation : "nil"},
+          opacity = ${opacity !== undefined ? opacity : "nil"},
+        }
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Additional Clip Operations ───────────────────────────────────
+    case "fcp_duplicate_clip": {
+      const resp = await client.executeLua(withVerification(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {error = "No clip selected. Select a clip before duplicating."}
+        end
+
+        fcp:doShortcut("Copy"):Now()
+        hs.timer.usleep(100000)
+        fcp:doShortcut("PasteAsConnected"):Now()
+        return {action = "duplicate"}
+      `));
+      const raw = unwrapNestedResult(resp) as Record<string, unknown> | null;
+      const result = raw ?? {};
+      if (result?.error && !result?.verified) {
+        return formatResult({ ...result, duplicated: false, success: false });
+      }
+      // Check verification at multiple possible nesting levels
+      const verified = (result?.verified ?? (result as Record<string, unknown>)?.after) as Record<string, unknown> | undefined;
+      const clipDelta = Number(verified?.clipDelta ?? 0);
+      const undoText = String(verified?.undoText ?? (result?.after as Record<string, unknown>)?.undoText ?? "");
+      const afterClipCount = Number((result?.after as Record<string, unknown>)?.clipCount ?? 0);
+      const beforeClipCount = Number((result?.before as Record<string, unknown>)?.clipCount ?? 0);
+      const duplicated = clipDelta > 0 || undoText.includes("Paste") || (afterClipCount > beforeClipCount);
+      return formatResult({
+        ...result,
+        duplicated,
+        ...(!duplicated ? { error: "Duplicate may not have succeeded. No new clip detected in timeline." } : {}),
+      });
+    }
+
+    case "fcp_enable_disable_clip": {
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {error = "No clip selected. Select a clip before toggling enabled state."}
+        end
+
+        fcp:selectMenu({"Clip", "Enable"}, {plain = true})
+        return {action = "toggle_enable"}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, toggled: false, success: false });
+      }
+      return formatResult({
+        ...result,
+        toggled: result?.undoChanged === true,
+        ...(!result?.undoChanged ? { error: "Enable/disable toggle did not take effect." } : {}),
+      });
+    }
+
+    case "fcp_split_at_timecode": {
+      const timecode = args.timecode as string;
+      const validErr = validateStringInput(timecode, "timecode");
+      if (validErr) return JSON.stringify({ error: validErr });
+      const resp = await client.executeLua(withVerification(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp.viewer:timecode("${escapeLua(timecode)}")
+        hs.timer.usleep(200000)
+        fcp:doShortcut("BladeAtPlayhead"):Now()
+        return {action = "split", timecode = "${escapeLua(timecode)}"}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      const clipDelta = Number((result?.verified as Record<string, unknown>)?.clipDelta ?? 0);
+      if (clipDelta <= 0) {
+        return formatResult({
+          ...result,
+          split: false,
+          error: "Blade did not split the clip. There may be no clip at the specified timecode, or the timeline was not focused.",
+        });
+      }
+      return formatResult({ ...result, split: true });
+    }
+
+    case "fcp_speed_custom": {
+      const percentage = args.percentage as number;
+      const rangeErr = validateRange(percentage, 1, 10000, "percentage");
+      if (rangeErr) return JSON.stringify({ error: rangeErr });
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local just = require("cp.just")
+        local speedPopover = fcp.timeline.speedPopover
+
+        -- Open the speed popover using the native CommandPost API
+        speedPopover:doShow():Now()
+        if not just.doUntil(function() return speedPopover:isShowing() end, 3) then
+          return {error = "Speed popover did not appear"}
+        end
+
+        -- Ensure "Rate" mode is selected (not Duration)
+        if not speedPopover.byRate:checked() then
+          speedPopover.byRate:doPress():Now()
+          just.doUntil(function() return speedPopover.byRate:checked() end, 1)
+        end
+
+        -- Set the rate value via the TextField API instead of eventtap keystrokes
+        local rateField = speedPopover.rate
+        if rateField then
+          rateField:value("${percentage}")
+          -- Confirm with AXConfirm on the text field
+          local rateUI = rateField:UI()
+          if rateUI then
+            rateUI:performAction("AXConfirm")
+          end
+        else
+          -- Close the popover before returning error
+          speedPopover:hide()
+          return {error = "Rate field not available in speed popover"}
+        end
+
+        -- Dismiss the speed popover so it doesn't block subsequent operations
+        hs.timer.usleep(200000)
+        speedPopover:hide()
+        just.doUntil(function() return not speedPopover:isShowing() end, 2)
+
+        return {speed = ${percentage}, note = "Custom speed set via SpeedPopover API"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Range Selection / Work Area ──────────────────────────────────
+    case "fcp_set_range": {
+      const rangeStart = args.start as string;
+      const rangeEnd = args.end as string;
+      const startErr = validateStringInput(rangeStart, "start");
+      if (startErr) return JSON.stringify({ error: startErr });
+      const endErr = validateStringInput(rangeEnd, "end");
+      if (endErr) return JSON.stringify({ error: endErr });
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        fcp.viewer:timecode("${escapeLua(rangeStart)}")
+        hs.timer.usleep(200000)
+        fcp:doShortcut("SetSelectionStart"):Now()
+        hs.timer.usleep(100000)
+        fcp.viewer:timecode("${escapeLua(rangeEnd)}")
+        hs.timer.usleep(200000)
+        fcp:doShortcut("SetSelectionEnd"):Now()
+        return {rangeSet = true, start = "${escapeLua(rangeStart)}", ["end"] = "${escapeLua(rangeEnd)}"}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    case "fcp_clear_range": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        -- Use the native timeline contents API instead of selectMenu
+        fcp.timeline.contents:selectNone()
+        return {rangeCleared = true}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Compound Clips & Auditions ───────────────────────────────────
+    case "fcp_create_compound_clip": {
+      const compName = args.name as string | undefined;
+      const nameCode = compName
+        ? `
+        -- Wait for the compound clip name dialog to appear and find the text field
+        local just = require("cp.just")
+        local nameField = just.doUntil(function()
+          local focused = hs.axuielement.systemWideElement():attributeValue("AXFocusedUIElement")
+          if focused and focused:attributeValue("AXRole") == "AXTextField" then
+            return focused
+          end
+          return false
+        end, 3)
+        if nameField then
+          -- Set value directly via accessibility instead of simulating keystrokes
+          nameField:setAttributeValue("AXValue", "${escapeLua(compName)}")
+          nameField:performAction("AXConfirm")
+        else
+          return {created = false, error = "Compound clip name dialog did not appear"}
+        end`
+        : "";
+      const resp = await client.executeLua(withVerification(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {created = false, error = "No clips selected. Select one or more clips before creating a compound clip."}
+        end
+
+        fcp:selectMenu({"File", "New", "Compound Clip..."}, {plain = true})
+        ${nameCode}
+        return {action = "create_compound"${compName ? `, name = "${escapeLua(compName)}"` : ""}}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, created: false, success: false });
+      }
+      const undoText = String((result?.verified as Record<string, unknown>)?.undoText ?? "");
+      const created = undoText.toLowerCase().includes("compound");
+      return formatResult({
+        ...result,
+        created,
+        ...(!created ? { warning: "Compound clip creation could not be verified via undo state." } : {}),
+      });
+    }
+
+    case "fcp_break_apart_compound": {
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {error = "No clip selected. Select a compound clip before breaking apart."}
+        end
+
+        fcp:selectMenu({"Clip", "Break Apart Clip Items"}, {plain = true})
+        return {action = "break_apart"}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, brokenApart: false, success: false });
+      }
+      return formatResult({
+        ...result,
+        brokenApart: result?.undoChanged === true,
+        ...(!result?.undoChanged ? {
+          error: "Break apart did not take effect. The selected clip may not be a compound clip.",
+        } : {}),
+      });
+    }
+
+    case "fcp_create_audition": {
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected < 2 then
+          return {error = "Select at least 2 clips to create an audition."}
+        end
+
+        fcp:selectMenu({"Clip", "Audition", "Create Audition"}, {plain = true})
+        return {action = "create_audition"}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, created: false, success: false });
+      }
+      return formatResult({
+        ...result,
+        created: result?.undoChanged === true,
+        ...(!result?.undoChanged ? {
+          error: "Audition creation did not take effect. Ensure multiple clips are selected.",
+        } : {}),
+      });
+    }
+
+    // ── Roles ────────────────────────────────────────────────────────
+    case "fcp_assign_role": {
+      const role = args.role as string;
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+
+        -- Check selection first
+        local contents = fcp.timeline.contents
+        local selected = contents and contents:selectedClipsUI() or {}
+        if #selected == 0 then
+          return {error = "No clip selected. Select a clip before assigning a role."}
+        end
+
+        local result = fcp:selectMenu({"Modify", "Assign Roles", "${escapeLua(role)}"}, {plain = true})
+        return {role = "${escapeLua(role)}", menuResult = result ~= nil}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, assigned: false, success: false });
+      }
+      return formatResult({
+        ...result,
+        assigned: result?.undoChanged === true || result?.menuResult === true,
+        ...(!result?.menuResult ? {
+          error: `Role "${role}" could not be assigned. The menu item may not exist or be disabled.`,
+        } : {}),
+      });
+    }
+
+    // ── Stabilization ────────────────────────────────────────────────
+    case "fcp_stabilization": {
+      const stabEnabled = (args.enabled as boolean) !== false;
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local inspector = fcp.inspector
+        inspector:show()
+        local videoInspector = inspector.video
+        if not videoInspector then
+          return {error = "Video inspector not available"}
+        end
+        videoInspector:show()
+        local ok, err = pcall(function()
+          local stabilization = videoInspector:stabilization()
+          if stabilization then
+            stabilization:enabled(${stabEnabled})
+          end
+        end)
+        if not ok then
+          return {error = "Could not access stabilization controls: " .. tostring(err)}
+        end
+        return {stabilization = ${stabEnabled}}
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Proxy Management ─────────────────────────────────────────────
+    case "fcp_proxy_toggle": {
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local Viewer = require("cp.apple.finalcutpro.viewer.Viewer")
+        local viewer = fcp.viewer
+        local wasUsingProxies = viewer:usingProxies()
+        if wasUsingProxies then
+          -- Switch back to original quality
+          viewer:playbackMode(Viewer.PLAYBACK_MODE.ORIGINAL_BETTER_PERFORMANCE)
+        else
+          -- Switch to proxy preferred
+          viewer:playbackMode(Viewer.PLAYBACK_MODE.PROXY_PREFERRED)
+        end
+        return {
+          toggled = true,
+          wasUsingProxies = wasUsingProxies,
+          nowUsingProxies = not wasUsingProxies,
+        }
+      `);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Batch Operations ─────────────────────────────────────────────
+    case "fcp_batch_apply_transition": {
+      const resp = await client.executeLua(withVerification(`
+        local fcp = require("cp.apple.finalcutpro")
+        -- Use native timeline contents API to select all clips
+        local contents = fcp.timeline.contents
+        local clips = contents:clipsUI(true)
+        if not clips or #clips < 2 then
+          return {error = "Need at least 2 clips in the timeline to apply transitions between them."}
+        end
+        contents:selectClips(clips)
+        hs.timer.usleep(200000)
+        fcp:doShortcut("AddTransition"):Now()
+        return {action = "batch_transition", clipCount = #clips}
+      `));
+      const result = (extractResult(resp) ?? {}) as Record<string, unknown>;
+      if (result?.error) {
+        return formatResult({ ...result, applied: false, success: false });
+      }
+      const clipDelta = Number((result?.verified as Record<string, unknown>)?.clipDelta ?? 0);
+      const undoText = String((result?.verified as Record<string, unknown>)?.undoText ?? "");
+      const applied = clipDelta > 0 || undoText.toLowerCase().includes("transition");
+      return formatResult({
+        ...result,
+        applied,
+        transition: "default",
+        ...(!applied ? {
+          error: "Batch transition application could not be verified. No timeline changes detected.",
+        } : {}),
+      });
+    }
+
+    // ── Composite Workflow: Assemble Rough Cut ────────────────────────
+    case "fcp_assemble_rough_cut": {
+      const projectName = args.projectName as string | undefined;
+      const clipPlan = args.clipPlan as Array<{
+        mediaPath: string;
+      }>;
+
+      const clipStatements = clipPlan
+        .map((clip, i) => {
+          const lines: string[] = [];
+          lines.push(`  -- Clip ${i + 1}`);
+          lines.push(
+            `  local imported${i}, msg${i} = mediaImport:importPath("${escapeLua(clip.mediaPath)}")`
+          );
+          lines.push(
+            `  table.insert(results, {index=${i + 1}, path="${escapeLua(clip.mediaPath)}", imported=imported${i}~=false, error=imported${i} and nil or msg${i}})`
+          );
+          lines.push(`  if imported${i} then importedCount = importedCount + 1 end`);
+          lines.push("  hs.timer.usleep(500000)");
+          return lines.join("\n");
+        })
+        .join("\n");
+
+      const resp = await client.executeLua(
+        safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local mediaImport = fcp.mediaImport
+        if not fcp:isRunning() then
+          return {error = "Final Cut Pro is not running"}
+        end
+        local openedProject = nil
+        ${
+          projectName
+            ? `
+        local projectOpened = fcp.timeline:doOpenProject("${escapeLua(projectName)}"):Now()
+        if not projectOpened then
+          return {error = "Unable to open project: ${escapeLua(projectName)}"}
+        end
+        openedProject = "${escapeLua(projectName)}"
+        hs.timer.usleep(500000)
+        `
+            : ""
+        }
+        local results = {}
+        local importedCount = 0
+${clipStatements}
+        return {
+          assembled = false,
+          prepared = true,
+          clipCount = ${clipPlan.length},
+          importedCount = importedCount,
+          clips = results,
+          projectName = openedProject,
+          note = "Imported media for rough-cut preparation. Timeline assembly, trimming, effects, and transitions must be performed separately.",
+        }
+      `),
+        120000
+      );
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Color Wheels ──────────────────────────────────────────────
+    case "fcp_color_wheels": {
+      const control = args.control as string;
+      const value = args.value as number | undefined;
+      const reset = args.reset as boolean | undefined;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local inspector = fcp.inspector
+        inspector:show()
+        local colorInspector = inspector.color
+        if not colorInspector then return {error = "Color inspector not available"} end
+        colorInspector:show()
+        local wheels = colorInspector:colorWheels()
+        if not wheels then return {error = "Color Wheels not available — make sure a clip is selected and the color inspector is open"} end
+        wheels:show()
+        hs.timer.usleep(300000)
+        local control = "${escapeLua(control)}"
+        local prop = wheels[control]
+        if not prop then return {error = "Unknown color wheel control: " .. control} end
+        ${reset ? `
+        if type(prop.doReset) == "function" then prop:doReset():Now()
+        else return {error = "Reset not supported for " .. control} end
+        return {reset = true, control = control}
+        ` : value !== undefined ? `
+        prop(${value})
+        return {control = control, value = ${value}, set = true}
+        ` : `
+        local val = prop()
+        return {control = control, value = val}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Video Inspector ───────────────────────────────────────────
+    case "fcp_video_inspector": {
+      const viAction = args.action as string;
+      const section = args.section as string;
+      const property = args.property as string | undefined;
+      const viValue = args.value;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local inspector = fcp.inspector
+        inspector:show()
+        local video = inspector.video
+        if not video then return {error = "Video inspector not available"} end
+        video:show()
+        hs.timer.usleep(300000)
+        local section = video:${escapeLua(section)}()
+        if not section then return {error = "Section '${escapeLua(section)}' not available"} end
+        ${viAction === "get" ? `
+        -- Read all properties from this section
+        local result = {section = "${escapeLua(section)}"}
+        local ok, val = pcall(function()
+          local ui = section:UI()
+          if ui then
+            local children = ui:attributeValue("AXChildren") or {}
+            result.propertyCount = #children
+          end
+        end)
+        ${property ? `
+        local prop = section["${escapeLua(property)}"]
+        if prop then
+          local pok, pval = pcall(function() return prop() end)
+          if pok then result["${escapeLua(property)}"] = pval end
+        end
+        ` : ""}
+        return result
+        ` : `
+        ${property && viValue !== undefined ? `
+        local prop = section["${escapeLua(property)}"]
+        if not prop then return {error = "Property '${escapeLua(property ?? "")}' not found in section '${escapeLua(section)}'"} end
+        prop(${toLuaLiteral(viValue)})
+        return {section = "${escapeLua(section)}", property = "${escapeLua(property ?? "")}", value = ${toLuaLiteral(viValue)}, set = true}
+        ` : `return {error = "property and value are required for action=set"}`}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Audio Inspector ───────────────────────────────────────────
+    case "fcp_audio_inspector": {
+      const aiAction = args.action as string;
+      const aiProp = args.property as string | undefined;
+      const aiValue = args.value as number | undefined;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local inspector = fcp.inspector
+        inspector:show()
+        local audio = inspector.audio
+        if not audio then return {error = "Audio inspector not available"} end
+        audio:show()
+        hs.timer.usleep(300000)
+        ${aiAction === "get" ? `
+        local result = {}
+        ${aiProp ? `
+        local prop = audio["${escapeLua(aiProp)}"]
+        if prop then
+          local ok, val = pcall(function() return prop() end)
+          if ok then result["${escapeLua(aiProp)}"] = val end
+        end
+        ` : `result.showing = audio:isShowing()`}
+        return result
+        ` : `
+        ${aiProp && aiValue !== undefined ? `
+        local prop = audio["${escapeLua(aiProp)}"]
+        if not prop then return {error = "Property '${escapeLua(aiProp ?? "")}' not found"} end
+        prop(${aiValue})
+        return {property = "${escapeLua(aiProp ?? "")}", value = ${aiValue}, set = true}
+        ` : `return {error = "property and value are required for action=set"}`}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Toolbar State ─────────────────────────────────────────────
+    case "fcp_toolbar_state": {
+      const tbAction = args.action as string;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local toolbar = fcp.timeline.toolbar
+        if not toolbar then return {error = "Timeline toolbar not available"} end
+        ${tbAction === "get" ? `
+        return {
+          snapping = safeGet(function() return toolbar:snapping() end),
+          skimming = safeGet(function() return toolbar:skimming() end),
+          audioSkimming = safeGet(function() return toolbar:audioSkimming() end),
+          solo = safeGet(function() return toolbar:solo() end),
+        }
+        ` : `
+        ${args.toggle ? `
+        local toggle = toolbar["${escapeLua(args.toggle as string)}"]
+        if toggle then
+          toggle(${args.enabled === true})
+          return {toggle = "${escapeLua(args.toggle as string)}", enabled = ${args.enabled === true}, set = true}
+        else
+          return {error = "Unknown toggle: ${escapeLua(args.toggle as string)}"}
+        end
+        ` : ""}
+        ${args.tool ? `
+        local toolMap = {
+          select = "SelectTool", trim = "TrimTool", position = "PositionTool",
+          range = "RangeSelectionTool", blade = "BladeTool", zoom = "ZoomTool", hand = "HandTool",
+        }
+        local shortcutName = toolMap["${escapeLua(args.tool as string)}"]
+        if shortcutName then
+          fcp:doShortcut(shortcutName):Now()
+          return {tool = "${escapeLua(args.tool as string)}", set = true}
+        else
+          return {error = "Unknown tool: ${escapeLua(args.tool as string)}"}
+        end
+        ` : ""}
+        ${!args.toggle && !args.tool ? `return {error = "Specify toggle and/or tool for set action"}` : ""}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Timeline Appearance ───────────────────────────────────────
+    case "fcp_timeline_appearance": {
+      const taAction = args.action as string;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local appearance = fcp.timeline.toolbar:appearance()
+        if not appearance then return {error = "Timeline appearance popover not available"} end
+        ${taAction === "get" ? `
+        appearance:show()
+        hs.timer.usleep(300000)
+        local result = {
+          clipHeight = safeGet(function() return appearance:clipHeight() end),
+          clipNames = safeGet(function() return appearance:clipNames() end),
+          clipRoles = safeGet(function() return appearance:clipRoles() end),
+          laneHeaders = safeGet(function() return appearance:laneHeaders() end),
+        }
+        appearance:hide()
+        return result
+        ` : `
+        appearance:show()
+        hs.timer.usleep(300000)
+        local changed = {}
+        ${args.clipHeight !== undefined ? `appearance:clipHeight(${Number(args.clipHeight)}); changed.clipHeight = ${Number(args.clipHeight)}` : ""}
+        ${args.clipNames !== undefined ? `appearance:clipNames(${args.clipNames === true}); changed.clipNames = ${args.clipNames === true}` : ""}
+        ${args.clipRoles !== undefined ? `appearance:clipRoles(${args.clipRoles === true}); changed.clipRoles = ${args.clipRoles === true}` : ""}
+        ${args.laneHeaders !== undefined ? `appearance:laneHeaders(${args.laneHeaders === true}); changed.laneHeaders = ${args.laneHeaders === true}` : ""}
+        appearance:hide()
+        return {set = true, changed = changed}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Viewer Config ─────────────────────────────────────────────
+    case "fcp_viewer_config": {
+      const vcAction = args.action as string;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local Viewer = require("cp.apple.finalcutpro.viewer.Viewer")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local viewer = fcp.viewer
+        ${vcAction === "get" ? `
+        return {
+          usingProxies = safeGet(function() return viewer:usingProxies() end),
+          betterQuality = safeGet(function() return viewer:betterQuality() end),
+          isPlaying = safeGet(function() return viewer:isPlaying() end),
+          timecode = safeGet(function() return viewer:timecode() end),
+        }
+        ` : `
+        local changed = {}
+        ${args.quality ? `
+        local modeMap = {
+          better_quality = Viewer.PLAYBACK_MODE.ORIGINAL_BETTER_QUALITY,
+          better_performance = Viewer.PLAYBACK_MODE.ORIGINAL_BETTER_PERFORMANCE,
+          proxy_preferred = Viewer.PLAYBACK_MODE.PROXY_PREFERRED,
+          proxy_only = Viewer.PLAYBACK_MODE.PROXY_ONLY,
+          original_better_quality = Viewer.PLAYBACK_MODE.ORIGINAL_BETTER_QUALITY,
+          original_better_performance = Viewer.PLAYBACK_MODE.ORIGINAL_BETTER_PERFORMANCE,
+        }
+        local mode = modeMap["${escapeLua(args.quality as string)}"]
+        if mode then
+          viewer:playbackMode(mode)
+          changed.quality = "${escapeLua(args.quality as string)}"
+        end
+        ` : ""}
+        return {set = true, changed = changed}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── CSV Export ─────────────────────────────────────────────────
+    case "fcp_export_csv": {
+      const csvSource = args.source as string;
+      const csvPath = args.path as string | undefined;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        ${csvSource === "browser" ? `
+        fcp:selectMenu({"File", "Export", "Browser Contents as CSV..."})
+        ` : `
+        fcp:selectMenu({"File", "Export", "Timeline Index as CSV..."})
+        `}
+        return {exported = true, source = "${escapeLua(csvSource)}"}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Match Frame ───────────────────────────────────────────────
+    case "fcp_match_frame": {
+      const multicam = args.multicam as boolean | undefined;
+      const resp = await client.executeLua(withUndoCheck(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        ${multicam ? `
+        fcp:selectMenu({"File", "Reveal in Browser", "Multicam Match Frame"})
+        return {action = "multicam_match_frame"}
+        ` : `
+        fcp:doShortcut("RevealInBrowserMatchFrame"):Now()
+        return {action = "match_frame"}
+        `}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Transcode ─────────────────────────────────────────────────
+    case "fcp_transcode": {
+      const mode = args.mode as string;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        ${mode === "optimize" || mode === "both" ? `
+        fcp:selectMenu({"File", "Transcode Media", "Create Optimized Media"})
+        ` : ""}
+        ${mode === "proxy" || mode === "both" ? `
+        ${mode === "both" ? "hs.timer.usleep(500000)" : ""}
+        fcp:selectMenu({"File", "Transcode Media", "Create Proxy Media"})
+        ` : ""}
+        return {transcoding = true, mode = "${escapeLua(mode)}"}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Find & Replace Titles ─────────────────────────────────────
+    case "fcp_find_replace_titles": {
+      const findText = args.find as string;
+      const replaceText = args.replace as string;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        -- Open Find and Replace Title Text dialog
+        fcp:selectMenu({"Edit", "Find and Replace Title Text…"})
+        hs.timer.usleep(500000)
+        -- Use AX to find the dialog and fill in fields
+        local app = fcp:application()
+        if not app then return {error = "FCP application not found"} end
+        local just = require("cp.just")
+        local dialog = just.doUntil(function()
+          local wins = app:allWindows()
+          for _, w in ipairs(wins) do
+            local axWin = hs.axuielement.windowElement(w)
+            if axWin and axWin:attributeValue("AXSubrole") == "AXDialog" then
+              return axWin
+            end
+          end
+          return false
+        end, 3)
+        if not dialog then return {error = "Find and Replace dialog did not open"} end
+        local textFields = dialog:attributeValue("AXChildren") or {}
+        local fields = {}
+        for _, child in ipairs(textFields) do
+          if child:attributeValue("AXRole") == "AXTextField" then
+            table.insert(fields, child)
+          end
+        end
+        if #fields < 2 then return {error = "Could not find text fields in dialog"} end
+        fields[1]:setAttributeValue("AXValue", "${escapeLua(findText)}")
+        fields[2]:setAttributeValue("AXValue", "${escapeLua(replaceText)}")
+        -- Click Replace All button
+        for _, child in ipairs(textFields) do
+          if child:attributeValue("AXRole") == "AXButton" and (child:attributeValue("AXTitle") or ""):find("Replace All") then
+            child:performAction("AXPress")
+            hs.timer.usleep(300000)
+            return {replaced = true, find = "${escapeLua(findText)}", replace = "${escapeLua(replaceText)}"}
+          end
+        end
+        return {error = "Replace All button not found"}
+      `), 30000);
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Keyword Presets ───────────────────────────────────────────
+    case "fcp_keyword_presets": {
+      const kpAction = args.action as string;
+      const kpPreset = args.preset as number | undefined;
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        ${kpAction === "list" ? `
+        local config = require("cp.config")
+        local presets = {}
+        for i = 1, 9 do
+          local key = "fcpxBrowserKeywordPreset" .. i
+          local val = config.get(key)
+          if val then presets[i] = val end
+        end
+        return {presets = presets}
+        ` : kpAction === "save" && kpPreset ? `
+        local keywordEditor = fcp.keywordEditor
+        local keywords = keywordEditor and keywordEditor:keywords() or nil
+        if not keywords then return {error = "Could not read keywords from Keyword Editor"} end
+        local config = require("cp.config")
+        config.set("fcpxBrowserKeywordPreset${kpPreset}", keywords)
+        return {saved = true, preset = ${kpPreset}, keywords = keywords}
+        ` : kpAction === "restore" && kpPreset ? `
+        local config = require("cp.config")
+        local keywords = config.get("fcpxBrowserKeywordPreset${kpPreset}")
+        if not keywords then return {error = "No keywords saved in preset ${kpPreset}"} end
+        local keywordEditor = fcp.keywordEditor
+        if keywordEditor then
+          keywordEditor:keywords(keywords)
+          return {restored = true, preset = ${kpPreset}, keywords = keywords}
+        end
+        return {error = "Could not access Keyword Editor"}
+        ` : `return {error = "Invalid action or missing preset number"}`}
+      `));
+      return formatResult(extractResult(resp));
+    }
+
+    // ── Text to Markers ───────────────────────────────────────────
+    case "fcp_text_to_markers": {
+      const markerText = args.text as string;
+      const markerType = (args.type as string) || "marker";
+      const resp = await client.executeLua(safeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        if not fcp:isRunning() then return {error = "FCP not running"} end
+        local lines = {}
+        for line in ("${escapeLua(markerText)}"):gmatch("[^\\n]+") do
+          table.insert(lines, line)
+        end
+        local created = 0
+        local errors = {}
+        for i, line in ipairs(lines) do
+          -- Parse "HH:MM:SS:FF description" or "HH:MM:SS;FF description" format
+          local tc, desc = line:match("^(%d%d[:%%;]%d%d[:%%;]%d%d[:%%;]%d%d)%s+(.+)$")
+          if tc and desc then
+            -- Navigate to timecode
+            fcp.viewer:timecode(tc)
+            hs.timer.usleep(200000)
+            -- Add marker
+            ${markerType === "todo" ? `
+            fcp:doShortcut("AddTodoMarker"):Now()
+            ` : `
+            fcp:doShortcut("AddMarker"):Now()
+            `}
+            hs.timer.usleep(200000)
+            created = created + 1
+          else
+            table.insert(errors, {line = i, text = line, error = "Could not parse timecode"})
+          end
+        end
+        return {created = created, totalLines = #lines, errors = #errors > 0 and errors or nil}
+      `), 120000);
+      return formatResult(extractResult(resp));
+    }
+
+    default:
+      return JSON.stringify({ success: false, error: `Unknown tool: ${name}` });
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Input Validation & Security
+// ═══════════════════════════════════════════════════════════════════════════
+
+const MAX_STRING_LENGTH = 10000;
+const MAX_CODE_LENGTH = 500000;
+
+/** Validate a file path to prevent directory traversal attacks */
+function validateFilePath(path: string): string | null {
+  if (!path || typeof path !== "string") return "Path is required";
+  if (path.length > MAX_STRING_LENGTH) return "Path exceeds maximum length";
+  // Reject relative path traversal
+  if (path.includes("..")) return "Path traversal (..) is not allowed";
+  // Reject null bytes
+  if (path.includes("\0")) return "Path contains null bytes";
+  return null;
+}
+
+/** Validate string input length */
+function validateStringInput(
+  value: unknown,
+  fieldName: string,
+  maxLength = MAX_STRING_LENGTH
+): string | null {
+  if (typeof value !== "string") return null;
+  if (value.length > maxLength)
+    return `${fieldName} exceeds maximum length of ${maxLength} characters`;
+  return null;
+}
+
+function validateStringList(
+  values: unknown,
+  fieldName: string
+): string | null {
+  if (!Array.isArray(values) || values.length === 0) {
+    return `${fieldName} must be a non-empty array`;
+  }
+
+  for (const [index, value] of values.entries()) {
+    if (typeof value !== "string" || value.length === 0) {
+      return `${fieldName}[${index}] must be a non-empty string`;
+    }
+    const err = validateStringInput(value, `${fieldName}[${index}]`);
+    if (err) return err;
+  }
+
+  return null;
+}
+
+/** Validate Lua code input */
+function validateCode(code: unknown): string | null {
+  if (typeof code !== "string") return "Code must be a string";
+  if (code.length === 0) return "Code cannot be empty";
+  if (code.length > MAX_CODE_LENGTH)
+    return `Code exceeds maximum length of ${MAX_CODE_LENGTH} characters`;
+  return null;
+}
+
+/** Validate numeric range */
+function validateRange(
+  value: number,
+  min: number,
+  max: number,
+  fieldName: string
+): string | null {
+  if (typeof value !== "number" || isNaN(value))
+    return `${fieldName} must be a number`;
+  if (value < min || value > max)
+    return `${fieldName} must be between ${min} and ${max}`;
+  return null;
+}
+
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function validateClipPlan(clipPlan: unknown): string | null {
+  if (!Array.isArray(clipPlan) || clipPlan.length === 0) {
+    return "clipPlan is required and must have at least one entry";
+  }
+
+  for (const [index, clip] of clipPlan.entries()) {
+    if (!clip || typeof clip !== "object" || Array.isArray(clip)) {
+      return `clipPlan[${index}] must be an object`;
+    }
+
+    const clipObj = clip as Record<string, unknown>;
+    const unsupportedKeys = Object.keys(clipObj).filter(
+      (key) => key !== "mediaPath"
+    );
+    if (unsupportedKeys.length > 0) {
+      return `clipPlan[${index}] includes unsupported fields: ${unsupportedKeys.join(", ")}. fcp_assemble_rough_cut currently supports only mediaPath for each clip.`;
+    }
+
+    if (typeof clipObj.mediaPath !== "string" || clipObj.mediaPath.length === 0) {
+      return `clipPlan[${index}].mediaPath is required`;
+    }
+
+    const pathErr = validateFilePath(clipObj.mediaPath);
+    if (pathErr) {
+      return `Invalid mediaPath "${clipObj.mediaPath}": ${pathErr}`;
+    }
+  }
+
+  return null;
+}
+
+function validateToolArgs(
+  name: string,
+  args: Record<string, unknown>
+): string | null {
+  switch (name) {
+    case "commandpost_get_handler_info": {
+      if (typeof args.handler !== "string" || args.handler.length === 0) {
+        return "handler is required";
+      }
+      const handlerErr = validateStringInput(args.handler, "handler");
+      if (handlerErr) return handlerErr;
+
+      if (args.includeChoices !== undefined && typeof args.includeChoices !== "boolean") {
+        return "includeChoices must be a boolean";
+      }
+
+      if (args.includeParams !== undefined && typeof args.includeParams !== "boolean") {
+        return "includeParams must be a boolean";
+      }
+
+      if (args.limit !== undefined) {
+        const limitErr = validateRange(args.limit as number, 0, 1000, "limit");
+        if (limitErr) return limitErr;
+      }
+
+      if (args.offset !== undefined) {
+        const offsetErr = validateRange(args.offset as number, 0, 100000, "offset");
+        if (offsetErr) return offsetErr;
+      }
+
+      return null;
+    }
+
+    case "commandpost_execute_lua":
+      return validateCode(args.code);
+
+    case "commandpost_chain":
+      if (!Array.isArray(args.operations) || args.operations.length === 0) {
+        return "operations must be a non-empty array";
+      }
+      return null;
+
+    case "commandpost_get_preference":
+    case "commandpost_set_preference":
+      if (typeof args.key !== "string" || args.key.length === 0) {
+        return "key is required";
+      }
+      return validateStringInput(args.key, "key");
+
+    case "fcp_import_media":
+    case "fcp_import_xml": {
+      const path = args.path;
+      if (typeof path !== "string" || path.length === 0) {
+        return "path is required";
+      }
+      return validateFilePath(path);
+    }
+
+    case "fcp_open_project":
+      if (typeof args.name !== "string" || args.name.length === 0) {
+        return "name is required";
+      }
+      return validateStringInput(args.name, "name");
+
+    case "fcp_select_menu":
+      return validateStringList(args.path, "path");
+
+    case "fcp_timeline_navigate": {
+      const action = args.action;
+      if (typeof action !== "string" || !TIMELINE_NAVIGATION_ACTIONS.has(action)) {
+        return `Unknown navigation action: ${String(action)}`;
+      }
+      if (
+        action === "timecode" &&
+        (typeof args.timecode !== "string" || args.timecode.length === 0)
+      ) {
+        return "timecode is required when action is \"timecode\"";
+      }
+      return null;
+    }
+
+    case "fcp_color_board": {
+      const VALID_ASPECTS = new Set(["color", "saturation", "exposure"]);
+      const VALID_PUCKS = new Set(["master", "shadows", "midtones", "highlights"]);
+      if (typeof args.aspect !== "string" || !VALID_ASPECTS.has(args.aspect)) {
+        return `Invalid aspect: ${String(args.aspect)}. Must be one of: color, saturation, exposure`;
+      }
+      if (typeof args.puck !== "string" || !VALID_PUCKS.has(args.puck)) {
+        return `Invalid puck: ${String(args.puck)}. Must be one of: master, shadows, midtones, highlights`;
+      }
+      if (typeof args.value !== "number" || Number.isNaN(args.value)) {
+        return "value must be a number";
+      }
+      return null;
+    }
+
+    case "fcp_multicam_switch_angle": {
+      const rangeErr = validateRange(args.angle as number, 1, 16, "angle");
+      if (rangeErr) return rangeErr;
+      const typeValue = args.type;
+      if (
+        typeValue !== undefined &&
+        typeValue !== "video" &&
+        typeValue !== "audio" &&
+        typeValue !== "both"
+      ) {
+        return `Unknown multicam switch type: ${String(typeValue)}`;
+      }
+      return null;
+    }
+
+    case "fcp_pasteboard": {
+      const action = args.action;
+      if (typeof action !== "string" || !PASTEBOARD_ACTIONS.has(action)) {
+        return `Unknown pasteboard action: ${String(action)}`;
+      }
+      if (args.slot !== undefined) {
+        return validateRange(args.slot as number, 1, 50, "slot");
+      }
+      return null;
+    }
+
+    case "fcp_undo_redo":
+      if (args.count !== undefined) {
+        const countErr = validateRange(args.count as number, 1, 100, "count");
+        if (countErr) return countErr;
+      }
+      return null;
+
+    case "fcp_batch_apply_transition":
+      if (Object.keys(args).length > 0) {
+        return "fcp_batch_apply_transition does not support custom transition or duration parameters. It applies Final Cut Pro's current default transition across the active timeline.";
+      }
+      return null;
+
+    case "fcp_assemble_rough_cut": {
+      const unsupportedKeys = Object.keys(args).filter(
+        (key) => key !== "projectName" && key !== "clipPlan"
+      );
+      if (unsupportedKeys.length > 0) {
+        return `Unsupported fields for fcp_assemble_rough_cut: ${unsupportedKeys.join(", ")}. Supported fields are projectName and clipPlan.`;
+      }
+
+      if (hasOwn(args, "projectName")) {
+        if (typeof args.projectName !== "string" || args.projectName.length === 0) {
+          return "projectName must be a non-empty string";
+        }
+        const err = validateStringInput(args.projectName, "projectName");
+        if (err) return err;
+      }
+
+      return validateClipPlan(args.clipPlan);
+    }
+
+    case "fcp_color_wheels": {
+      const VALID_CONTROLS = new Set(["temperature", "tint", "hue", "mix", "saturation", "brightness", "contrast"]);
+      if (typeof args.control !== "string" || !VALID_CONTROLS.has(args.control)) {
+        return `Invalid control. Must be one of: ${[...VALID_CONTROLS].join(", ")}`;
+      }
+      if (args.value !== undefined && typeof args.value !== "number") return "value must be a number";
+      return null;
+    }
+
+    case "fcp_video_inspector": {
+      if (args.action !== "get" && args.action !== "set") return "action must be 'get' or 'set'";
+      const VALID_SECTIONS = new Set(["transform", "crop", "compositing", "stabilization", "spatial"]);
+      if (typeof args.section !== "string" || !VALID_SECTIONS.has(args.section)) {
+        return `Invalid section. Must be one of: ${[...VALID_SECTIONS].join(", ")}`;
+      }
+      if (args.action === "set" && !args.property) return "property is required for action=set";
+      return null;
+    }
+
+    case "fcp_audio_inspector":
+      if (args.action !== "get" && args.action !== "set") return "action must be 'get' or 'set'";
+      if (args.action === "set" && !args.property) return "property is required for action=set";
+      if (args.action === "set" && typeof args.value !== "number") return "value must be a number for action=set";
+      return null;
+
+    case "fcp_toolbar_state":
+      if (args.action !== "get" && args.action !== "set") return "action must be 'get' or 'set'";
+      return null;
+
+    case "fcp_timeline_appearance":
+      if (args.action !== "get" && args.action !== "set") return "action must be 'get' or 'set'";
+      if (args.clipHeight !== undefined) {
+        const err = validateRange(args.clipHeight as number, 0, 100, "clipHeight");
+        if (err) return err;
+      }
+      return null;
+
+    case "fcp_viewer_config":
+      if (args.action !== "get" && args.action !== "set") return "action must be 'get' or 'set'";
+      return null;
+
+    case "fcp_export_csv": {
+      const VALID_SOURCES = new Set(["browser", "timeline"]);
+      if (typeof args.source !== "string" || !VALID_SOURCES.has(args.source)) {
+        return "source must be 'browser' or 'timeline'";
+      }
+      if (args.path !== undefined) {
+        const pathErr = validateFilePath(args.path as string);
+        if (pathErr) return pathErr;
+      }
+      return null;
+    }
+
+    case "fcp_transcode": {
+      const VALID_MODES = new Set(["optimize", "proxy", "both"]);
+      if (typeof args.mode !== "string" || !VALID_MODES.has(args.mode)) {
+        return "mode must be 'optimize', 'proxy', or 'both'";
+      }
+      return null;
+    }
+
+    case "fcp_find_replace_titles":
+      if (typeof args.find !== "string" || args.find.length === 0) return "find is required";
+      if (typeof args.replace !== "string") return "replace is required";
+      return validateStringInput(args.find, "find") || validateStringInput(args.replace, "replace");
+
+    case "fcp_keyword_presets": {
+      const VALID_ACTIONS = new Set(["save", "restore", "list"]);
+      if (typeof args.action !== "string" || !VALID_ACTIONS.has(args.action)) {
+        return "action must be 'save', 'restore', or 'list'";
+      }
+      if ((args.action === "save" || args.action === "restore") && args.preset !== undefined) {
+        const presetErr = validateRange(args.preset as number, 1, 9, "preset");
+        if (presetErr) return presetErr;
+      }
+      return null;
+    }
+
+    case "fcp_text_to_markers":
+      if (typeof args.text !== "string" || args.text.length === 0) return "text is required";
+      return validateStringInput(args.text, "text");
+
+    default:
+      return null;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Utility Functions
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Escape a string for safe inclusion in Lua string literals */
+function escapeLua(str: string): string {
+  return str
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\0/g, "\\0");
+}
+
+/** Convert a JavaScript value to a Lua literal */
+function toLuaLiteral(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (typeof value === "boolean") return value.toString();
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) return "0/0";
+    if (value === Infinity) return "math.huge";
+    if (value === -Infinity) return "-math.huge";
+    return value.toString();
+  }
+  if (typeof value === "string") return `"${escapeLua(value)}"`;
+  if (Array.isArray(value)) {
+    const items = value.map((v) => toLuaLiteral(v)).join(", ");
+    return `{${items}}`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => `["${escapeLua(k)}"] = ${toLuaLiteral(v)}`)
+      .join(", ");
+    return `{${entries}}`;
+  }
+  return `"${escapeLua(String(value))}"`;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MCP Server Setup
+// ═══════════════════════════════════════════════════════════════════════════
+
+const server = new Server(
+  {
+    name: "commandpost",
+    version: "2.0.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+      resources: {},
+      prompts: {},
+    },
+  }
+);
+
+// ── Resources ─────────────────────────────────────────────────────────────
+
+const RESOURCES = [
+  {
+    uri: "commandpost://instructions",
+    name: "CommandPost FCPX Editing Instructions",
+    description:
+      "Best practices and guidelines for editing in Final Cut Pro via CommandPost MCP. Attach this before performing complex edits.",
+    mimeType: "text/plain",
+  },
+  {
+    uri: "commandpost://fcp-status",
+    name: "Final Cut Pro Current Status",
+    description:
+      "Live status of Final Cut Pro — whether it's running, which libraries are open, and current playhead position.",
+    mimeType: "application/json",
+  },
+  {
+    uri: "commandpost://tool-reference",
+    name: "Available Tools Quick Reference",
+    description:
+      "Quick reference of all available MCP tools organized by category.",
+    mimeType: "text/plain",
+  },
+  {
+    uri: "commandpost://timeline/clips",
+    name: "Timeline Clips",
+    description:
+      "Live list of clips currently in the active timeline — names, positions, durations.",
+    mimeType: "application/json",
+  },
+];
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return { resources: RESOURCES };
+});
+
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const { uri } = request.params;
+
+  switch (uri) {
+    case "commandpost://instructions":
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "text/plain",
+            text: [
+              "# CommandPost FCPX Editing Best Practices",
+              "",
+              "## Before Editing",
+              "1. Always check FCP status first (fcp_status) to confirm it's running",
+              "2. Verify the correct project is open (fcp_browser_list_libraries)",
+              "3. Check current playhead position (fcp_get_playhead_position) for context",
+              "",
+              "## Editing Workflow",
+              "- Use fcp_get_selected_clips to understand what's currently selected before applying effects",
+              "- Use fcp_list_effects / fcp_list_transitions to discover available plugins before applying them",
+              "- Navigate to specific timecodes with fcp_set_playhead_position before blading or adding markers",
+              "- For batch operations, select all first (fcp_timeline_select action=all) then apply",
+              "",
+              "## Safety",
+              "- Use fcp_undo_redo to revert mistakes — always safer than trying to manually reverse changes",
+              "- Check clip properties before and after modifications to verify changes applied correctly",
+              "- For destructive operations (delete, blade), confirm the selection/position first",
+              "- Validate file paths before import operations",
+              "",
+              "## Performance Tips",
+              "- Use the commandpost_chain tool for multi-step workflows to reduce round-trips",
+              "- Use fcp_assemble_rough_cut for batch-importing multiple media paths instead of repeated individual import calls",
+              "- Batch transition application (fcp_batch_apply_transition) applies Final Cut Pro's current default transition across the active timeline",
+              "- Avoid querying the full effects list repeatedly — cache the results within your workflow",
+              "",
+              "## FCP-Specific Notes",
+              "- Final Cut Pro uses a magnetic timeline — clips snap to each other",
+              "- Connected clips (B-roll) attach to the primary storyline and move with it",
+              "- Compound clips group multiple clips into a single container",
+              "- Auditions let you group alternative clips and switch between them",
+              "- Roles (Dialogue, Music, Effects, Video) help organize clips for output",
+              "- Proxy media can speed up editing on slower hardware — toggle with fcp_proxy_toggle",
+            ].join("\n"),
+          },
+        ],
+      };
+
+    case "commandpost://fcp-status": {
+      try {
+        await client.ensureConnected();
+        const resp = await client.executeLua(FCP_STATUS_LUA, 60000);
+        const envelope = extractResult(resp) as Record<string, unknown>;
+        const payload =
+          envelope &&
+          typeof envelope === "object" &&
+          envelope.result &&
+          typeof envelope.result === "object"
+            ? {
+                ...(envelope.result as Record<string, unknown>),
+                ...(envelope.success !== undefined ? { success: envelope.success } : {}),
+              }
+            : envelope;
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: formatResult(payload),
+            },
+          ],
+        };
+      } catch {
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: JSON.stringify({
+                error:
+                  "Cannot read Final Cut Pro status. Ensure CommandPost is running with WebSocket enabled and that Final Cut Pro is available.",
+              }),
+            },
+          ],
+        };
+      }
+    }
+
+    case "commandpost://tool-reference":
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "text/plain",
+            text: [
+              "# CommandPost MCP Tool Reference",
+              "",
+              "## System: commandpost_ping, commandpost_list_handlers, commandpost_get_handler_info, commandpost_execute_lua, commandpost_execute_action, commandpost_chain, commandpost_get/set_preference, commandpost_alert",
+              "",
+              "## FCP App: fcp_launch, fcp_quit, fcp_restart, fcp_status, fcp_select_menu, fcp_do_shortcut",
+              "",
+              "## Timeline: fcp_timeline_show, fcp_timeline_playback, fcp_timeline_navigate, fcp_timeline_select, fcp_timeline_blade, fcp_timeline_delete, fcp_timeline_clipboard, fcp_timeline_zoom, fcp_timeline_get_info",
+              "",
+              "## Discovery: fcp_list_effects, fcp_list_audio_effects, fcp_list_transitions, fcp_list_generators, fcp_list_titles, fcp_get_selected_clips, fcp_get_playhead_position, fcp_set_playhead_position, fcp_get_project_settings",
+              "",
+              "## Clip Properties: fcp_get_clip_properties, fcp_set_clip_properties",
+              "",
+              "## Effects: fcp_apply_effect, fcp_apply_transition, fcp_apply_generator, fcp_apply_title",
+              "",
+              "## Clip Ops: fcp_rename_clip, fcp_rate_clip, fcp_duplicate_clip, fcp_enable_disable_clip, fcp_split_at_timecode, fcp_speed_custom, fcp_retime",
+              "",
+              "## Range: fcp_set_range, fcp_clear_range",
+              "",
+              "## Compound/Auditions: fcp_create_compound_clip, fcp_break_apart_compound, fcp_create_audition",
+              "",
+              "## Organization: fcp_assign_role, fcp_add_keyword, fcp_add_marker, fcp_list_markers",
+              "",
+              "## Color/Stabilization: fcp_color_board, fcp_color_wheels, fcp_stabilization",
+              "",
+              "## Inspector: fcp_video_inspector, fcp_audio_inspector, fcp_inspector_show",
+              "",
+              "## Export/Import: fcp_export, fcp_export_csv, fcp_import_media, fcp_import_xml, fcp_export_xml",
+              "",
+              "## Batch/Workflow: fcp_batch_apply_transition, fcp_assemble_rough_cut, fcp_text_to_markers",
+              "",
+              "## Media: fcp_proxy_toggle, fcp_transcode, fcp_match_frame",
+              "",
+              "## Toolbar/Appearance: fcp_toolbar_state, fcp_timeline_appearance, fcp_viewer_config",
+              "",
+              "## Titles/Keywords: fcp_find_replace_titles, fcp_keyword_presets",
+              "",
+              "## Window/Browser: fcp_window_layout, fcp_browser_show, fcp_browser_list_libraries, fcp_browser_select_library, fcp_viewer_show",
+            ].join("\n"),
+          },
+        ],
+      };
+
+    case "commandpost://timeline/clips": {
+      try {
+        await client.ensureConnected();
+        const resp = await client.executeLua(safeLua(`
+          local timeline = fcp.timeline
+          if not timeline:isShowing() then
+            return {error = "Timeline is not showing", clips = {}, count = 0}
+          end
+
+          local contentsUI = timeline.contents:UI()
+          if not contentsUI then
+            return {clips = {}, count = 0, note = "Could not access timeline contents"}
+          end
+
+          local clips = {}
+          local children = contentsUI:attributeValue("AXChildren")
+          if children then
+            for _, child in ipairs(children) do
+              local desc = safeGet(function() return child:attributeValue("AXDescription") end) or ""
+              if desc ~= "Playhead" and desc ~= "" then
+                table.insert(clips, {
+                  description = desc,
+                  role = safeGet(function() return child:attributeValue("AXRole") end) or "unknown",
+                  value = safeGet(function() return child:attributeValue("AXValue") end),
+                  position = safeGet(function() return child:attributeValue("AXPosition") end),
+                  size = safeGet(function() return child:attributeValue("AXSize") end),
+                  selected = safeGet(function() return child:attributeValue("AXSelected") end),
+                })
+              end
+            end
+          end
+          return {clips = clips, count = #clips}
+        `), 60000);
+        const envelope = extractResult(resp) as Record<string, unknown>;
+        const payload =
+          envelope &&
+          typeof envelope === "object" &&
+          envelope.result &&
+          typeof envelope.result === "object"
+            ? {
+                ...(envelope.result as Record<string, unknown>),
+                ...(envelope.success !== undefined ? { success: envelope.success } : {}),
+              }
+            : envelope;
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: formatResult(payload),
+            },
+          ],
+        };
+      } catch {
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: JSON.stringify({
+                success: false,
+                error: "Cannot connect to CommandPost.",
+                clips: [],
+                count: 0,
+              }),
+            },
+          ],
+        };
+      }
+    }
+
+    default:
+      throw new Error(`Unknown resource: ${uri}`);
+  }
+});
+
+// ── Prompts ───────────────────────────────────────────────────────────────
+
+const PROMPTS = [
+  {
+    name: "edit_video",
+    description:
+      "Guided workflow for editing a video project in Final Cut Pro — from organizing media to rough cut to export.",
+    arguments: [
+      {
+        name: "project_type",
+        description:
+          'Type of project (e.g., "short film", "social media", "documentary", "commercial")',
+        required: false,
+      },
+    ],
+  },
+  {
+    name: "color_grade",
+    description:
+      "Step-by-step color grading workflow using Final Cut Pro's Color Board and color tools.",
+    arguments: [
+      {
+        name: "look",
+        description:
+          'Desired look (e.g., "cinematic warm", "cool desaturated", "high contrast")',
+        required: false,
+      },
+    ],
+  },
+  {
+    name: "organize_media",
+    description:
+      "Workflow for organizing media with keywords, ratings, roles, and smart collections in FCP.",
+    arguments: [],
+  },
+  {
+    name: "audio_edit",
+    description:
+      "Audio editing and mixing workflow — levels, effects, roles, and export considerations.",
+    arguments: [],
+  },
+  {
+    name: "multicam_edit",
+    description:
+      "Multicam editing workflow — syncing angles, switching, and audio selection.",
+    arguments: [
+      {
+        name: "angle_count",
+        description: "Number of camera angles",
+        required: false,
+      },
+    ],
+  },
+  {
+    name: "rough_cut_assembly",
+    description:
+      "Assemble a rough cut from raw footage — import, arrange, trim, and add basic transitions.",
+    arguments: [
+      {
+        name: "media_folder",
+        description: "Path to folder containing media files to import",
+        required: false,
+      },
+    ],
+  },
+];
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => {
+  return { prompts: PROMPTS };
+});
+
+server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  const { name, arguments: promptArgs } = request.params;
+
+  switch (name) {
+    case "edit_video": {
+      const projectType = promptArgs?.project_type || "general";
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `I want to edit a ${projectType} video project in Final Cut Pro using CommandPost. Please guide me through the full workflow:\n\n1. First check that FCP is running (fcp_status)\n2. List available libraries (fcp_browser_list_libraries)\n3. Help me organize my media — suggest keywords and ratings\n4. Create a rough cut assembly\n5. Apply transitions between clips\n6. Do basic color correction\n7. Add titles if needed\n8. Review and export\n\nStart by checking the current state of Final Cut Pro.`,
+            },
+          },
+        ],
+      };
+    }
+
+    case "color_grade": {
+      const look = promptArgs?.look || "balanced";
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `I want to color grade my Final Cut Pro project with a "${look}" look. Please guide me through:\n\n1. Check FCP status and current project\n2. Get the current clip properties to see the starting point\n3. Walk me through Color Board adjustments (exposure, saturation, color)\n4. Apply corrections clip-by-clip or suggest batch approaches\n5. Preview and adjust\n\nUse the fcp_color_board tool to make adjustments. Start by checking what's in the timeline.`,
+            },
+          },
+        ],
+      };
+    }
+
+    case "organize_media":
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: "Help me organize my media in Final Cut Pro. I need to:\n\n1. Check the current libraries and what's imported (fcp_browser_list_libraries, fcp_status)\n2. Review clips in the timeline and browser\n3. Add keywords to categorize clips (fcp_add_keyword)\n4. Rate clips as favorites or rejects (fcp_rate_clip)\n5. Assign roles for audio and video tracks (fcp_assign_role)\n6. Create compound clips for grouped elements (fcp_create_compound_clip)\n\nStart by showing me what's currently in the project.",
+            },
+          },
+        ],
+      };
+
+    case "audio_edit":
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: "I need to edit and mix the audio in my Final Cut Pro project. Please help me:\n\n1. Check the current project state\n2. List available audio effects (fcp_list_audio_effects)\n3. Review the timeline clips and their audio\n4. Apply audio effects as needed\n5. Adjust audio levels and balance\n6. Assign audio roles (Dialogue, Music, Effects)\n7. Help with any audio-specific export settings\n\nStart by checking what's in the timeline.",
+            },
+          },
+        ],
+      };
+
+    case "multicam_edit": {
+      const angleCount = promptArgs?.angle_count || "multiple";
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `I want to do a multicam edit with ${angleCount} camera angles in Final Cut Pro. Guide me through:\n\n1. Check FCP is running and the multicam clip is in the timeline\n2. Show me how to switch between angles (fcp_multicam_switch_angle)\n3. Help me cut between video angles while keeping one audio source\n4. Review the edit and make adjustments\n5. Break apart the multicam if needed for fine-tuning\n\nStart by checking the project state.`,
+            },
+          },
+        ],
+      };
+    }
+
+    case "rough_cut_assembly": {
+      const mediaFolder = promptArgs?.media_folder;
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `I want to assemble a rough cut in Final Cut Pro.${mediaFolder ? ` My media is in: ${mediaFolder}` : ""}\n\nPlease help me:\n1. Check FCP is running (fcp_status)\n2. ${mediaFolder ? "Import media from the folder (fcp_import_media)" : "Identify what media to work with in the current library"}\n3. Arrange clips in the timeline in a logical order\n4. Add basic transitions between clips\n5. Do a quick review of the assembly\n\n${mediaFolder ? "You can use fcp_assemble_rough_cut with a clipPlan for batch import, or import clips individually." : "Start by checking what's available in the current project."}`,
+            },
+          },
+        ],
+      };
+    }
+
+    default:
+      throw new Error(`Unknown prompt: ${name}`);
+  }
+});
+
+// ── Tool Handlers ─────────────────────────────────────────────────────────
+
+// List available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: TOOLS };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  const startTime = Date.now();
+  try {
+    const result = await handleTool(name, (args as Record<string, unknown>) || {});
+    log("debug", `Tool ${name} completed in ${Date.now() - startTime}ms`);
+    return {
+      content: [{ type: "text" as const, text: result }],
+    };
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : String(err);
+    log("error", `Tool ${name} failed after ${Date.now() - startTime}ms: ${errorMessage}`);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ success: false, error: errorMessage }),
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Entry Point
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function shutdown(): Promise<void> {
+  log("info", "Shutting down...");
+  try {
+    await client.disconnect();
+  } catch {
+    // Ignore disconnect errors during shutdown
+  }
+  try {
+    await server.close();
+  } catch {
+    // Ignore close errors during shutdown
+  }
+  process.exit(0);
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+async function main(): Promise<void> {
+  log("info", `CommandPost MCP Server v2.0.0 starting (${TOOLS.length} tools, ${RESOURCES.length} resources, ${PROMPTS.length} prompts)`);
+
+  // Try to pre-connect to CommandPost (non-blocking)
+  client.connect().then(() => {
+    log("info", "Connected to CommandPost WebSocket");
+  }).catch(() => {
+    log("warn", "Could not pre-connect to CommandPost — will retry on first tool call");
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log("info", "MCP server ready on stdio transport");
+}
+
+main().catch((err) => {
+  log("error", "Fatal error", err);
+  process.exit(1);
+});

--- a/src/mcp-server/src/index.ts
+++ b/src/mcp-server/src/index.ts
@@ -21,6 +21,7 @@ import {
   GetPromptRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { CommandPostClient } from "./commandpost.js";
+import { execSync } from "child_process";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Logging (stderr to avoid polluting MCP JSON-RPC on stdout)
@@ -1643,6 +1644,38 @@ const TOOLS = [
         },
       },
       required: ["clipPlan"],
+    },
+  },
+  // ── Scene Detection & Auto-Blade ─────────────────────────────────
+  {
+    name: "fcp_scene_detect_and_cut",
+    description:
+      "Detect scene changes in a video file using ffmpeg and blade the current timeline at all detected cut points in one batch operation. Requires ffmpeg installed. The video file should match the clip on the timeline.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        videoPath: {
+          type: "string",
+          description:
+            "Absolute path to the video file to analyze (e.g., /Users/you/Movies/clip.mp4)",
+        },
+        threshold: {
+          type: "number",
+          description:
+            "Scene detection sensitivity (1-100). Lower = more sensitive, detects more cuts. Default: 8. Use 3-5 for fast-cut content, 8-12 for normal edits, 15+ for only hard cuts.",
+        },
+        minGap: {
+          type: "number",
+          description:
+            "Minimum gap in seconds between detected cuts to filter out flash frames. Default: 0.5",
+        },
+        dryRun: {
+          type: "boolean",
+          description:
+            "If true, only detect and return cut points without actually blading. Default: false",
+        },
+      },
+      required: ["videoPath"],
     },
   },
 ];
@@ -5435,6 +5468,181 @@ ${clipStatements}
       return formatResult(extractResult(resp));
     }
 
+    // ── Scene Detection & Auto-Blade ───────────────────────────────
+    case "fcp_scene_detect_and_cut": {
+      const videoPath = args.videoPath as string;
+      const threshold = (args.threshold as number) ?? 8;
+      const minGap = (args.minGap as number) ?? 0.5;
+      const dryRun = (args.dryRun as boolean) ?? false;
+
+      // Validate file exists
+      try {
+        const fs = await import("fs");
+        if (!fs.existsSync(videoPath)) {
+          return formatResult({ success: false, error: `File not found: ${videoPath}` });
+        }
+      } catch {
+        return formatResult({ success: false, error: `Cannot access file: ${videoPath}` });
+      }
+
+      // Get video frame rate via ffprobe
+      let fps = 30;
+      try {
+        const probeOut = execSync(
+          `ffprobe -v quiet -print_format json -show_streams ${JSON.stringify(videoPath)}`,
+          { timeout: 30000, encoding: "utf-8" }
+        );
+        const probeData = JSON.parse(probeOut);
+        const videoStream = probeData.streams?.find((s: Record<string, unknown>) => s.codec_type === "video");
+        if (videoStream?.r_frame_rate) {
+          const [num, den] = (videoStream.r_frame_rate as string).split("/").map(Number);
+          fps = den ? num / den : num;
+        }
+      } catch (e) {
+        log("warn", "Could not determine frame rate, defaulting to 30fps", e);
+      }
+
+      // Run ffmpeg scene detection
+      log("info", `Running scene detection on ${videoPath} (threshold=${threshold}, fps=${fps})`);
+      let rawOutput: string;
+      try {
+        rawOutput = execSync(
+          `ffmpeg -i ${JSON.stringify(videoPath)} -vf "scdet=threshold=${threshold}" -f null - 2>&1`,
+          { timeout: 600000, encoding: "utf-8", maxBuffer: 50 * 1024 * 1024 }
+        );
+      } catch (e) {
+        const err = e as { stderr?: string; message?: string };
+        return formatResult({
+          success: false,
+          error: `ffmpeg scene detection failed: ${err.message ?? "unknown error"}`,
+        });
+      }
+
+      // Parse scene change timestamps
+      const sceneRegex = /lavfi\.scd\.time:\s*([\d.]+)/g;
+      const rawTimes: number[] = [];
+      let match: RegExpExecArray | null;
+      while ((match = sceneRegex.exec(rawOutput)) !== null) {
+        rawTimes.push(parseFloat(match[1]));
+      }
+
+      // Deduplicate: keep only first detection within minGap window
+      const cutTimes: number[] = [];
+      for (const t of rawTimes) {
+        if (cutTimes.length === 0 || (t - cutTimes[cutTimes.length - 1]) > minGap) {
+          cutTimes.push(t);
+        }
+      }
+
+      // Convert to FCP timecodes (HH:MM:SS:FF)
+      const timecodes = cutTimes.map((t) => {
+        const h = Math.floor(t / 3600);
+        const m = Math.floor((t % 3600) / 60);
+        const s = Math.floor(t % 60);
+        let f = Math.round((t % 1) * fps);
+        if (f >= fps) f = Math.ceil(fps) - 1;
+        return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}:${String(f).padStart(2, "0")}`;
+      });
+
+      if (timecodes.length === 0) {
+        return formatResult({
+          success: true,
+          cutsDetected: 0,
+          message: "No scene changes detected. Try lowering the threshold.",
+        });
+      }
+
+      if (dryRun) {
+        return formatResult({
+          success: true,
+          dryRun: true,
+          cutsDetected: timecodes.length,
+          fps,
+          threshold,
+          minGap,
+          cuts: timecodes.map((tc, i) => ({
+            index: i + 1,
+            timecode: tc,
+            seconds: Math.round(cutTimes[i] * 1000) / 1000,
+          })),
+        });
+      }
+
+      // Build Lua timecode array
+      const luaTimecodes = timecodes.map((tc) => `"${tc}"`).join(", ");
+
+      // Execute all blades in a single Lua call
+      await activateFinalCutPro();
+      const resp = await client.executeLua(`
+        local fcp = require("cp.apple.finalcutpro")
+        local timecodes = {${luaTimecodes}}
+        local results = {}
+        local succeeded = 0
+        local failed = 0
+
+        -- Ensure timeline is showing and focused
+        local contents = fcp.timeline.contents
+        if not contents:isShowing() then
+          return {error = "Timeline is not showing"}
+        end
+
+        -- Focus the timeline contents (required for blade to work)
+        pcall(function() contents:doFocus(true):Now() end)
+        hs.timer.usleep(300000)
+
+        -- Get initial clip count
+        local initialCount = 0
+        pcall(function()
+          local clips = contents:clipsUI(true) or {}
+          initialCount = #clips
+        end)
+
+        for i, tc in ipairs(timecodes) do
+          -- Navigate to timecode via the viewer
+          fcp.viewer:timecode(tc)
+          hs.timer.usleep(50000)
+
+          -- Blade via Trim > Blade All menu (works without clip selection, FCP v12)
+          local ok, err = pcall(function()
+            local result = fcp:selectMenu({"Trim", "Blade All"}, {plain = true})
+            if not result then
+              result = fcp:selectMenu({"Trim", "Blade"}, {plain = true})
+            end
+            if not result then
+              error("Blade menu item not available")
+            end
+          end)
+
+          if ok then
+            succeeded = succeeded + 1
+            table.insert(results, {index = i, timecode = tc, status = "ok"})
+          else
+            failed = failed + 1
+            table.insert(results, {index = i, timecode = tc, status = "failed", error = tostring(err)})
+          end
+        end
+
+        -- Get final clip count
+        hs.timer.usleep(200000)
+        local finalCount = 0
+        pcall(function()
+          local clips = contents:clipsUI(true) or {}
+          finalCount = #clips
+        end)
+
+        return {
+          cutsAttempted = #timecodes,
+          cutsSucceeded = succeeded,
+          cutsFailed = failed,
+          clipsBefore = initialCount,
+          clipsAfter = finalCount,
+          newClips = finalCount - initialCount,
+          cuts = results,
+        }
+      `, 120000);
+      return formatResult(extractResult(resp));
+    }
+
     default:
       return JSON.stringify({ success: false, error: `Unknown tool: ${name}` });
   }
@@ -5782,6 +5990,23 @@ function validateToolArgs(
     case "fcp_text_to_markers":
       if (typeof args.text !== "string" || args.text.length === 0) return "text is required";
       return validateStringInput(args.text, "text");
+
+    case "fcp_scene_detect_and_cut": {
+      if (typeof args.videoPath !== "string" || args.videoPath.length === 0) {
+        return "videoPath is required";
+      }
+      const pathErr = validateFilePath(args.videoPath);
+      if (pathErr) return pathErr;
+      if (args.threshold !== undefined) {
+        const tErr = validateRange(args.threshold as number, 1, 100, "threshold");
+        if (tErr) return tErr;
+      }
+      if (args.minGap !== undefined) {
+        const gErr = validateRange(args.minGap as number, 0.1, 10, "minGap");
+        if (gErr) return gErr;
+      }
+      return null;
+    }
 
     default:
       return null;

--- a/src/mcp-server/test-edit-workflow-mini.mjs
+++ b/src/mcp-server/test-edit-workflow-mini.mjs
@@ -1,0 +1,195 @@
+/**
+ * Quick MCP timeline demo.
+ *
+ * Usage:
+ *   node test-edit-workflow-mini.mjs
+ *
+ * This is a non-destructive-first demo:
+ * - shows timeline
+ * - performs a few navigation and marker operations
+ * - logs each step
+ * - undoes the marker operations at the end
+ */
+
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(__dirname, "dist", "index.js");
+
+class MCPTestClient {
+  constructor() {
+    this.proc = null;
+    this.buffer = "";
+    this.idCounter = 0;
+    this.pendingRequests = new Map();
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      this.proc = spawn("node", [SERVER_PATH], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: process.env,
+      });
+
+      this.proc.stdout.on("data", (data) => {
+        this.buffer += data.toString();
+        this.#processBuffer();
+      });
+
+      this.proc.stderr.on("data", () => {});
+      this.proc.on("error", reject);
+
+      this.#send("initialize", {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "edit-workflow-mini", version: "1.0.0" },
+      }, 10000)
+        .then((resp) => {
+          this.proc.stdin.write(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              method: "notifications/initialized",
+              params: {},
+            }) + "\n",
+          );
+          resolve(resp);
+        })
+        .catch(reject);
+    });
+  }
+
+  stop() {
+    if (this.proc) {
+      this.proc.kill();
+      this.proc = null;
+    }
+    for (const [, { reject, timeout }] of this.pendingRequests) {
+      clearTimeout(timeout);
+      reject(new Error("Client stopped"));
+    }
+    this.pendingRequests.clear();
+  }
+
+  callTool(name, args = {}, timeoutMs = 30000) {
+    return this.#send("tools/call", { name, arguments: args }, timeoutMs);
+  }
+
+  #send(method, params, timeoutMs = 30000) {
+    const id = ++this.idCounter;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request ${method} (id=${id}) timed out after ${timeoutMs / 1000}s`));
+      }, timeoutMs);
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.proc.stdin.write(msg + "\n");
+    });
+  }
+
+  #processBuffer() {
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && this.pendingRequests.has(msg.id)) {
+          const { resolve, timeout } = this.pendingRequests.get(msg.id);
+          clearTimeout(timeout);
+          this.pendingRequests.delete(msg.id);
+          resolve(msg);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+function parsePayload(response) {
+  const text = response?.result?.content?.[0]?.text;
+  if (!text) return response;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { success: false, error: `Non-JSON tool response: ${text}` };
+  }
+}
+
+function expectSuccessful(payload, context) {
+  if (payload?.success === false) {
+    throw new Error(`${context} failed: ${payload.error || "unknown error"}`);
+  }
+}
+
+async function callTool(client, name, args = {}, timeoutMs = 30000) {
+  const response = await client.callTool(name, args, timeoutMs);
+  const payload = parsePayload(response);
+  expectSuccessful(payload, name);
+  if (payload?.error) {
+    throw new Error(`${name} failed: ${payload.error}`);
+  }
+  return payload;
+}
+
+async function main() {
+  const client = new MCPTestClient();
+  const undoableSteps = [];
+
+  try {
+    await client.start();
+    console.log("[step] MCP server connected");
+
+    await callTool(client, "fcp_timeline_show");
+    await callTool(client, "fcp_timeline_zoom", { action: "fit" });
+    const before = await callTool(client, "fcp_list_markers");
+    const beforeCount = before?.count ?? before?.markers?.length ?? 0;
+    console.log(`[before] markers: ${beforeCount}`);
+
+    await callTool(client, "fcp_set_playhead_position", { timecode: "00:00:00:00" });
+    const markerOne = await callTool(client, "fcp_add_marker", { name: "MCP Mini Marker 1" });
+    undoableSteps.push("marker");
+    console.log("[edit] added:", markerOne.marker, markerOne.name);
+
+    await callTool(client, "fcp_timeline_navigate", { action: "next_edit" }).catch(() => {
+      // next_edit is optional depending on timeline content; continue with warning.
+      console.log("[warn] next_edit unavailable, continuing");
+    });
+
+    const markerTwo = await callTool(client, "fcp_add_marker", { name: "MCP Mini Marker 2" });
+    undoableSteps.push("marker");
+    console.log("[edit] added:", markerTwo.marker, markerTwo.name);
+
+    const after = await callTool(client, "fcp_list_markers");
+    const afterCount = after?.count ?? after?.markers?.length ?? 0;
+    console.log(`[after] markers: ${afterCount}`);
+
+    console.log("[done] demo sequence completed");
+  } catch (error) {
+    console.error("[error]", error.stack || String(error));
+    process.exitCode = 1;
+  } finally {
+    if (client.proc) {
+      if (undoableSteps.length > 0) {
+        try {
+          await callTool(client, "fcp_undo_redo", {
+            action: "undo",
+            count: undoableSteps.length,
+          }, 45000);
+          console.log(`[cleanup] undid ${undoableSteps.length} marker action(s)`);
+        } catch (undoErr) {
+          console.error("[warn] cleanup undo failed:", undoErr.message || undoErr);
+        }
+      }
+    }
+    client.stop();
+  }
+}
+
+main().catch((err) => {
+  console.error(err.stack || String(err));
+  process.exit(1);
+});

--- a/src/mcp-server/test-edit-workflow-storm.mjs
+++ b/src/mcp-server/test-edit-workflow-storm.mjs
@@ -1,0 +1,419 @@
+/**
+ * High-volume timeline edit stress demo.
+ *
+ * Usage:
+ *   node test-edit-workflow-storm.mjs
+ *
+ * This runs a larger sequence of MCP timeline actions (markers + effects +
+ * generators + transitions) to prove the connection can execute repeated edits.
+ */
+
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(__dirname, "dist", "index.js");
+
+const EDIT_CYCLES = 24;
+const TRANSITION_INTERVAL = 4;
+const EFFECT_INTERVAL = 2;
+const GENERATOR_INTERVAL = 3;
+
+class MCPTestClient {
+  constructor() {
+    this.proc = null;
+    this.buffer = "";
+    this.idCounter = 0;
+    this.pendingRequests = new Map();
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      this.proc = spawn("node", [SERVER_PATH], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: process.env,
+      });
+
+      this.proc.stdout.on("data", (data) => {
+        this.buffer += data.toString();
+        this.#processBuffer();
+      });
+      this.proc.stderr.on("data", () => {});
+      this.proc.on("error", reject);
+
+      this.#send("initialize", {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "edit-workflow-storm", version: "1.0.0" },
+      }, 12000)
+        .then((resp) => {
+          this.proc.stdin.write(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              method: "notifications/initialized",
+              params: {},
+            }) + "\n",
+          );
+          resolve(resp);
+        })
+        .catch(reject);
+    });
+  }
+
+  stop() {
+    if (this.proc) {
+      this.proc.kill();
+      this.proc = null;
+    }
+
+    for (const [, { reject, timeout }] of this.pendingRequests) {
+      clearTimeout(timeout);
+      reject(new Error("Client stopped"));
+    }
+    this.pendingRequests.clear();
+  }
+
+  callTool(name, args = {}, timeoutMs = 45000) {
+    return this.#send("tools/call", { name, arguments: args }, timeoutMs);
+  }
+
+  #send(method, params, timeoutMs = 45000) {
+    const id = ++this.idCounter;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request ${method} (id=${id}) timed out after ${timeoutMs / 1000}s`));
+      }, timeoutMs);
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.proc.stdin.write(msg + "\n");
+    });
+  }
+
+  #processBuffer() {
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && this.pendingRequests.has(msg.id)) {
+          const { resolve, timeout } = this.pendingRequests.get(msg.id);
+          clearTimeout(timeout);
+          this.pendingRequests.delete(msg.id);
+          resolve(msg);
+        }
+      } catch {
+      }
+    }
+  }
+}
+
+function parsePayload(response) {
+  const text = response?.result?.content?.[0]?.text;
+  if (!text) return response;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { success: false, error: `Non-JSON tool response: ${text}` };
+  }
+}
+
+function ensureSuccess(payload, label) {
+  if (payload?.success === false) {
+    throw new Error(`${label} failed: ${payload.error || "unknown error"}`);
+  }
+}
+
+async function safeCall(client, name, args, timeoutMs = 45000) {
+  try {
+    const resp = await client.callTool(name, args, timeoutMs);
+    const payload = parsePayload(resp);
+    if (payload?.error) {
+      throw new Error(payload.error);
+    }
+    ensureSuccess(payload, name);
+    return payload;
+  } catch (error) {
+    return { __error: error.message || String(error), _failed: true };
+  }
+}
+
+async function runLua(client, code, timeoutMs = 45000) {
+  const payload = await callTool(client, "commandpost_execute_lua", { code }, timeoutMs);
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+  return payload;
+}
+
+async function callTool(client, name, args = {}, timeoutMs = 45000) {
+  const resp = await client.callTool(name, args, timeoutMs);
+  const payload = parsePayload(resp);
+  ensureSuccess(payload, name);
+  if (payload?.error) {
+    throw new Error(`${name} failed: ${payload.error}`);
+  }
+  return payload;
+}
+
+async function resolveHandlerChoice(client, handler, preferredCategory, preferredName, fallbackNameContains) {
+  const payload = await callTool(
+    client,
+    "commandpost_get_handler_info",
+    { handler, includeChoices: true, includeParams: true, limit: 500 },
+    30000,
+  );
+  const handlerInfo = payload?.handler || payload;
+  const choices = handlerInfo?.choices || [];
+
+  const exact = choices.find((choice) =>
+    choice?.params?.category === preferredCategory
+    && choice?.params?.name === preferredName
+  );
+  if (exact?.params?.category && exact?.params?.name) {
+    return `${exact.params.category}/${exact.params.name}`;
+  }
+
+  if (fallbackNameContains) {
+    const byName = choices.find((choice) =>
+      String(choice?.params?.name || "").toLowerCase().includes(fallbackNameContains.toLowerCase())
+    );
+    if (byName?.params?.category && byName?.params?.name) {
+      return `${byName.params.category}/${byName.params.name}`;
+    }
+  }
+
+  const first = choices.find((choice) => choice?.params?.category && choice?.params?.name);
+  if (!first) {
+    return null;
+  }
+  return `${first.params.category}/${first.params.name}`;
+}
+
+async function selectFirstClip(client) {
+  const payload = await runLua(client, `
+    local fcp = require("cp.apple.finalcutpro")
+    local contents = fcp.timeline.contents
+    local ui = contents:UI()
+    if not ui then
+      return { selected = false, reason = "No timeline UI" }
+    end
+
+    local children = ui:attributeValue("AXChildren") or {}
+    local avClip
+    for _, child in ipairs(children) do
+      local desc = child:attributeValue("AXDescription") or ""
+      if string.sub(desc, 1, 8) == "AV-Clip:" then
+        avClip = child
+        break
+      end
+    end
+    if not avClip then
+      return { selected = false, reason = "No AV clips visible" }
+    end
+
+    contents:selectClips({avClip})
+    hs.timer.usleep(120000)
+
+    local selected = ui:attributeValue("AXSelectedChildren") or {}
+    return {
+      selected = #selected >= 1,
+      count = #selected,
+      description = avClip:attributeValue("AXDescription"),
+    }
+  `);
+  return payload;
+}
+
+async function selectTwoClipsForTransition(client) {
+  const payload = await runLua(client, `
+    local fcp = require("cp.apple.finalcutpro")
+    local contents = fcp.timeline.contents
+    local ui = contents:UI()
+    if not ui then
+      return { selected = false, reason = "No timeline UI" }
+    end
+
+    local candidates = {}
+    local children = ui:attributeValue("AXChildren") or {}
+
+    for _, child in ipairs(children) do
+      local desc = child:attributeValue("AXDescription") or ""
+      local frame = child:attributeValue("AXFrame")
+      if string.sub(desc, 1, 8) == "AV-Clip:" and frame then
+        table.insert(candidates, {
+          ui = child,
+          x = frame.x or 0,
+          y = frame.y or 0,
+        })
+      end
+    end
+
+    table.sort(candidates, function(a, b)
+      if math.abs(a.y - b.y) <= 4 then
+        return a.x < b.x
+      end
+      return a.y < b.y
+    end)
+
+    if #candidates < 2 then
+      return {
+        selected = false,
+        count = #candidates,
+        reason = "Need two AV clips to apply transition",
+      }
+    end
+
+    local first = candidates[1].ui
+    local second = candidates[2].ui
+    contents:selectClips({first, second})
+    hs.timer.usleep(150000)
+
+    local selected = ui:attributeValue("AXSelectedChildren") or {}
+    return {
+      selected = #selected >= 2,
+      count = #selected,
+      first = first:attributeValue("AXDescription"),
+      second = second:attributeValue("AXDescription"),
+    }
+  `);
+  return payload;
+}
+
+async function main() {
+  const client = new MCPTestClient();
+  const counters = {
+    marker: 0,
+    effect: 0,
+    generator: 0,
+    transition: 0,
+  };
+
+  try {
+    await client.start();
+    console.log("[step] connected to MCP");
+
+    await safeCall(client, "fcp_timeline_show");
+    await safeCall(client, "fcp_timeline_zoom", { action: "fit" });
+    await callTool(client, "fcp_timeline_navigate", { action: "beginning" }, 30000);
+
+    const before = await safeCall(client, "fcp_list_markers") || {};
+    const beforeCount = Number(before.count || before.markers?.length || 0);
+    console.log(`[before] markers ${beforeCount}`);
+
+    const effectChoice = await resolveHandlerChoice(client, "fcpx_videoEffect", "Basics", "Noise Reduction", "Noise");
+    const transitionChoice = await resolveHandlerChoice(
+      client,
+      "fcpx_transition",
+      "Dissolves",
+      "Cross Dissolve",
+      "Cross",
+    );
+    const generatorChoice = await resolveHandlerChoice(client, "fcpx_generator", "Solids", "Custom", "Custom");
+
+    if (!effectChoice || !transitionChoice || !generatorChoice) {
+      throw new Error("Could not resolve required handler choices (effect/transition/generator)");
+    }
+
+    console.log(`[resolve] effect=${effectChoice}`);
+    console.log(`[resolve] transition=${transitionChoice}`);
+    console.log(`[resolve] generator=${generatorChoice}`);
+
+    for (let i = 1; i <= EDIT_CYCLES; i += 1) {
+      console.log(`[cycle ${i}]`);
+
+      const nav = i === 1
+        ? { action: "beginning" }
+        : (i % 2 === 0 ? { action: "next_frame" } : { action: "next_edit" });
+      const navResult = await safeCall(client, "fcp_timeline_navigate", nav, 25000);
+      if (navResult?.error) {
+        await safeCall(client, "fcp_timeline_navigate", { action: "next_frame" }, 25000);
+      }
+
+      const markerResult = await safeCall(
+        client,
+        "fcp_add_marker",
+        { name: `MCP Storm Marker ${i}` },
+        25000,
+      );
+      if (!markerResult._failed && !markerResult.__error) {
+        counters.marker += 1;
+      }
+
+      if (i % EFFECT_INTERVAL === 0) {
+        const clipSel = await selectFirstClip(client);
+        if (clipSel && clipSel.selected) {
+          const effectResult = await safeCall(
+            client,
+            "fcp_apply_effect",
+            { name: effectChoice, type: "video" },
+            45000,
+          );
+          if (!effectResult._failed && !effectResult.__error) {
+            counters.effect += 1;
+            console.log(`  [effect] applied`);
+          }
+        }
+      }
+
+      if (i % GENERATOR_INTERVAL === 0) {
+        const genResult = await safeCall(
+          client,
+          "fcp_apply_generator",
+          { name: generatorChoice },
+          45000,
+        );
+        if (!genResult._failed && !genResult.__error) {
+          counters.generator += 1;
+          console.log(`  [generator] inserted`);
+        }
+      }
+
+      if (i % TRANSITION_INTERVAL === 0) {
+        const transitionSel = await selectTwoClipsForTransition(client);
+        if (transitionSel && transitionSel.selected) {
+          const transResult = await safeCall(
+            client,
+            "fcp_apply_transition",
+            { name: transitionChoice },
+            45000,
+          );
+          if (transResult && transResult.applied && !transResult._failed && !transResult.__error) {
+            counters.transition += 1;
+          }
+        }
+      }
+    }
+
+    const after = await safeCall(client, "fcp_list_markers") || {};
+    const afterCount = Number(after.count || after.markers?.length || 0);
+    console.log(`[after] markers ${afterCount}`);
+    console.log(`[result] marker=${counters.marker}, effect=${counters.effect}, generator=${counters.generator}, transition=${counters.transition}`);
+    console.log("[result] stress cycle complete");
+  } catch (error) {
+    console.error("[error]", error.stack || String(error));
+    process.exitCode = 1;
+  } finally {
+    const undoTotal = counters.marker + counters.effect + counters.generator + counters.transition;
+    if (client.proc && undoTotal > 0) {
+      try {
+        const undoResult = await callTool(client, "fcp_undo_redo", {
+          action: "undo",
+          count: undoTotal,
+        }, 60000);
+        console.log(`[cleanup] requested undo ${undoTotal}`);
+        console.log(`[cleanup]`, undoResult);
+      } catch (undoErr) {
+        console.error("[warn] cleanup undo failed:", undoErr.message || undoErr);
+      }
+    }
+    client.stop();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || String(error));
+  process.exit(1);
+});

--- a/src/mcp-server/test-edit-workflow.mjs
+++ b/src/mcp-server/test-edit-workflow.mjs
@@ -1,0 +1,955 @@
+/**
+ * Dedicated live edit-workflow smoke test for Final Cut Pro via CommandPost MCP.
+ *
+ * This script is intentionally separate from test.mjs because it performs
+ * destructive timeline edits against a user-provided project.
+ *
+ * Usage:
+ *   node test-edit-workflow.mjs
+ *   node test-edit-workflow.mjs --project "MCP Edit Tests"
+ *
+ * Notes:
+ *   - This workflow expects the target timeline/project to already be open in
+ *     Final Cut Pro. Project switching is exercised separately because FCP can
+ *     become non-deterministic while reopening the same project repeatedly.
+ */
+
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(__dirname, "dist", "index.js");
+const argv = process.argv.slice(2);
+const PROJECT_NAME = getFlagValue("--project") || "MCP Edit Tests";
+
+function getFlagValue(flag) {
+  const index = argv.indexOf(flag);
+  if (index === -1 || index === argv.length - 1) return null;
+  return argv[index + 1];
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function log(step, message) {
+  console.log(`[${step}] ${message}`);
+}
+
+function parseTimecodeToFrames(timecode, fps = 30) {
+  if (typeof timecode !== "string") return null;
+  const match = timecode.match(/^(\d{2}):(\d{2}):(\d{2}):(\d{2})$/);
+  if (!match) return null;
+  const [, hh, mm, ss, ff] = match;
+  return (((Number(hh) * 60 + Number(mm)) * 60 + Number(ss)) * fps) + Number(ff);
+}
+
+function framesToTimecode(frames, fps = 30) {
+  const totalFrames = Math.max(0, Math.floor(frames));
+  const ff = totalFrames % fps;
+  const totalSeconds = Math.floor(totalFrames / fps);
+  const ss = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const mm = totalMinutes % 60;
+  const hh = Math.floor(totalMinutes / 60);
+  return [hh, mm, ss, ff].map((value) => String(value).padStart(2, "0")).join(":");
+}
+
+class MCPTestClient {
+  constructor() {
+    this.proc = null;
+    this.buffer = "";
+    this.idCounter = 0;
+    this.pendingRequests = new Map();
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      this.proc = spawn("node", [SERVER_PATH], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: process.env,
+      });
+
+      this.proc.stdout.on("data", (data) => {
+        this.buffer += data.toString();
+        this.#processBuffer();
+      });
+
+      this.proc.stderr.on("data", () => {});
+      this.proc.on("error", reject);
+
+      this.#send("initialize", {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "edit-workflow-test", version: "1.0.0" },
+      }, 10000).then((resp) => {
+        this.proc.stdin.write(JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {},
+        }) + "\n");
+        resolve(resp);
+      }).catch(reject);
+    });
+  }
+
+  stop() {
+    if (this.proc) {
+      this.proc.kill();
+      this.proc = null;
+    }
+
+    for (const [, { reject, timeout }] of this.pendingRequests) {
+      clearTimeout(timeout);
+      reject(new Error("Client stopped"));
+    }
+    this.pendingRequests.clear();
+  }
+
+  async callTool(name, args = {}, timeoutMs = 30000) {
+    return this.#send("tools/call", { name, arguments: args }, timeoutMs);
+  }
+
+  #send(method, params, timeoutMs = 30000) {
+    const id = ++this.idCounter;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request ${method} (id=${id}) timed out after ${timeoutMs / 1000}s`));
+      }, timeoutMs);
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.proc.stdin.write(msg + "\n");
+    });
+  }
+
+  #processBuffer() {
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && this.pendingRequests.has(msg.id)) {
+          const { resolve, timeout } = this.pendingRequests.get(msg.id);
+          clearTimeout(timeout);
+          this.pendingRequests.delete(msg.id);
+          resolve(msg);
+        }
+      } catch {
+        // Ignore non-JSON lines.
+      }
+    }
+  }
+}
+
+function parseToolResponse(resp) {
+  const text = resp?.result?.content?.[0]?.text;
+  if (!text) return resp;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { success: false, error: `Non-JSON tool response: ${text}` };
+  }
+}
+
+function extractPayload(parsed) {
+  return parsed?.result ?? parsed;
+}
+
+async function main() {
+  const client = new MCPTestClient();
+  const summary = [];
+
+  async function call(name, args = {}, timeoutMs = 30000) {
+    const resp = await client.callTool(name, args, timeoutMs);
+    const parsed = parseToolResponse(resp);
+    summary.push({ name, args, parsed });
+    return parsed;
+  }
+
+  async function expectTool(name, args = {}, options = {}) {
+    const { timeoutMs = 30000, verify } = options;
+    const parsed = await call(name, args, timeoutMs);
+    const payload = extractPayload(parsed);
+
+    if (parsed?.success === false) {
+      throw new Error(`${name} failed: ${parsed.error || "unknown error"}`);
+    }
+    if (payload?.error) {
+      throw new Error(`${name} failed: ${payload.error}`);
+    }
+
+    if (verify) {
+      await verify(payload, parsed);
+    }
+
+    await assertNoAlert(name);
+
+    return payload;
+  }
+
+  async function resolveHandlerChoice(handler, preferredCategory, preferredName) {
+    const parsed = await call("commandpost_get_handler_info", {
+      handler,
+      includeChoices: true,
+      includeParams: true,
+      limit: 500,
+    }, 30000);
+    if (parsed?.success === false) {
+      throw new Error(`commandpost_get_handler_info failed for ${handler}: ${parsed.error}`);
+    }
+    const info = parsed?.handler || extractPayload(parsed)?.handler || extractPayload(parsed);
+    const choices = info?.choices || [];
+    const match = choices.find((choice) =>
+      choice?.params?.category === preferredCategory
+      && choice?.params?.name === preferredName
+    );
+    if (!match) {
+      throw new Error(
+        `No ${handler} choice matched ${preferredCategory}/${preferredName}`
+      );
+    }
+    return `${preferredCategory}/${preferredName}`;
+  }
+
+  async function getTimelineInfo(timeoutMs = 60000) {
+    const parsed = await call("fcp_timeline_get_info", {}, timeoutMs);
+    if (parsed?.success === false) {
+      throw new Error(`fcp_timeline_get_info failed: ${parsed.error}`);
+    }
+    const payload = extractPayload(parsed);
+    if (payload?.error) {
+      throw new Error(`fcp_timeline_get_info failed: ${payload.error}`);
+    }
+    return payload;
+  }
+
+  async function getUndoState(timeoutMs = 30000) {
+    const result = await runLua(`
+      local fcp = require("cp.apple.finalcutpro")
+      local state = {
+        showing = false,
+        loaded = false,
+      }
+
+      pcall(function()
+        state.showing = fcp.timeline:isShowing()
+        state.loaded = fcp.timeline:isLoaded()
+      end)
+
+      pcall(function()
+        local app = fcp:application()
+        local menus = app and app:getMenuItems()
+        if menus then
+          for _, menu in ipairs(menus) do
+            if menu.AXTitle == "Edit" then
+              local group = menu.AXChildren and menu.AXChildren[1]
+              local undoItem = group and group[1]
+              state.undoText = undoItem and undoItem.AXTitle or nil
+              break
+            end
+          end
+        end
+      end)
+
+      return state
+    `, timeoutMs);
+
+    const payload = extractPayload(result);
+    if (payload?.error) {
+      throw new Error(payload.error);
+    }
+    return payload;
+  }
+
+  async function getCurrentProjectState(timeoutMs = 30000) {
+    const result = await runLua(`
+      local fcp = require("cp.apple.finalcutpro")
+      local state = {
+        showing = false,
+        loaded = false,
+      }
+
+      pcall(function()
+        state.showing = fcp.timeline:isShowing()
+        state.loaded = fcp.timeline:isLoaded()
+      end)
+
+      pcall(function()
+        state.projectTitle = fcp.timeline.toolbar.title:title()
+      end)
+
+      if not state.projectTitle then
+        pcall(function()
+          state.projectTitle = fcp.timeline.toolbar.title:value()
+        end)
+      end
+
+      return state
+    `, timeoutMs);
+
+    const payload = extractPayload(result);
+    if (payload?.error) {
+      throw new Error(payload.error);
+    }
+    return payload;
+  }
+
+  async function waitForTimelineVisible(timeoutMs = 30000) {
+    const deadline = Date.now() + timeoutMs;
+    let lastInfo = null;
+    let attempts = 0;
+
+    while (Date.now() < deadline) {
+      attempts += 1;
+      if (attempts > 1) {
+        await expectTool("fcp_timeline_show");
+      }
+
+      lastInfo = await getTimelineInfo();
+      if (lastInfo?.showing === true) {
+        return lastInfo;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    throw new Error(`Timeline did not become visible: ${JSON.stringify({
+      attempts,
+      lastInfo: lastInfo ? {
+        showing: lastInfo.showing,
+        clipCount: lastInfo.clipCount,
+        undoText: lastInfo.undoText,
+      } : null,
+    })}`);
+  }
+
+  async function runLua(code, timeoutMs = 30000) {
+    const parsed = await call("commandpost_execute_lua", { code }, timeoutMs);
+    if (parsed?.success === false) {
+      throw new Error(`commandpost_execute_lua failed: ${parsed.error}`);
+    }
+    const payload = extractPayload(parsed);
+    if (payload?.error) {
+      throw new Error(`commandpost_execute_lua failed: ${payload.error}`);
+    }
+    return payload;
+  }
+
+  async function assertNoAlert(context) {
+    const result = await runLua(`
+      local ax = require("hs.axuielement")
+      local app = hs.application("Final Cut Pro")
+      local appUI = app and ax.applicationElement(app)
+      if not appUI then
+        return {alert = false}
+      end
+
+      local function dismiss(window)
+        local children = window:attributeValue("AXChildren") or {}
+        for _, child in ipairs(children) do
+          local role = child:attributeValue("AXRole")
+          local title = child:attributeValue("AXTitle")
+          if role == "AXButton" and (title == "OK" or title == "Done") then
+            pcall(function() child:performAction("AXPress") end)
+            hs.timer.usleep(150000)
+            return true
+          end
+        end
+        return false
+      end
+
+      local windows = appUI:attributeValue("AXWindows") or {}
+      for _, window in ipairs(windows) do
+        local role = window:attributeValue("AXRole")
+        local subrole = window:attributeValue("AXSubrole")
+        local children = window:attributeValue("AXChildren") or {}
+        local texts = {}
+        if role == "AXWindow" or role == "AXDialog" or subrole == "AXDialog" then
+          for _, child in ipairs(children) do
+            local childRole = child:attributeValue("AXRole")
+            local value = child:attributeValue("AXValue")
+            if childRole == "AXStaticText" and value and tostring(value) ~= "" then
+              table.insert(texts, tostring(value))
+            end
+          end
+          if #texts > 0 then
+            local dismissed = dismiss(window)
+            return {
+              alert = true,
+              message = table.concat(texts, " "),
+              dismissed = dismissed,
+            }
+          end
+        end
+      end
+
+      return {alert = false}
+    `, 15000);
+
+    const payload = extractPayload(result);
+    if (payload?.alert) {
+      throw new Error(`${context} triggered Final Cut Pro alert: ${payload.message}`);
+    }
+  }
+
+  async function selectAvClips(count) {
+    const result = await runLua(`
+      local fcp = require("cp.apple.finalcutpro")
+      local contents = fcp.timeline.contents
+      local ui = contents:UI()
+      if not ui then
+        return {selected = false, error = "Timeline UI is unavailable"}
+      end
+
+      pcall(function() contents:doFocus(true):Now() end)
+      hs.timer.usleep(150000)
+
+      local children = ui:attributeValue("AXChildren") or {}
+      local selected = {}
+      for _, child in ipairs(children) do
+        local desc = child:attributeValue("AXDescription") or ""
+        if string.sub(desc, 1, 8) == "AV-Clip:" then
+          table.insert(selected, child)
+          if #selected >= ${count} then
+            break
+          end
+        end
+      end
+
+      if #selected < ${count} then
+        return {
+          selected = false,
+          error = "Need at least ${count} AV clips",
+          count = #selected,
+        }
+      end
+
+      contents:selectClips(selected)
+      hs.timer.usleep(200000)
+
+      local selectedChildren = ui:attributeValue("AXSelectedChildren") or {}
+      local descriptions = {}
+      for _, child in ipairs(selectedChildren) do
+        descriptions[#descriptions + 1] = child:attributeValue("AXDescription") or ""
+      end
+
+      return {
+        selected = #selectedChildren >= ${count},
+        count = #selectedChildren,
+        descriptions = descriptions,
+      }
+    `, 30000);
+
+    const payload = extractPayload(result);
+    if (!payload?.selected) {
+      throw new Error(payload?.error || `Could not select ${count} AV clips`);
+    }
+    return payload;
+  }
+
+  async function selectAdjacentAvClips() {
+    const result = await runLua(`
+      local fcp = require("cp.apple.finalcutpro")
+      local contents = fcp.timeline.contents
+      local ui = contents:UI()
+      if not ui then
+        return {selected = false, error = "Timeline UI is unavailable"}
+      end
+
+      pcall(function() contents:doFocus(true):Now() end)
+      hs.timer.usleep(150000)
+
+      local playheadX = contents.playhead and contents.playhead:position()
+      local laneTolerance = 4
+      local boundaryTolerance = 8
+
+      local function clipRecord(child)
+        local desc = child:attributeValue("AXDescription") or ""
+        local frame = child:attributeValue("AXFrame")
+        if string.sub(desc, 1, 8) ~= "AV-Clip:"
+          or not frame
+          or type(frame.x) ~= "number"
+          or type(frame.y) ~= "number"
+          or type(frame.w) ~= "number"
+        then
+          return nil
+        end
+        return {
+          ui = child,
+          description = desc,
+          x = frame.x,
+          y = frame.y,
+          w = frame.w,
+        }
+      end
+
+      local function sortClips(clips)
+        table.sort(clips, function(a, b)
+          if math.abs(a.y - b.y) <= laneTolerance then
+            return a.x < b.x
+          end
+          return a.y < b.y
+        end)
+      end
+
+      local function describeClips(clips, limit)
+        local description = {}
+        for i, clip in ipairs(clips or {}) do
+          if i > (limit or 10) then break end
+          description[#description + 1] = {
+            description = clip.description,
+            x = clip.x,
+            y = clip.y,
+            w = clip.w,
+            endX = clip.x + clip.w,
+          }
+        end
+        return description
+      end
+
+      local function collectVisibleClips()
+        local clips = {}
+        local children = ui:attributeValue("AXChildren") or {}
+        for _, child in ipairs(children) do
+          local record = clipRecord(child)
+          if record then
+            clips[#clips + 1] = record
+          end
+        end
+        sortClips(clips)
+        return clips
+      end
+
+      local function collectPlayheadClips()
+        local clips = {}
+        local playheadClips = contents:playheadClipsUI(true, function(clip)
+          local desc = clip:attributeValue("AXDescription") or ""
+          return string.sub(desc, 1, 8) == "AV-Clip:"
+        end) or {}
+        for _, clip in ipairs(playheadClips) do
+          local record = clipRecord(clip)
+          if record then
+            clips[#clips + 1] = record
+          end
+        end
+        sortClips(clips)
+        return clips
+      end
+
+      local function chooseBoundaryPair(clips)
+        if type(playheadX) ~= "number" then
+          return nil
+        end
+
+        local bestPair = nil
+        local bestScore = nil
+
+        for _, left in ipairs(clips or {}) do
+          local leftEnd = left.x + left.w
+          if leftEnd <= (playheadX + boundaryTolerance) then
+            for _, right in ipairs(clips or {}) do
+              if right.ui ~= left.ui
+                and math.abs(left.y - right.y) <= laneTolerance
+                and right.x >= (playheadX - boundaryTolerance)
+              then
+                local score = math.abs(leftEnd - playheadX) + math.abs(right.x - playheadX)
+                if bestScore == nil or score < bestScore then
+                  bestPair = {left.ui, right.ui}
+                  bestScore = score
+                end
+              end
+            end
+          end
+        end
+
+        return bestPair, bestScore
+      end
+
+      local function chooseNearestSequentialPair(clips)
+        local bestPair = nil
+        local bestScore = nil
+
+        for i = 1, (#clips - 1) do
+          local first = clips[i]
+          local second = clips[i + 1]
+          if math.abs(first.y - second.y) <= laneTolerance then
+            local gap = math.abs((first.x + first.w) - second.x)
+            local score = gap
+            if type(playheadX) == "number" then
+              score = score + math.abs((first.x + first.w) - playheadX) + math.abs(second.x - playheadX)
+            end
+            if bestScore == nil or score < bestScore then
+              bestPair = {first.ui, second.ui}
+              bestScore = score
+            end
+          end
+        end
+
+        if bestScore ~= nil and bestScore <= (boundaryTolerance * 3) then
+          return bestPair, bestScore
+        end
+        return nil, bestScore
+      end
+
+      local playheadClips = collectPlayheadClips()
+      local pair, score = chooseBoundaryPair(playheadClips)
+
+      if not pair and #playheadClips >= 2 then
+        pair, score = chooseNearestSequentialPair(playheadClips)
+      end
+
+      local visibleClips = nil
+      if not pair then
+        visibleClips = collectVisibleClips()
+        pair, score = chooseBoundaryPair(visibleClips)
+      end
+
+      if not pair then
+        visibleClips = visibleClips or collectVisibleClips()
+        pair, score = chooseNearestSequentialPair(visibleClips)
+      end
+
+      if not pair then
+        return {
+          selected = false,
+          error = "Need adjacent AV clips on the same timeline lane",
+          playheadX = playheadX,
+          playheadClips = describeClips(playheadClips, 8),
+          visibleClips = describeClips(visibleClips or collectVisibleClips(), 12),
+        }
+      end
+
+      contents:selectClips(pair)
+      hs.timer.usleep(200000)
+
+      local selectedChildren = ui:attributeValue("AXSelectedChildren") or {}
+      local descriptions = {}
+      for _, child in ipairs(selectedChildren) do
+        descriptions[#descriptions + 1] = child:attributeValue("AXDescription") or ""
+      end
+
+      return {
+        selected = #selectedChildren >= 2,
+        count = #selectedChildren,
+        descriptions = descriptions,
+        playheadX = playheadX,
+        score = score,
+      }
+    `, 30000);
+
+    const payload = extractPayload(result);
+    if (!payload?.selected) {
+      const diagnostics = JSON.stringify({
+        playheadX: payload?.playheadX,
+        playheadClips: payload?.playheadClips,
+        visibleClips: payload?.visibleClips,
+      });
+      throw new Error(`${payload?.error || "Could not select adjacent AV clips"} ${diagnostics}`);
+    }
+    return payload;
+  }
+
+  function countByPrefix(info, prefix) {
+    const clips = Array.isArray(info?.clips) ? info.clips : [];
+    return clips.filter((clip) => String(clip?.description || "").startsWith(prefix)).length;
+  }
+
+  async function findBladeTimecode() {
+    const result = await runLua(`
+      local fcp = require("cp.apple.finalcutpro")
+      local contents = fcp.timeline.contents
+      local ui = contents:UI()
+      if not ui then
+        return {error = "Timeline UI is unavailable"}
+      end
+
+      pcall(function() contents:doFocus(true):Now() end)
+      hs.timer.usleep(150000)
+
+      local playheadX = contents.playhead and contents.playhead:position()
+      local currentTimecode = fcp.viewer:timecode()
+      local children = ui:attributeValue("AXChildren") or {}
+      local candidate = nil
+
+      for _, child in ipairs(children) do
+        local description = child:attributeValue("AXDescription") or ""
+        local duration = child:attributeValue("AXValue")
+        local frame = child:attributeValue("AXFrame")
+        if string.sub(description, 1, 8) == "AV-Clip:"
+          and type(duration) == "string"
+          and frame
+          and type(frame.x) == "number"
+          and type(frame.w) == "number"
+          and frame.w >= 24
+        then
+          candidate = {
+            description = description,
+            duration = duration,
+            x = frame.x,
+            w = frame.w,
+          }
+          contents:selectClip(child)
+          hs.timer.usleep(150000)
+          break
+        end
+      end
+
+      return {
+        playheadX = playheadX,
+        currentTimecode = currentTimecode,
+        candidate = candidate,
+      }
+    `, 30000);
+
+    const payload = extractPayload(result);
+    if (payload?.error) {
+      throw new Error(payload.error);
+    }
+
+    const candidate = payload?.candidate;
+    const durationFrames = parseTimecodeToFrames(candidate?.duration);
+    const currentFrames = parseTimecodeToFrames(payload?.currentTimecode);
+    const playheadX = Number(payload?.playheadX);
+    const clipX = Number(candidate?.x);
+    const clipWidth = Number(candidate?.w);
+
+    if (!candidate || !durationFrames || !Number.isFinite(currentFrames) || !Number.isFinite(playheadX)
+      || !Number.isFinite(clipX) || !Number.isFinite(clipWidth) || clipWidth <= 0) {
+      throw new Error("Could not derive a bladable AV clip target from the visible timeline geometry");
+    }
+
+    const inset = Math.max(6, Math.min(24, Math.floor(clipWidth / 4)));
+    const targetX = clipX + Math.max(inset, Math.min(clipWidth - inset, Math.floor(clipWidth / 2)));
+    const deltaFrames = Math.round((targetX - playheadX) * (durationFrames / clipWidth));
+    return framesToTimecode(currentFrames + deltaFrames);
+  }
+
+  try {
+    await client.start();
+
+    log("setup", `Preparing current timeline for "${PROJECT_NAME}"`);
+    await expectTool("fcp_timeline_show");
+    const baseline = await waitForTimelineVisible(45000);
+    await expectTool("fcp_timeline_zoom", { action: "fit" });
+    assert(baseline.showing === true, "Timeline is not visible");
+    assert(countByPrefix(baseline, "AV-Clip:") >= 1, "Need at least one AV clip in the test project");
+
+    await expectTool("fcp_browser_show", { panel: "generators" });
+    await expectTool("fcp_browser_show", { panel: "libraries" });
+    await expectTool("fcp_inspector_show", { tab: "video" });
+
+    const generatorId = await resolveHandlerChoice("fcpx_generator", "Solids", "Custom");
+    const effectId = await resolveHandlerChoice("fcpx_videoEffect", "Basics", "Noise Reduction");
+    const transitionId = await resolveHandlerChoice("fcpx_transition", "Dissolves", "Cross Dissolve");
+
+    log("menu", "Insert a spacer/gap via the Edit menu");
+    const gapBefore = await getTimelineInfo();
+    await expectTool("fcp_set_playhead_position", { timecode: "00:00:01:00" }, { timeoutMs: 20000 });
+    await expectTool("fcp_select_menu", { path: ["Edit", "Insert Generator", "Gap"] }, {
+      timeoutMs: 20000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    const gapAfter = await getTimelineInfo();
+    const gapCountBefore = countByPrefix(gapBefore, "Gap:");
+    const gapCountAfter = countByPrefix(gapAfter, "Gap:");
+    assert(
+      gapAfter.clipCount > gapBefore.clipCount
+        || gapCountAfter > gapCountBefore
+        || String(gapAfter.undoText || "") !== String(gapBefore.undoText || ""),
+      `Gap insert did not change the timeline: ${JSON.stringify({
+        gapBefore: {
+          clipCount: gapBefore.clipCount,
+          gapCount: gapCountBefore,
+          undoText: gapBefore.undoText,
+        },
+        gapAfter: {
+          clipCount: gapAfter.clipCount,
+          gapCount: gapCountAfter,
+          undoText: gapAfter.undoText,
+        },
+      })}`
+    );
+
+    log("generator", "Apply a generator to the timeline");
+    const genBefore = await getTimelineInfo();
+    await expectTool("fcp_apply_generator", { name: generatorId }, {
+      timeoutMs: 30000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const genAfter = await getTimelineInfo();
+    const generatorCountBefore = countByPrefix(genBefore, "Generator:");
+    const generatorCountAfter = countByPrefix(genAfter, "Generator:");
+    assert(
+      generatorCountAfter > generatorCountBefore
+        || String(genAfter.undoText || "") !== String(genBefore.undoText || ""),
+      `Generator insert did not create a verifiable change: ${JSON.stringify({
+        genBefore: {
+          clipCount: genBefore.clipCount,
+          generatorCount: generatorCountBefore,
+          undoText: genBefore.undoText,
+        },
+        genAfter: {
+          clipCount: genAfter.clipCount,
+          generatorCount: generatorCountAfter,
+          undoText: genAfter.undoText,
+        },
+      })}`
+    );
+
+    log("effect", "Select one AV clip and apply a video effect");
+    const effectBefore = await getUndoState();
+    const singleSelection = await selectAvClips(1);
+    assert(singleSelection.count >= 1, "Expected one selected AV clip");
+    await expectTool("fcp_apply_effect", { name: effectId, type: "video" }, {
+      timeoutMs: 30000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const effectAfter = await getUndoState();
+    assert(
+      String(effectAfter.undoText || "") !== String(effectBefore.undoText || ""),
+      `Video effect apply did not register a new undo step: ${JSON.stringify({
+        effectBefore: effectBefore.undoText,
+        effectAfter: effectAfter.undoText,
+      })}`
+    );
+
+    log("color", "Open the video inspector and apply a small color-board change");
+    await expectTool("fcp_inspector_show", { tab: "video" });
+    const colorBefore = await getUndoState();
+    await expectTool("fcp_color_board", {
+      aspect: "exposure",
+      puck: "master",
+      value: 0.03,
+    }, {
+      timeoutMs: 30000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const colorAfter = await getUndoState();
+    assert(
+      String(colorAfter.undoText || "") !== String(colorBefore.undoText || ""),
+      `Color board apply did not register a new undo step: ${JSON.stringify({
+        colorBefore: colorBefore.undoText,
+        colorAfter: colorAfter.undoText,
+      })}`
+    );
+
+    log("blade", "Create a fresh cut point inside a real AV clip");
+    const bladeBefore = await getTimelineInfo();
+    const bladeTargetTimecode = await findBladeTimecode();
+    await expectTool("fcp_set_playhead_position", {
+      timecode: bladeTargetTimecode,
+    }, { timeoutMs: 20000 });
+    const bladeResult = await expectTool("fcp_timeline_blade", {}, {
+      timeoutMs: 30000,
+    });
+    assert(bladeResult.cut === true, "Blade did not report a successful cut");
+    assert(
+      String(bladeResult.undoText || "").startsWith("Undo Blade"),
+      "Blade did not register as the last Final Cut Pro action"
+    );
+    const bladeAfter = await getTimelineInfo();
+    assert(
+      bladeAfter.clipCount > bladeBefore.clipCount
+        || String(bladeAfter.undoText || "").startsWith("Undo Blade"),
+      "Blade did not leave a verifiable change in Final Cut Pro"
+    );
+
+    log("transition", "Select the new adjacent AV clips and apply a transition");
+    const transitionBefore = await getTimelineInfo();
+    const twoSelection = await selectAdjacentAvClips();
+    assert(twoSelection.count >= 2, "Expected two selected AV clips");
+    const transitionResult = await expectTool("fcp_apply_transition", { name: transitionId }, {
+      timeoutMs: 30000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const transitionAfter = await getTimelineInfo();
+    const transitionCountBefore = countByPrefix(transitionBefore, "Transition:");
+    const transitionCountAfter = countByPrefix(transitionAfter, "Transition:");
+    assert(
+      transitionResult.applied === true
+        || transitionCountAfter > transitionCountBefore
+        || String(transitionAfter.undoText || "") !== String(transitionBefore.undoText || ""),
+      `Transition apply did not produce a verifiable change: ${JSON.stringify({
+        transitionResult,
+        transitionBefore: {
+          undoText: transitionBefore.undoText,
+          clipCount: transitionBefore.clipCount,
+          transitionCount: transitionCountBefore,
+        },
+        transitionAfter: {
+          undoText: transitionAfter.undoText,
+          clipCount: transitionAfter.clipCount,
+          transitionCount: transitionCountAfter,
+        },
+        selection: twoSelection,
+      })}`
+    );
+
+    log("navigation", "Move through browser and timeline views");
+    await expectTool("fcp_browser_show", { panel: "generators" });
+    await expectTool("fcp_browser_show", { panel: "media" });
+    await expectTool("fcp_timeline_navigate", { action: "next_edit" });
+    await expectTool("fcp_timeline_navigate", { action: "previous_edit" });
+
+    const finalInfo = await getTimelineInfo();
+    console.log("\nWorkflow smoke test passed.");
+    console.log(JSON.stringify({
+      project: PROJECT_NAME,
+      destructive: true,
+      baselineClipCount: baseline.clipCount,
+      finalClipCount: finalInfo.clipCount,
+      baselineTransitionCount: countByPrefix(baseline, "Transition:"),
+      finalTransitionCount: countByPrefix(finalInfo, "Transition:"),
+      baselineGeneratorCount: countByPrefix(baseline, "Generator:"),
+      finalGeneratorCount: countByPrefix(finalInfo, "Generator:"),
+    }, null, 2));
+  } catch (error) {
+    console.error("\nWorkflow smoke test failed.");
+    console.error(error.stack || String(error));
+    console.error("\nLast tool calls:");
+    console.error(JSON.stringify(summary.slice(-12).map((entry) => ({
+      name: entry.name,
+      args: entry.args,
+      success: entry.parsed?.success,
+      error: entry.parsed?.error || entry.parsed?.result?.error || null,
+      keys: Object.keys(entry.parsed || {}),
+    })), null, 2));
+    process.exitCode = 1;
+  } finally {
+    if (client.proc) {
+      const destructiveSteps = summary.reduce((count, entry) => {
+        const payload = extractPayload(entry.parsed);
+        if (entry.parsed?.success === false || payload?.error) {
+          return count;
+        }
+        if (entry.name === "fcp_select_menu" && entry.args?.path?.join?.("/") === "Edit/Insert Generator/Gap") {
+          return count + 1;
+        }
+        if (entry.name === "fcp_apply_generator" || entry.name === "fcp_apply_effect"
+          || entry.name === "fcp_color_board" || entry.name === "fcp_timeline_blade"
+          || entry.name === "fcp_apply_transition") {
+          return count + 1;
+        }
+        return count;
+      }, 0);
+
+      if (destructiveSteps > 0) {
+        try {
+          log("cleanup", `Undo ${destructiveSteps} destructive step(s)`);
+          await call("fcp_undo_redo", { action: "undo", count: destructiveSteps }, 45000);
+        } catch (error) {
+          console.error(`Cleanup undo failed: ${error.message || error}`);
+        }
+      }
+    }
+    client.stop();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || String(error));
+  process.exit(1);
+});

--- a/src/mcp-server/test.mjs
+++ b/src/mcp-server/test.mjs
@@ -1,0 +1,1163 @@
+/**
+ * CommandPost MCP Server — Test Suite
+ *
+ * Tests the MCP server protocol, tool definitions, error handling,
+ * and (when CommandPost is running) live functionality.
+ *
+ * Usage:
+ *   node test.mjs           # Run all tests
+ *   node test.mjs --live    # Include live CommandPost tests (requires running CommandPost with WebSocket enabled)
+ */
+
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(__dirname, "dist", "index.js");
+const LIVE_MODE = process.argv.includes("--live");
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+function log(emoji, msg) {
+  console.log(`  ${emoji} ${msg}`);
+}
+
+function assert(condition, msg) {
+  if (!condition) throw new Error(`Assertion failed: ${msg}`);
+}
+
+// ── MCP Client Harness ───────────────────────────────────────────────────
+
+class MCPTestClient {
+  constructor(options = {}) {
+    this.proc = null;
+    this.buffer = "";
+    this.idCounter = 0;
+    this.pendingRequests = new Map();
+    this.env = { ...process.env, ...(options.env || {}) };
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      this.proc = spawn("node", [SERVER_PATH], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: this.env,
+      });
+
+      this.proc.stdout.on("data", (data) => {
+        this.buffer += data.toString();
+        this._processBuffer();
+      });
+
+      this.proc.stderr.on("data", (data) => {
+        // Capture stderr but don't fail — connection warnings are expected
+      });
+
+      this.proc.on("error", reject);
+
+      // Send initialize
+      this._send("initialize", {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test-harness", version: "1.0.0" },
+      }).then((resp) => {
+        // Send initialized notification (no response expected)
+        const notif = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {},
+        });
+        this.proc.stdin.write(notif + "\n");
+        resolve(resp);
+      }).catch(reject);
+    });
+  }
+
+  stop() {
+    if (this.proc) {
+      this.proc.kill();
+      this.proc = null;
+    }
+    // Reject any pending
+    for (const [, { reject }] of this.pendingRequests) {
+      reject(new Error("Client stopped"));
+    }
+    this.pendingRequests.clear();
+  }
+
+  async listTools() {
+    return this._send("tools/list", {});
+  }
+
+  async callTool(name, args = {}, timeoutMs = 30000) {
+    return this._send("tools/call", { name, arguments: args }, timeoutMs);
+  }
+
+  async listResources() {
+    return this._send("resources/list", {});
+  }
+
+  async readResource(uri, timeoutMs = 10000) {
+    return this._send("resources/read", { uri }, timeoutMs);
+  }
+
+  async listPrompts() {
+    return this._send("prompts/list", {});
+  }
+
+  async getPrompt(name, args = {}) {
+    return this._send("prompts/get", { name, arguments: args });
+  }
+
+  _send(method, params, timeoutMs = 30000) {
+    const id = ++this.idCounter;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request ${method} (id=${id}) timed out after ${timeoutMs / 1000}s`));
+      }, timeoutMs);
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.proc.stdin.write(msg + "\n");
+    });
+  }
+
+  _processBuffer() {
+    // MCP uses newline-delimited JSON
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() || ""; // Keep incomplete line in buffer
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && this.pendingRequests.has(msg.id)) {
+          const { resolve, timeout } = this.pendingRequests.get(msg.id);
+          clearTimeout(timeout);
+          this.pendingRequests.delete(msg.id);
+          resolve(msg);
+        }
+      } catch {
+        // Skip non-JSON lines
+      }
+    }
+  }
+}
+
+// ── Test Runner ─────────────────────────────────────────────────────────
+
+async function test(name, fn, { requiresLive = false, skipIfLive = false } = {}) {
+  if (requiresLive && !LIVE_MODE) {
+    skipped++;
+    log("⏭️ ", `SKIP: ${name} (requires --live)`);
+    return;
+  }
+  if (skipIfLive && LIVE_MODE) {
+    skipped++;
+    log("⏭️ ", `SKIP: ${name} (offline-only test)`);
+    return;
+  }
+  try {
+    await fn();
+    passed++;
+    log("✅", `PASS: ${name}`);
+  } catch (err) {
+    failed++;
+    log("❌", `FAIL: ${name}`);
+    log("  ", `     ${err.message}`);
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+async function runTests() {
+  console.log("\n🧪 CommandPost MCP Server Tests\n");
+  console.log(`   Mode: ${LIVE_MODE ? "LIVE (connected to CommandPost)" : "OFFLINE (protocol-only)"}\n`);
+
+  const client = new MCPTestClient();
+
+  // ── Protocol Tests ──────────────────────────────────────────────────
+
+  console.log("── Protocol & Initialization ──");
+
+  let initResp;
+  await test("Server initializes with correct protocol", async () => {
+    initResp = await client.start();
+    assert(initResp.result, "Missing result in init response");
+    assert(
+      initResp.result.protocolVersion === "2024-11-05",
+      `Wrong protocol: ${initResp.result.protocolVersion}`
+    );
+    assert(
+      initResp.result.serverInfo.name === "commandpost",
+      `Wrong server name: ${initResp.result.serverInfo.name}`
+    );
+    assert(
+      initResp.result.serverInfo.version,
+      `Missing version: ${initResp.result.serverInfo.version}`
+    );
+  });
+
+  await test("Server reports tools capability", async () => {
+    assert(initResp.result.capabilities.tools, "Missing tools capability");
+  });
+
+  await test("Server reports resources capability", async () => {
+    assert(initResp.result.capabilities.resources, "Missing resources capability");
+  });
+
+  await test("Server reports prompts capability", async () => {
+    assert(initResp.result.capabilities.prompts, "Missing prompts capability");
+  });
+
+  await test("Server version is 2.0.0", async () => {
+    assert(
+      initResp.result.serverInfo.version === "2.0.0",
+      `Expected 2.0.0, got: ${initResp.result.serverInfo.version}`
+    );
+  });
+
+  // ── Tool Listing Tests ──────────────────────────────────────────────
+
+  console.log("\n── Tool Listing ──");
+
+  let tools;
+  await test("tools/list returns all tools", async () => {
+    const resp = await client.listTools();
+    assert(resp.result, "Missing result");
+    assert(resp.result.tools, "Missing tools array");
+    tools = resp.result.tools;
+    assert(tools.length >= 70, `Expected at least 70 tools, got ${tools.length}`);
+  });
+
+  await test("All tools have required fields", async () => {
+    for (const tool of tools) {
+      assert(tool.name, `Tool missing name: ${JSON.stringify(tool)}`);
+      assert(tool.description, `Tool ${tool.name} missing description`);
+      assert(tool.inputSchema, `Tool ${tool.name} missing inputSchema`);
+      assert(
+        tool.inputSchema.type === "object",
+        `Tool ${tool.name} inputSchema.type is not 'object'`
+      );
+    }
+  });
+
+  await test("Tool names follow naming convention", async () => {
+    const validPrefixes = ["commandpost_", "fcp_"];
+    for (const tool of tools) {
+      const hasPrefix = validPrefixes.some((p) => tool.name.startsWith(p));
+      assert(
+        hasPrefix,
+        `Tool ${tool.name} doesn't start with commandpost_ or fcp_`
+      );
+    }
+  });
+
+  await test("Required parameters are correctly specified", async () => {
+    // Check a few known tools
+    const execLua = tools.find((t) => t.name === "commandpost_execute_lua");
+    assert(execLua, "commandpost_execute_lua not found");
+    assert(
+      execLua.inputSchema.required?.includes("code"),
+      "commandpost_execute_lua should require 'code'"
+    );
+
+    const selectMenu = tools.find((t) => t.name === "fcp_select_menu");
+    assert(selectMenu, "fcp_select_menu not found");
+    assert(
+      selectMenu.inputSchema.required?.includes("path"),
+      "fcp_select_menu should require 'path'"
+    );
+
+    const ping = tools.find((t) => t.name === "commandpost_ping");
+    assert(ping, "commandpost_ping not found");
+    // ping should have no required params
+    assert(
+      !ping.inputSchema.required || ping.inputSchema.required.length === 0,
+      "commandpost_ping should not require any params"
+    );
+  });
+
+  await test("Enum parameters have valid values", async () => {
+    const playback = tools.find((t) => t.name === "fcp_timeline_playback");
+    assert(playback, "fcp_timeline_playback not found");
+    const actionProp = playback.inputSchema.properties?.action;
+    assert(actionProp?.enum, "fcp_timeline_playback action should have enum");
+    assert(
+      actionProp.enum.includes("play") &&
+      actionProp.enum.includes("pause") &&
+      actionProp.enum.includes("toggle"),
+      "fcp_timeline_playback action should have play/pause/toggle"
+    );
+  });
+
+  // ── Tool Category Coverage Tests ────────────────────────────────────
+
+  console.log("\n── Tool Category Coverage ──");
+
+  await test("System tools present", async () => {
+    const sysTools = ["commandpost_ping", "commandpost_list_handlers", "commandpost_get_handler_info"];
+    for (const name of sysTools) {
+      assert(tools.find((t) => t.name === name), `Missing system tool: ${name}`);
+    }
+  });
+
+  await test("Lua execution tools present", async () => {
+    assert(tools.find((t) => t.name === "commandpost_execute_lua"), "Missing commandpost_execute_lua");
+    assert(tools.find((t) => t.name === "commandpost_execute_action"), "Missing commandpost_execute_action");
+    assert(tools.find((t) => t.name === "commandpost_chain"), "Missing commandpost_chain");
+  });
+
+  await test("FCP application tools present", async () => {
+    const fcpTools = ["fcp_launch", "fcp_quit", "fcp_restart", "fcp_status", "fcp_select_menu", "fcp_do_shortcut"];
+    for (const name of fcpTools) {
+      assert(tools.find((t) => t.name === name), `Missing FCP app tool: ${name}`);
+    }
+  });
+
+  await test("FCP timeline tools present", async () => {
+    const timelineTools = [
+      "fcp_timeline_show", "fcp_timeline_playback", "fcp_timeline_navigate",
+      "fcp_timeline_select", "fcp_timeline_blade", "fcp_timeline_delete",
+      "fcp_timeline_clipboard", "fcp_timeline_zoom", "fcp_timeline_get_info",
+    ];
+    for (const name of timelineTools) {
+      assert(tools.find((t) => t.name === name), `Missing timeline tool: ${name}`);
+    }
+  });
+
+  await test("FCP effects tools present", async () => {
+    const effectsTools = ["fcp_apply_effect", "fcp_apply_transition", "fcp_apply_generator", "fcp_apply_title"];
+    for (const name of effectsTools) {
+      assert(tools.find((t) => t.name === name), `Missing effects tool: ${name}`);
+    }
+  });
+
+  await test("FCP media tools present", async () => {
+    const mediaTools = [
+      "fcp_browser_show", "fcp_browser_list_libraries", "fcp_browser_select_library",
+      "fcp_inspector_show", "fcp_viewer_show",
+      "fcp_export", "fcp_import_media", "fcp_import_xml", "fcp_export_xml",
+    ];
+    for (const name of mediaTools) {
+      assert(tools.find((t) => t.name === name), `Missing media tool: ${name}`);
+    }
+  });
+
+  await test("FCP editing tools present", async () => {
+    const editTools = [
+      "fcp_open_project", "fcp_project_properties",
+      "fcp_add_marker", "fcp_add_keyword",
+      "fcp_rename_clip", "fcp_rate_clip",
+      "fcp_undo_redo", "fcp_retime",
+      "fcp_captions", "fcp_multicam_switch_angle",
+      "fcp_pasteboard", "fcp_color_board",
+      "fcp_window_layout",
+    ];
+    for (const name of editTools) {
+      assert(tools.find((t) => t.name === name), `Missing editing tool: ${name}`);
+    }
+  });
+
+  // ── New Tool Category Coverage Tests ────────────────────────────────
+
+  console.log("\n── New Tool Categories ──");
+
+  await test("Discovery/introspection tools present", async () => {
+    const discoveryTools = [
+      "fcp_list_effects", "fcp_list_audio_effects", "fcp_list_transitions",
+      "fcp_list_generators", "fcp_list_titles",
+      "fcp_get_selected_clips", "fcp_get_playhead_position", "fcp_set_playhead_position",
+      "fcp_get_project_settings",
+    ];
+    for (const name of discoveryTools) {
+      assert(tools.find((t) => t.name === name), `Missing discovery tool: ${name}`);
+    }
+  });
+
+  await test("Clip property tools present", async () => {
+    assert(tools.find((t) => t.name === "fcp_get_clip_properties"), "Missing fcp_get_clip_properties");
+    assert(tools.find((t) => t.name === "fcp_set_clip_properties"), "Missing fcp_set_clip_properties");
+  });
+
+  await test("Additional clip operation tools present", async () => {
+    const clipTools = [
+      "fcp_duplicate_clip", "fcp_enable_disable_clip",
+      "fcp_split_at_timecode", "fcp_speed_custom",
+    ];
+    for (const name of clipTools) {
+      assert(tools.find((t) => t.name === name), `Missing clip op tool: ${name}`);
+    }
+  });
+
+  await test("Range/work area tools present", async () => {
+    assert(tools.find((t) => t.name === "fcp_set_range"), "Missing fcp_set_range");
+    assert(tools.find((t) => t.name === "fcp_clear_range"), "Missing fcp_clear_range");
+  });
+
+  await test("Compound clip and audition tools present", async () => {
+    assert(tools.find((t) => t.name === "fcp_create_compound_clip"), "Missing fcp_create_compound_clip");
+    assert(tools.find((t) => t.name === "fcp_break_apart_compound"), "Missing fcp_break_apart_compound");
+    assert(tools.find((t) => t.name === "fcp_create_audition"), "Missing fcp_create_audition");
+  });
+
+  await test("Role, stabilization, proxy tools present", async () => {
+    assert(tools.find((t) => t.name === "fcp_assign_role"), "Missing fcp_assign_role");
+    assert(tools.find((t) => t.name === "fcp_stabilization"), "Missing fcp_stabilization");
+    assert(tools.find((t) => t.name === "fcp_proxy_toggle"), "Missing fcp_proxy_toggle");
+  });
+
+  await test("Batch and workflow tools present", async () => {
+    assert(tools.find((t) => t.name === "fcp_batch_apply_transition"), "Missing fcp_batch_apply_transition");
+    assert(tools.find((t) => t.name === "fcp_assemble_rough_cut"), "Missing fcp_assemble_rough_cut");
+  });
+
+  await test("Marker listing tool present", async () => {
+    assert(tools.find((t) => t.name === "fcp_list_markers"), "Missing fcp_list_markers");
+  });
+
+  // ── New Tool Schema Validation ────────────────────────────────────
+
+  console.log("\n── New Tool Schemas ──");
+
+  await test("fcp_set_clip_properties has numeric params", async () => {
+    const tool = tools.find((t) => t.name === "fcp_set_clip_properties");
+    const props = tool.inputSchema.properties;
+    assert(props.positionX?.type === "number", "positionX should be number");
+    assert(props.scaleAll?.type === "number", "scaleAll should be number");
+    assert(props.rotation?.type === "number", "rotation should be number");
+    assert(props.opacity?.type === "number", "opacity should be number");
+  });
+
+  await test("fcp_split_at_timecode requires timecode", async () => {
+    const tool = tools.find((t) => t.name === "fcp_split_at_timecode");
+    assert(
+      tool.inputSchema.required?.includes("timecode"),
+      "Should require timecode"
+    );
+  });
+
+  await test("fcp_speed_custom requires percentage", async () => {
+    const tool = tools.find((t) => t.name === "fcp_speed_custom");
+    assert(
+      tool.inputSchema.required?.includes("percentage"),
+      "Should require percentage"
+    );
+  });
+
+  await test("fcp_set_range requires start and end", async () => {
+    const tool = tools.find((t) => t.name === "fcp_set_range");
+    assert(tool.inputSchema.required?.includes("start"), "Should require start");
+    assert(tool.inputSchema.required?.includes("end"), "Should require end");
+  });
+
+  await test("fcp_assign_role requires role", async () => {
+    const tool = tools.find((t) => t.name === "fcp_assign_role");
+    assert(tool.inputSchema.required?.includes("role"), "Should require role");
+  });
+
+  await test("fcp_assemble_rough_cut requires clipPlan", async () => {
+    const tool = tools.find((t) => t.name === "fcp_assemble_rough_cut");
+    assert(tool.inputSchema.required?.includes("clipPlan"), "Should require clipPlan");
+    const clipPlan = tool.inputSchema.properties?.clipPlan;
+    assert(clipPlan?.type === "array", "clipPlan should be array");
+    assert(clipPlan?.items?.properties?.mediaPath, "clipPlan items should have mediaPath");
+  });
+
+  await test("fcp_assemble_rough_cut no longer advertises unsupported clip instructions", async () => {
+    const tool = tools.find((t) => t.name === "fcp_assemble_rough_cut");
+    const clipProps = tool.inputSchema.properties?.clipPlan?.items?.properties || {};
+    assert(!clipProps.inPoint, "Should not advertise inPoint");
+    assert(!clipProps.outPoint, "Should not advertise outPoint");
+    assert(!clipProps.transitionAfter, "Should not advertise transitionAfter");
+    assert(!clipProps.effectName, "Should not advertise effectName");
+    assert(!clipProps.keyword, "Should not advertise keyword");
+    assert(!tool.inputSchema.properties?.defaultTransition, "Should not advertise defaultTransition");
+  });
+
+  await test("fcp_batch_apply_transition no longer advertises unsupported params", async () => {
+    const tool = tools.find((t) => t.name === "fcp_batch_apply_transition");
+    const props = tool.inputSchema.properties || {};
+    assert(!props.transition, "Should not advertise transition");
+    assert(!props.duration, "Should not advertise duration");
+  });
+
+  await test("fcp_list_effects has optional category filter", async () => {
+    const tool = tools.find((t) => t.name === "fcp_list_effects");
+    assert(tool.inputSchema.properties?.category, "Should have category property");
+    assert(!tool.inputSchema.required?.includes("category"), "Category should be optional");
+  });
+
+  // ── Resources Tests ───────────────────────────────────────────────
+
+  console.log("\n── Resources ──");
+
+  let resources;
+  await test("resources/list returns resources", async () => {
+    const resp = await client.listResources();
+    assert(resp.result, "Missing result");
+    assert(resp.result.resources, "Missing resources array");
+    resources = resp.result.resources;
+    assert(resources.length >= 4, `Expected at least 4 resources, got ${resources.length}`);
+  });
+
+  await test("All resources have required fields", async () => {
+    for (const r of resources) {
+      assert(r.uri, `Resource missing uri`);
+      assert(r.name, `Resource ${r.uri} missing name`);
+      assert(r.description, `Resource ${r.uri} missing description`);
+      assert(r.mimeType, `Resource ${r.uri} missing mimeType`);
+    }
+  });
+
+  await test("Instructions resource exists", async () => {
+    assert(
+      resources.find((r) => r.uri === "commandpost://instructions"),
+      "Missing instructions resource"
+    );
+  });
+
+  await test("FCP status resource exists", async () => {
+    assert(
+      resources.find((r) => r.uri === "commandpost://fcp-status"),
+      "Missing fcp-status resource"
+    );
+  });
+
+  await test("Tool reference resource exists", async () => {
+    assert(
+      resources.find((r) => r.uri === "commandpost://tool-reference"),
+      "Missing tool-reference resource"
+    );
+  });
+
+  await test("Timeline clips resource exists", async () => {
+    assert(
+      resources.find((r) => r.uri === "commandpost://timeline/clips"),
+      "Missing timeline/clips resource"
+    );
+  });
+
+  await test("Instructions resource returns content", async () => {
+    const resp = await client.readResource("commandpost://instructions");
+    assert(resp.result, "Missing result");
+    const contents = resp.result.contents;
+    assert(contents && contents.length > 0, "Missing contents");
+    assert(contents[0].text.includes("Best Practices"), "Should contain best practices");
+    assert(contents[0].text.includes("magnetic timeline"), "Should mention magnetic timeline");
+  });
+
+  await test("Tool reference resource returns content", async () => {
+    const resp = await client.readResource("commandpost://tool-reference");
+    assert(resp.result, "Missing result");
+    const contents = resp.result.contents;
+    assert(contents && contents.length > 0, "Missing contents");
+    const text = contents[0].text;
+    assert(text.includes("fcp_list_effects"), "Should list discovery tools");
+    assert(text.includes("fcp_list_markers"), "Should list markers tool");
+    assert(text.includes("fcp_assemble_rough_cut"), "Should list workflow tools");
+  });
+
+  await test("Unknown resource returns error", async () => {
+    const resp = await client.readResource("commandpost://nonexistent");
+    assert(resp.error, "Should return error for unknown resource");
+  });
+
+  // ── Prompts Tests ─────────────────────────────────────────────────
+
+  console.log("\n── Prompts ──");
+
+  let prompts;
+  await test("prompts/list returns prompts", async () => {
+    const resp = await client.listPrompts();
+    assert(resp.result, "Missing result");
+    assert(resp.result.prompts, "Missing prompts array");
+    prompts = resp.result.prompts;
+    assert(prompts.length >= 6, `Expected at least 6 prompts, got ${prompts.length}`);
+  });
+
+  await test("All prompts have required fields", async () => {
+    for (const p of prompts) {
+      assert(p.name, `Prompt missing name`);
+      assert(p.description, `Prompt ${p.name} missing description`);
+    }
+  });
+
+  await test("Expected prompts exist", async () => {
+    const expectedPrompts = [
+      "edit_video", "color_grade", "organize_media",
+      "audio_edit", "multicam_edit", "rough_cut_assembly",
+    ];
+    for (const name of expectedPrompts) {
+      assert(prompts.find((p) => p.name === name), `Missing prompt: ${name}`);
+    }
+  });
+
+  await test("edit_video prompt has project_type argument", async () => {
+    const prompt = prompts.find((p) => p.name === "edit_video");
+    assert(prompt.arguments, "Missing arguments");
+    assert(
+      prompt.arguments.find((a) => a.name === "project_type"),
+      "Missing project_type argument"
+    );
+  });
+
+  await test("edit_video prompt returns messages", async () => {
+    const resp = await client.getPrompt("edit_video", { project_type: "documentary" });
+    assert(resp.result, "Missing result");
+    assert(resp.result.messages, "Missing messages");
+    assert(resp.result.messages.length > 0, "Should have at least one message");
+    const msg = resp.result.messages[0];
+    assert(msg.role === "user", "First message should be from user");
+    assert(msg.content.text.includes("documentary"), "Should include project type");
+  });
+
+  await test("color_grade prompt returns messages with look", async () => {
+    const resp = await client.getPrompt("color_grade", { look: "cinematic warm" });
+    assert(resp.result, "Missing result");
+    assert(resp.result.messages[0].content.text.includes("cinematic warm"), "Should include look");
+  });
+
+  await test("rough_cut_assembly prompt handles media_folder", async () => {
+    const resp = await client.getPrompt("rough_cut_assembly", {
+      media_folder: "/Users/test/footage",
+    });
+    assert(resp.result, "Missing result");
+    assert(
+      resp.result.messages[0].content.text.includes("/Users/test/footage"),
+      "Should include media folder path"
+    );
+  });
+
+  await test("Unknown prompt returns error", async () => {
+    const resp = await client.getPrompt("nonexistent_prompt");
+    assert(resp.error, "Should return error for unknown prompt");
+  });
+
+  // ── Response Shape Tests ──────────────────────────────────────────
+
+  console.log("\n── Response Shape (success field) ──");
+
+  await test("Unknown tool response has success=false", async () => {
+    const resp = await client.callTool("nonexistent_tool_shape_test", {});
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.success === false, `Expected success=false, got: ${parsed.success}`);
+    assert(parsed.error, "Should have error field");
+  });
+
+  // ── Error Handling Tests ────────────────────────────────────────────
+  // NOTE: These tests expect CommandPost to be DISCONNECTED. In --live mode
+  // the server is connected, so these calls succeed (slowly) and would block
+  // the entire test suite. We skip them in live mode.
+
+  console.log("\n── Error Handling (offline) ──");
+
+  await test("commandpost_ping returns helpful error when disconnected", async () => {
+    const resp = await client.callTool("commandpost_ping");
+    assert(resp.result, "Missing result");
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    const parsed = JSON.parse(content);
+    assert(
+      parsed.error || parsed.status === "connected",
+      "Should return error or connected status"
+    );
+  }, { requiresLive: false, skipIfLive: true });
+
+  await test("commandpost_execute_lua returns result or connection error", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: "return 1+1",
+    });
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    const parsed = JSON.parse(content);
+    assert(
+      parsed.result !== undefined || parsed.error,
+      "Should have result or error field"
+    );
+  }, { requiresLive: false, skipIfLive: true });
+
+  await test("commandpost_chain returns result or connection error", async () => {
+    const resp = await client.callTool("commandpost_chain", {
+      operations: [{ type: "execute", code: "return 1" }],
+    });
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    const parsed = JSON.parse(content);
+    assert(
+      parsed.results || parsed.error,
+      "Should have results or error field"
+    );
+  }, { requiresLive: false, skipIfLive: true });
+
+  await test("Unknown tool returns error", async () => {
+    const resp = await client.callTool("nonexistent_tool", {});
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    const parsed = JSON.parse(content);
+    assert(
+      parsed.error && parsed.error.includes("Unknown tool"),
+      `Expected 'Unknown tool' error, got: ${parsed.error}`
+    );
+  });
+
+  await test("fcp_timeline_navigate rejects invalid action", async () => {
+    const resp = await client.callTool("fcp_timeline_navigate", {
+      action: "invalid_action",
+    });
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    // Should either be connection error or validation error
+    const parsed = JSON.parse(content);
+    assert(
+      parsed.error,
+      "Should have error for invalid action"
+    );
+  });
+
+  await test("Invalid input validation runs before connection attempts", async () => {
+    const deadClient = new MCPTestClient({
+      env: {
+        COMMANDPOST_WS_URL: "ws://127.0.0.1:9",
+      },
+    });
+
+    try {
+      await deadClient.start();
+      const resp = await deadClient.callTool("commandpost_execute_lua", {
+        code: "",
+      });
+      const content = resp.result.content?.[0]?.text;
+      assert(content, "Missing content text");
+      const parsed = JSON.parse(content);
+      assert(parsed.error === "Code cannot be empty", `Expected validation error, got: ${parsed.error}`);
+      assert(
+        !parsed.error.includes("Cannot connect to CommandPost"),
+        "Should validate before attempting to connect"
+      );
+    } finally {
+      deadClient.stop();
+    }
+  });
+
+  await test("fcp_batch_apply_transition rejects unsupported custom params", async () => {
+    const resp = await client.callTool("fcp_batch_apply_transition", {
+      transition: "Dissolves/Cross Dissolve",
+      duration: 1,
+    });
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should have validation error");
+    assert(
+      parsed.error.includes("does not support custom transition or duration parameters"),
+      `Expected unsupported params error, got: ${parsed.error}`
+    );
+  });
+
+  await test("fcp_assemble_rough_cut rejects unsupported clip instructions", async () => {
+    const resp = await client.callTool("fcp_assemble_rough_cut", {
+      clipPlan: [
+        {
+          mediaPath: "/tmp/example.mov",
+          inPoint: "00:00:01:00",
+        },
+      ],
+    });
+    const content = resp.result.content?.[0]?.text;
+    assert(content, "Missing content text");
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should have validation error");
+    assert(
+      parsed.error.includes("unsupported fields: inPoint"),
+      `Expected unsupported clip field error, got: ${parsed.error}`
+    );
+  });
+
+  // ── Error response structure ────────────────────────────────────────
+
+  await test("Connection error responses include help text", async () => {
+    // Use an unknown tool to test error format without needing a connection
+    const resp = await client.callTool("nonexistent_tool_2", {});
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should have error");
+    // Unknown tool errors have a simple format; connection errors have help
+    // Just verify we get a structured error response
+    assert(typeof parsed.error === "string", "Error should be a string");
+  });
+
+  // ── Input Schema Validation Tests ──────────────────────────────────
+
+  console.log("\n── Input Schema Validation ──");
+
+  await test("Tools with array params have items schema", async () => {
+    const chain = tools.find((t) => t.name === "commandpost_chain");
+    const ops = chain.inputSchema.properties?.operations;
+    assert(ops?.type === "array", "operations should be array type");
+    assert(ops?.items, "operations should have items schema");
+  });
+
+  await test("fcp_select_menu path is array of strings", async () => {
+    const tool = tools.find((t) => t.name === "fcp_select_menu");
+    const path = tool.inputSchema.properties?.path;
+    assert(path?.type === "array", "path should be array type");
+    assert(path?.items?.type === "string", "path items should be strings");
+  });
+
+  await test("fcp_color_board has all required params", async () => {
+    const tool = tools.find((t) => t.name === "fcp_color_board");
+    assert(
+      tool.inputSchema.required?.includes("aspect"),
+      "Should require aspect"
+    );
+    assert(
+      tool.inputSchema.required?.includes("puck"),
+      "Should require puck"
+    );
+    assert(
+      tool.inputSchema.required?.includes("value"),
+      "Should require value"
+    );
+  });
+
+  // ── Live Tests (require CommandPost with WebSocket) ─────────────────
+
+  console.log("\n── Live Tests ──");
+
+  await test("commandpost_ping succeeds against live server", async () => {
+    const resp = await client.callTool("commandpost_ping");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.status === "connected", `Expected connected, got: ${JSON.stringify(parsed)}`);
+  }, { requiresLive: true });
+
+  await test("commandpost_execute_lua returns arithmetic result", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: "1 + 1",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result === 2, `Expected 2, got: ${JSON.stringify(parsed)}`);
+  }, { requiresLive: true });
+
+  await test("commandpost_execute_lua returns string", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: '"hello" .. " " .. "world"',
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result === "hello world", `Expected 'hello world', got: ${JSON.stringify(parsed)}`);
+  }, { requiresLive: true });
+
+  await test("commandpost_execute_lua returns table", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: '{name = "test", value = 42, nested = {a = 1}}',
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result?.name === "test", "Missing name field");
+    assert(parsed.result?.value === 42, "Missing value field");
+    assert(parsed.result?.nested?.a === 1, "Missing nested field");
+  }, { requiresLive: true });
+
+  await test("commandpost_execute_lua returns array", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: "{10, 20, 30}",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(Array.isArray(parsed.result), "Expected array result");
+    assert(parsed.result.length === 3, "Expected 3 elements");
+    assert(parsed.result[0] === 10, "First element should be 10");
+  }, { requiresLive: true });
+
+  await test("commandpost_execute_lua handles runtime errors", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: 'error("intentional test error")',
+    });
+    const content = resp.result.content?.[0]?.text;
+    // The server should catch the error and return it
+    assert(content, "Should have response content");
+  }, { requiresLive: true });
+
+  await test("commandpost_execute_lua handles multi-statement code", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", {
+      code: "local x = 10\nlocal y = 20\nreturn x + y",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result === 30, `Expected 30, got: ${JSON.stringify(parsed)}`);
+  }, { requiresLive: true });
+
+  await test("commandpost_list_handlers returns handlers", async () => {
+    const resp = await client.callTool("commandpost_list_handlers");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.handlers, "Missing handlers array");
+    assert(parsed.handlers.length > 0, "Expected at least one handler");
+    // Verify structure — all handlers must have an id, group may be nil
+    for (const h of parsed.handlers) {
+      assert(h.id, `Handler missing id: ${JSON.stringify(h)}`);
+    }
+  }, { requiresLive: true });
+
+  await test("commandpost_chain executes multiple operations", async () => {
+    const resp = await client.callTool("commandpost_chain", {
+      operations: [
+        { type: "execute", code: "return 10" },
+        { type: "execute", code: "return _prev + 5" },
+        { type: "execute", code: "return {first = 10, second = _prev, sum = 10 + _prev}" },
+      ],
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.results, "Missing results array");
+    assert(parsed.completedOperations === 3, `Should complete 3 operations, got ${parsed.completedOperations}`);
+    // Verify chaining: step 1 returns 10, step 2 returns 15, step 3 builds table
+    assert(parsed.results[0].status === "success", "Step 1 should succeed");
+    assert(parsed.results[1].status === "success", "Step 2 should succeed");
+    assert(parsed.results[2].status === "success", "Step 3 should succeed");
+  }, { requiresLive: true });
+
+  await test("commandpost_chain stops on error when stopOnError is true", async () => {
+    const resp = await client.callTool("commandpost_chain", {
+      operations: [
+        { type: "execute", code: "return 1" },
+        { type: "execute", code: 'error("test")' },
+        { type: "execute", code: "return 3" },
+      ],
+      stopOnError: true,
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.completedOperations === 2, "Should stop after 2 operations");
+  }, { requiresLive: true });
+
+  await test("fcp_status returns status info", async () => {
+    const resp = await client.callTool("fcp_status");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result !== undefined, "Missing result");
+    // Should have running field at minimum
+    const result = parsed.result;
+    assert(result.running !== undefined, "Missing running field");
+    assert(result.installed !== undefined, "Missing installed field");
+  }, { requiresLive: true });
+
+  await test("commandpost_alert shows notification", async () => {
+    const resp = await client.callTool("commandpost_alert", {
+      message: "MCP Test Passed!",
+      duration: 1,
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result?.alerted === true, "Alert should be shown");
+  }, { requiresLive: true });
+
+  await test("commandpost_get_preference reads a value", async () => {
+    const resp = await client.callTool("commandpost_get_preference", {
+      key: "websocket.enabled",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    // Should return truthy value since we're connected via WebSocket
+    // (may be boolean true or integer 1 depending on how it was stored)
+    assert(parsed.result, `Expected truthy for websocket.enabled, got: ${JSON.stringify(parsed)}`);
+  }, { requiresLive: true });
+
+  await test("fcp_pasteboard history returns structured items", async () => {
+    const resp = await client.callTool("fcp_pasteboard", {
+      action: "history",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.result?.action === "history", `Expected history action, got: ${JSON.stringify(parsed)}`);
+    assert(Array.isArray(parsed.result?.items), "Expected items array");
+    assert(typeof parsed.result?.count === "number", "Expected numeric count");
+  }, { requiresLive: true });
+
+  // ── Live: New Features ────────────────────────────────────────────
+
+  console.log("\n── Live: Response Shape ──");
+
+  await test("fcp_status response has success field", async () => {
+    const resp = await client.callTool("fcp_status");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.success !== undefined, "Response should have success field");
+  }, { requiresLive: true });
+
+  await test("fcp_status uses graceful degradation (safeGet)", async () => {
+    const resp = await client.callTool("fcp_status");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    const result = parsed.result || parsed;
+    // Should have running field — even if FCP is not running, it should return false not crash
+    assert(result.running !== undefined, "Should have running field");
+    // Version, path, etc. may be null if FCP not installed — but should not throw
+    assert(result.success !== undefined || result.running !== undefined, "Should have structured response");
+  }, { requiresLive: true });
+
+  console.log("\n── Live: Discovery Tools ──");
+
+  await test("fcp_get_playhead_position returns timecode", async () => {
+    const resp = await client.callTool("fcp_get_playhead_position");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    const result = parsed.result || parsed;
+    assert(result.timecode !== undefined, `Should have timecode field, got: ${JSON.stringify(result)}`);
+  }, { requiresLive: true });
+
+  await test("fcp_get_project_settings returns settings", async () => {
+    const resp = await client.callTool("fcp_get_project_settings");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    const result = parsed.result || parsed;
+    assert(result.running !== undefined, "Should have running field");
+    assert(result.success !== undefined, "Should have success field from safeLua");
+  }, { requiresLive: true });
+
+  await test("fcp_get_selected_clips returns clip info or empty", async () => {
+    const resp = await client.callTool("fcp_get_selected_clips");
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    const result = parsed.result || parsed;
+    // Should have clips array (may be empty) or error if timeline not showing
+    assert(
+      result.clips !== undefined || result.error,
+      `Should have clips array or error, got: ${JSON.stringify(result)}`
+    );
+  }, { requiresLive: true });
+
+  await test("fcp_get_clip_properties returns properties or error", async () => {
+    const resp = await client.callTool("fcp_get_clip_properties", {}, 30000);
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    const result = parsed.result || parsed;
+    // Should return structured properties or error
+    assert(
+      result.transform !== undefined || result.error || result.available !== undefined,
+      `Should have transform or error, got: ${JSON.stringify(result)}`
+    );
+  }, { requiresLive: true });
+
+  await test("fcp_list_markers returns markers or error", async () => {
+    const resp = await client.callTool("fcp_list_markers", {}, 30000);
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    const result = parsed.result || parsed;
+    assert(
+      result.markers !== undefined || result.error,
+      `Should have markers array or error, got: ${JSON.stringify(result)}`
+    );
+  }, { requiresLive: true });
+
+  console.log("\n── Live: Input Validation ──");
+
+  await test("commandpost_execute_lua validates empty code", async () => {
+    const resp = await client.callTool("commandpost_execute_lua", { code: "" });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject empty code");
+  }, { requiresLive: true });
+
+  await test("fcp_import_media validates path traversal", async () => {
+    const resp = await client.callTool("fcp_import_media", {
+      path: "/tmp/../../../etc/passwd",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject path with traversal");
+    assert(parsed.error.includes("traversal") || parsed.error.includes(".."), "Error should mention traversal");
+  }, { requiresLive: true });
+
+  await test("fcp_import_xml validates path traversal", async () => {
+    const resp = await client.callTool("fcp_import_xml", {
+      path: "../../../secret.xml",
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject path with traversal");
+  }, { requiresLive: true });
+
+  await test("fcp_speed_custom validates percentage range", async () => {
+    const resp = await client.callTool("fcp_speed_custom", {
+      percentage: -50,
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject negative percentage");
+  }, { requiresLive: true });
+
+  await test("fcp_assemble_rough_cut validates clipPlan paths", async () => {
+    const resp = await client.callTool("fcp_assemble_rough_cut", {
+      clipPlan: [{ mediaPath: "../../../etc/passwd" }],
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject path traversal in clipPlan");
+  }, { requiresLive: true });
+
+  await test("fcp_assemble_rough_cut validates empty clipPlan", async () => {
+    const resp = await client.callTool("fcp_assemble_rough_cut", {
+      clipPlan: [],
+    });
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject empty clipPlan");
+  }, { requiresLive: true });
+
+  await test("fcp_set_clip_properties rejects no properties", async () => {
+    const resp = await client.callTool("fcp_set_clip_properties", {});
+    const content = resp.result.content?.[0]?.text;
+    const parsed = JSON.parse(content);
+    assert(parsed.error, "Should reject when no properties specified");
+  }, { requiresLive: true });
+
+  console.log("\n── Live: Resources ──");
+
+  await test("commandpost://fcp-status returns live data", async () => {
+    const resp = await client.readResource("commandpost://fcp-status", 30000);
+    assert(resp.result, "Missing result");
+    const contents = resp.result.contents;
+    assert(contents && contents.length > 0, "Missing contents");
+    const data = JSON.parse(contents[0].text);
+    assert(data.running !== undefined, "Should have running field");
+  }, { requiresLive: true });
+
+  await test("commandpost://timeline/clips returns clip data", async () => {
+    const resp = await client.readResource("commandpost://timeline/clips", 30000);
+    assert(resp.result, "Missing result");
+    const contents = resp.result.contents;
+    assert(contents && contents.length > 0, "Missing contents");
+    const data = JSON.parse(contents[0].text);
+    // Should have clips array (possibly empty) or error
+    assert(
+      data.clips !== undefined || data.error,
+      `Should have clips or error, got: ${JSON.stringify(data)}`
+    );
+  }, { requiresLive: true });
+
+  // ── Cleanup ───────────────────────────────────────────────────────
+
+  client.stop();
+
+  // ── Summary ───────────────────────────────────────────────────────
+
+  console.log("\n" + "─".repeat(50));
+  console.log(`\n  Results: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+  console.log(`  Total:   ${passed + failed + skipped} tests\n`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+runTests().catch((err) => {
+  console.error("Test runner error:", err);
+  process.exit(1);
+});

--- a/src/mcp-server/tsconfig.json
+++ b/src/mcp-server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/plugins/core/websocket/manager/init.lua
+++ b/src/plugins/core/websocket/manager/init.lua
@@ -14,12 +14,79 @@ local config        = require "cp.config"
 local i18n          = require "cp.i18n"
 local prop          = require "cp.prop"
 local json          = require "hs.json"
+local hash          = require "hs.hash"
 
 local client        = require "client"
 local server        = require "server"
 local messageHandler = require "message-handler"
 
 local mod = {}
+
+--- plugins.core.websocket.manager.AUTH_TOKEN_FILENAME
+--- Constant
+--- Filename for the auth token file
+local AUTH_TOKEN_FILENAME = "mcp-auth-token"
+
+--- plugins.core.websocket.manager.generateAuthToken() -> string
+--- Function
+--- Generates a random auth token and writes it to a well-known file.
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The generated token string
+local function generateAuthToken()
+    -- Generate a random token using timestamp + random data
+    local seed = tostring(os.time()) .. tostring(math.random(1000000, 9999999)) .. tostring(hs.processInfo.processID)
+    local token = hash.SHA256(seed)
+    return token
+end
+
+--- plugins.core.websocket.manager.writeAuthToken(token) -> boolean
+--- Function
+--- Writes the auth token to the well-known file path.
+---
+--- Parameters:
+---  * token - The token string to write
+---
+--- Returns:
+---  * true if written successfully
+local function writeAuthToken(token)
+    local tokenDir = config.userConfigRootPath
+    if not tokenDir then
+        tokenDir = os.getenv("HOME") .. "/.CommandPost"
+    end
+    -- Ensure directory exists
+    os.execute("mkdir -p " .. string.format("%q", tokenDir))
+    local tokenPath = tokenDir .. "/" .. AUTH_TOKEN_FILENAME
+    local f = io.open(tokenPath, "w")
+    if f then
+        f:write(token)
+        f:close()
+        -- Restrict permissions to owner only
+        os.execute("chmod 600 " .. string.format("%q", tokenPath))
+        log.df("Auth token written to: %s", tokenPath)
+        return true
+    else
+        log.ef("Failed to write auth token to: %s", tokenPath)
+        return false
+    end
+end
+
+--- plugins.core.websocket.manager.getAuthTokenPath() -> string
+--- Function
+--- Returns the path where the auth token file is stored.
+---
+--- Returns:
+---  * The file path string
+function mod.getAuthTokenPath()
+    local tokenDir = config.userConfigRootPath
+    if not tokenDir then
+        tokenDir = os.getenv("HOME") .. "/.CommandPost"
+    end
+    return tokenDir .. "/" .. AUTH_TOKEN_FILENAME
+end
 
 --- plugins.core.websocket.manager.MODE
 --- Constant
@@ -110,7 +177,13 @@ end
 ---  * true if started successfully, false otherwise
 function mod.startServer()
     local port = mod.serverPort()
-    --log.df("Starting WebSocket server on port %d", port)
+
+    -- Generate and write auth token for this session
+    local token = generateAuthToken()
+    writeAuthToken(token)
+    messageHandler.setAuthToken(token)
+    log.df("WebSocket server auth token generated for session")
+
     return server.start(port, mod.handleMessage)
 end
 
@@ -148,7 +221,15 @@ function mod.handleMessage(connection, message)
     if response then
         local ok, encoded = pcall(json.encode, response)
         if ok then
-            connection:send(encoded)
+            -- In client mode we must explicitly send the response back across the
+            -- outbound websocket connection. In server mode the websocket callback
+            -- return value is already routed to the requesting client, so sending
+            -- it again would broadcast request/response traffic to every client.
+            if connection and (connection.mode == "client" or connection.type == "client") then
+                connection:send(encoded)
+                return nil
+            end
+            return encoded
         else
             log.ef("Failed to encode response: %s", encoded)
         end
@@ -262,6 +343,12 @@ function plugin.init(deps, env)
     client.init(mod)
     server.init(mod)
     messageHandler.init(deps.actionManager)
+
+    -- Initialize audit log in the CommandPost config directory
+    local configPath = config.userConfigRootPath
+    if configPath then
+        messageHandler.initAuditLog(configPath)
+    end
 
     --------------------------------------------------------------------------------
     -- Setup Commands:

--- a/src/plugins/core/websocket/manager/message-handler.lua
+++ b/src/plugins/core/websocket/manager/message-handler.lua
@@ -9,10 +9,106 @@ local require = require
 
 local json      = require "hs.json"
 local timer     = require "hs.timer"
+local just      = require "cp.just"
 
 local log       = require("hs.logger").new("ws_msg")
 
 local mod = {}
+local sanitizeForJson
+
+--- Authentication token for WebSocket connections.
+--- Set by the manager on startup. If nil, auth is disabled (backwards compat).
+local authToken = nil
+
+--- plugins.core.websocket.manager.message-handler.setAuthToken(token) -> nil
+--- Function
+--- Sets the authentication token required for all non-ping messages.
+---
+--- Parameters:
+---  * token - The token string, or nil to disable auth
+function mod.setAuthToken(token)
+    authToken = token
+end
+
+local MAX_SERIALIZE_DEPTH = 8
+local MAX_SERIALIZE_ITEMS = 200
+local MAX_SERIALIZE_NODES = 2000
+local MAX_SERIALIZE_STRING_LENGTH = 4096
+local SLOW_MESSAGE_WARNING_SECONDS = 0.5
+local SLOW_EXECUTE_WARNING_SECONDS = 0.25
+local SLOW_SERIALIZE_WARNING_SECONDS = 0.1
+
+local wait = just.wait
+
+local DEFAULT_HANDLER_INFO_LIMIT = 200
+local MAX_HANDLER_INFO_LIMIT = 1000
+
+-- ============================================================================
+-- Audit Log
+-- ============================================================================
+-- Logs every MCP operation (except pings) to a rotating file for debugging.
+
+local AUDIT_LOG_MAX_SIZE = 512 * 1024  -- 512KB before rotation
+local AUDIT_LOG_MAX_FILES = 3          -- Keep 3 rotated files
+local auditLogPath = nil
+local auditLogEnabled = true
+
+--- summarizePayload(data) -> string
+--- Summarizes a message payload for audit logging (abbreviated, no secrets).
+local function summarizePayload(data)
+    if not data or not data.payload then return "" end
+    local p = data.payload
+    if p.code then
+        -- Truncate Lua code to first 80 chars
+        local code = tostring(p.code):gsub("\n", " "):sub(1, 80)
+        return "code=" .. code
+    elseif p.handler then
+        return "handler=" .. tostring(p.handler) .. " action=" .. tostring(p.actionId or "")
+    elseif p.query then
+        return "query=" .. tostring(p.query)
+    elseif p.operations then
+        return "batch_ops=" .. tostring(#p.operations)
+    end
+    return ""
+end
+
+--- rotateAuditLog() -> nil
+--- Rotates the audit log file if it exceeds the max size.
+local function rotateAuditLog()
+    if not auditLogPath then return end
+    local attr = hs.fs and hs.fs.attributes and hs.fs.attributes(auditLogPath)
+    if not attr or not attr.size or attr.size < AUDIT_LOG_MAX_SIZE then return end
+
+    -- Rotate: .log.2 -> .log.3, .log.1 -> .log.2, .log -> .log.1
+    for i = AUDIT_LOG_MAX_FILES - 1, 1, -1 do
+        local src = auditLogPath .. "." .. i
+        local dst = auditLogPath .. "." .. (i + 1)
+        os.rename(src, dst)
+    end
+    os.rename(auditLogPath, auditLogPath .. ".1")
+end
+
+--- writeAuditLog(entry) -> nil
+--- Appends a log entry to the audit log file.
+local function writeAuditLog(entry)
+    if not auditLogEnabled or not auditLogPath then return end
+    rotateAuditLog()
+    -- Use raw io here since this is internal logging, not user code
+    local f = io.open(auditLogPath, "a")
+    if f then
+        f:write(entry .. "\n")
+        f:close()
+    end
+end
+
+--- mod.initAuditLog(configPath) -> nil
+--- Initializes the audit log path.
+function mod.initAuditLog(configPath)
+    if configPath then
+        auditLogPath = configPath .. "/mcp-audit.log"
+        log.df("MCP audit log: %s", auditLogPath)
+    end
+end
 
 --- plugins.core.websocket.manager.message-handler.MESSAGE_TYPES
 --- Constant
@@ -23,6 +119,8 @@ mod.MESSAGE_TYPES = {
     PING = "ping",
     RESPONSE = "response",
     EVENT = "event",
+    EXECUTE = "execute",
+    BATCH = "batch",
 }
 
 --- plugins.core.websocket.manager.message-handler.init(actionManager)
@@ -129,6 +227,9 @@ end
 local function findFCPXPluginBySimplifiedPath(choices, simplifiedPath)
     --log.df("Searching %d choices for simplified path: %s", #choices, simplifiedPath)
 
+    -- Track name-only matches as fallback (lower priority than exact category/name)
+    local nameOnlyMatch = nil
+
     for i, choice in ipairs(choices) do
         if type(choice.params) == "table" then
             local matched = false
@@ -151,6 +252,13 @@ local function findFCPXPluginBySimplifiedPath(choices, simplifiedPath)
                 end
             end
 
+            -- Try name-only match as fallback (for inputs like "Cross Dissolve" without category)
+            if not matched and not nameOnlyMatch and choice.params.name then
+                if choice.params.name == simplifiedPath then
+                    nameOnlyMatch = choice
+                end
+            end
+
             -- Log first few choices for debugging
             if i <= 3 then
                 if choice.params.path then
@@ -162,8 +270,140 @@ local function findFCPXPluginBySimplifiedPath(choices, simplifiedPath)
         end
     end
 
+    -- Return name-only match if no exact match was found
+    if nameOnlyMatch then
+        --log.df("Found FCPX plugin by name-only: %s", nameOnlyMatch.params.name)
+        return nameOnlyMatch
+    end
+
     --log.df("No matching plugin found for: %s", simplifiedPath)
     return nil
+end
+
+-- getHandlerChoices(handler) -> table | nil
+-- Function
+-- Safely fetches a handler's available choices, preferring cached choices.
+--
+-- Parameters:
+--  * handler - The action handler
+--
+-- Returns:
+--  * Array of choices, or nil if unavailable
+local function getHandlerChoices(handler)
+    if not handler then
+        return nil
+    end
+
+    local handlerChoices = handler._choices
+    if handlerChoices then
+        return handlerChoices:getChoices()
+    end
+
+    local ok, choicesResult = pcall(function()
+        return handler:choices()
+    end)
+
+    if ok and choicesResult then
+        return choicesResult:getChoices()
+    end
+
+    return nil
+end
+
+-- copyTable(original) -> table | any
+-- Function
+-- Creates a shallow copy of a table so cached handler choice params are not
+-- mutated while building action payloads.
+--
+-- Parameters:
+--  * original - The original value
+--
+-- Returns:
+--  * A shallow-copied table, or the original value if it is not a table
+local function copyTable(original)
+    if type(original) ~= "table" then
+        return original
+    end
+
+    local copy = {}
+    local key = next(original)
+    while key ~= nil do
+        copy[key] = rawget(original, key)
+        key = next(original, key)
+    end
+    return copy
+end
+
+-- clampInteger(value, defaultValue, minimumValue, maximumValue) -> number
+-- Function
+-- Coerces a value to an integer within the supplied bounds.
+--
+-- Parameters:
+--  * value - The raw value
+--  * defaultValue - The fallback integer
+--  * minimumValue - The minimum allowed value
+--  * maximumValue - The maximum allowed value
+--
+-- Returns:
+--  * The bounded integer value
+local function clampInteger(value, defaultValue, minimumValue, maximumValue)
+    local numberValue = tonumber(value)
+    if not numberValue then
+        return defaultValue
+    end
+
+    local integerValue = math.floor(numberValue)
+    if integerValue < minimumValue then
+        return minimumValue
+    elseif integerValue > maximumValue then
+        return maximumValue
+    end
+
+    return integerValue
+end
+
+local function summarizeCode(code)
+    if type(code) ~= "string" then
+        return "<non-string code>"
+    end
+
+    local summary = code:gsub("%s+", " ")
+    if #summary > 160 then
+        summary = summary:sub(1, 157) .. "..."
+    end
+    return summary
+end
+
+local function createSerializationState()
+    return {
+        refs = {},
+        nodes = 0,
+        tables = 0,
+        userdata = 0,
+        maxDepth = 0,
+        truncated = false,
+        truncationReason = nil,
+    }
+end
+
+local function markSerializationTruncated(state, reason)
+    if state and not state.truncated then
+        state.truncated = true
+        state.truncationReason = reason
+    end
+end
+
+local function safeJsonKey(key, index)
+    local keyType = type(key)
+    if keyType == "string" then
+        if #key > MAX_SERIALIZE_STRING_LENGTH then
+            return key:sub(1, MAX_SERIALIZE_STRING_LENGTH) .. "... [truncated]"
+        end
+        return key
+    elseif keyType == "number" or keyType == "boolean" then
+        return tostring(key)
+    end
+    return "[" .. keyType .. ":" .. tostring(index or "?") .. "]"
 end
 
 --- plugins.core.websocket.manager.message-handler.parseMessage(message) -> table | nil, string
@@ -231,6 +471,20 @@ function mod.validateMessage(data)
                 return false, "Missing 'action' or 'handler' field in payload"
             end
         end
+    elseif data.type == mod.MESSAGE_TYPES.EXECUTE then
+        if not data.payload then
+            return false, "Missing 'payload' field for execute"
+        end
+        if not data.payload.code or type(data.payload.code) ~= "string" then
+            return false, "Missing or invalid 'code' field in execute payload"
+        end
+    elseif data.type == mod.MESSAGE_TYPES.BATCH then
+        if not data.payload then
+            return false, "Missing 'payload' field for batch"
+        end
+        if not data.payload.operations or type(data.payload.operations) ~= "table" then
+            return false, "Missing or invalid 'operations' array in batch payload"
+        end
     end
 
     return true, nil
@@ -263,16 +517,65 @@ function mod.handleMessage(connection, message)
         return mod.createErrorResponse(data.id, "Validation error: " .. validError)
     end
 
+    -- Authentication check (skip for ping — allows health checks without auth)
+    if authToken and data.type ~= mod.MESSAGE_TYPES.PING then
+        local msgToken = data.auth
+        if not msgToken or msgToken ~= authToken then
+            log.wf("WebSocket auth failed for message id=%s type=%s", tostring(data.id), tostring(data.type))
+            return mod.createErrorResponse(data.id, "Authentication failed: invalid or missing auth token")
+        end
+    end
+
+    local startedAt = timer.secondsSinceEpoch()
+    local response
+
     -- Handle different message types
     if data.type == mod.MESSAGE_TYPES.PING then
-        return mod.handlePing(data)
+        response = mod.handlePing(data)
     elseif data.type == mod.MESSAGE_TYPES.COMMAND then
-        return mod.handleCommand(data)
+        response = mod.handleCommand(data)
     elseif data.type == mod.MESSAGE_TYPES.QUERY then
-        return mod.handleQuery(data)
+        response = mod.handleQuery(data)
+    elseif data.type == mod.MESSAGE_TYPES.EXECUTE then
+        response = mod.handleExecute(data)
+    elseif data.type == mod.MESSAGE_TYPES.BATCH then
+        response = mod.handleBatch(data)
     else
-        return mod.createErrorResponse(data.id, "Unsupported message type: " .. data.type)
+        response = mod.createErrorResponse(data.id, "Unsupported message type: " .. data.type)
     end
+
+    local elapsed = timer.secondsSinceEpoch() - startedAt
+    if elapsed >= SLOW_MESSAGE_WARNING_SECONDS then
+        log.wf(
+            "Slow websocket message id=%s type=%s elapsed=%.3fs bytes=%d status=%s",
+            tostring(data.id),
+            tostring(data.type),
+            elapsed,
+            type(message) == "string" and #message or 0,
+            response and tostring(response.status) or "unknown"
+        )
+    end
+
+    -- Audit log (skip pings to avoid noise)
+    if data.type ~= mod.MESSAGE_TYPES.PING then
+        pcall(function()
+            local status = response and response.status or "unknown"
+            local errMsg = response and response.error or ""
+            local summary = summarizePayload(data)
+            local entry = string.format(
+                "%s | %s | %s | %.3fs | %s | %s",
+                os.date("%Y-%m-%d %H:%M:%S"),
+                tostring(data.type),
+                status,
+                elapsed,
+                summary,
+                errMsg ~= "" and ("err=" .. tostring(errMsg):sub(1, 100)) or ""
+            )
+            writeAuditLog(entry)
+        end)
+    end
+
+    return response
 end
 
 --- plugins.core.websocket.manager.message-handler.handlePing(data) -> table
@@ -395,8 +698,8 @@ function mod.handleCommand(data)
                 end
 
                 if choiceParams then
-                    -- Use the params directly as the action
-                    action = choiceParams
+                    -- Copy the params so cached handler choices remain immutable.
+                    action = copyTable(choiceParams)
                 else
                     log.ef("FCPX plugin not found with path: %s", actionId)
                     return nil, "Plugin not found: " .. actionId
@@ -445,9 +748,9 @@ function mod.handleCommand(data)
 
                 -- Create action object with params if found
                 if choiceParams then
-                    -- Ensure choiceParams is a table before using it
+                    -- Copy the params so cached handler choices remain immutable.
                     if type(choiceParams) == "table" then
-                        action = choiceParams
+                        action = copyTable(choiceParams)
                         action.id = commandId
                     else
                         -- choiceParams is a string or other type, wrap it in params
@@ -537,6 +840,42 @@ function mod.handleQuery(data)
             label = handler:label()
         }
 
+        local includeChoices = data.payload.includeChoices ~= false
+        if includeChoices then
+            local choices = getHandlerChoices(handler) or {}
+            local limit = clampInteger(data.payload.limit, DEFAULT_HANDLER_INFO_LIMIT, 0, MAX_HANDLER_INFO_LIMIT)
+            local offset = clampInteger(data.payload.offset, 0, 0, #choices)
+            local includeParams = data.payload.includeParams == true
+            local summarizedChoices = {}
+            local lastIndex = math.min(#choices, offset + limit)
+
+            for index = offset + 1, lastIndex do
+                local choice = choices[index]
+                local summary = {
+                    id = choice.id,
+                    text = choice.text,
+                    subText = choice.subText,
+                }
+                if includeParams then
+                    summary.params = sanitizeForJson(choice.params)
+                end
+                table.insert(summarizedChoices, summary)
+            end
+
+            handlerInfo.choiceCount = #choices
+            handlerInfo.returnedChoiceCount = #summarizedChoices
+            handlerInfo.offset = offset
+            handlerInfo.limit = limit
+            handlerInfo.hasMoreChoices = lastIndex < #choices
+            handlerInfo.includeParams = includeParams
+            handlerInfo.choices = summarizedChoices
+        else
+            local cachedChoices = handler._choices
+            if cachedChoices then
+                handlerInfo.choiceCount = #cachedChoices:getChoices()
+            end
+        end
+
         return mod.createSuccessResponse(data.id, {handler = handlerInfo})
     elseif queryType == "ping" then
         return mod.createSuccessResponse(data.id, {message = "pong"})
@@ -544,6 +883,453 @@ function mod.handleQuery(data)
         -- For other queries, treat as command
         return mod.handleCommand(data)
     end
+end
+
+-- ============================================================================
+-- Lua Execution Support (for MCP)
+-- ============================================================================
+
+-- sanitizeForJson(value, seen) -> any
+-- Function
+-- Recursively converts a Lua value into a JSON-safe representation.
+-- Handles tables, functions, userdata, and circular references.
+--
+-- Parameters:
+--  * value - Any Lua value
+--  * seen  - Internal table for tracking circular references
+--
+-- Returns:
+--  * A JSON-safe value
+function sanitizeForJson(value, state, depth)
+    state = state or createSerializationState()
+    depth = depth or 0
+    local t = type(value)
+
+    state.nodes = state.nodes + 1
+    if state.nodes > MAX_SERIALIZE_NODES then
+        markSerializationTruncated(state, "max node count exceeded")
+        return "[truncated: max nodes]"
+    end
+
+    if depth > state.maxDepth then
+        state.maxDepth = depth
+    end
+
+    if depth >= MAX_SERIALIZE_DEPTH then
+        markSerializationTruncated(state, "max depth exceeded")
+        return "[truncated: max depth]"
+    end
+
+    if value == nil then
+        return json.null
+    elseif t == "boolean" or t == "number" then
+        return value
+    elseif t == "string" then
+        if #value > MAX_SERIALIZE_STRING_LENGTH then
+            markSerializationTruncated(state, "max string length exceeded")
+            return value:sub(1, MAX_SERIALIZE_STRING_LENGTH) .. "... [truncated]"
+        end
+        return value
+    elseif t == "table" then
+        if state.refs[value] then
+            return "[circular reference]"
+        end
+        state.refs[value] = true
+        state.tables = state.tables + 1
+
+        -- Determine if array-like without invoking __pairs metamethods.
+        local arrayLength = rawlen(value)
+        local isArray = arrayLength > 0
+        local key = nil
+        local keyCount = 0
+        while true do
+            key = next(value, key)
+            if key == nil then break end
+
+            keyCount = keyCount + 1
+            if keyCount > MAX_SERIALIZE_ITEMS then
+                markSerializationTruncated(state, "max table items exceeded")
+                break
+            end
+
+            if isArray then
+                if type(key) ~= "number" or key < 1 or key ~= math.floor(key) or key > arrayLength then
+                    isArray = false
+                end
+            else
+                -- Continue iterating to count raw keys and trigger truncation above.
+            end
+        end
+
+        local result = {}
+        if isArray then
+            local limit = math.min(arrayLength, MAX_SERIALIZE_ITEMS)
+            if arrayLength > MAX_SERIALIZE_ITEMS then
+                markSerializationTruncated(state, "max array items exceeded")
+            end
+            for i = 1, limit do
+                result[i] = sanitizeForJson(rawget(value, i), state, depth + 1)
+            end
+            if arrayLength > limit then
+                result[limit + 1] = "[truncated " .. tostring(arrayLength - limit) .. " items]"
+            end
+        else
+            local itemIndex = 0
+            local currentKey = nil
+            while true do
+                currentKey = next(value, currentKey)
+                if currentKey == nil then break end
+
+                itemIndex = itemIndex + 1
+                if itemIndex > MAX_SERIALIZE_ITEMS then
+                    markSerializationTruncated(state, "max object items exceeded")
+                    result.__truncated = "[truncated after " .. tostring(MAX_SERIALIZE_ITEMS) .. " entries]"
+                    break
+                end
+
+                result[safeJsonKey(currentKey, itemIndex)] =
+                    sanitizeForJson(rawget(value, currentKey), state, depth + 1)
+            end
+        end
+
+        state.refs[value] = nil
+        return result
+    elseif t == "function" then
+        return "[function]"
+    elseif t == "userdata" then
+        state.userdata = state.userdata + 1
+        markSerializationTruncated(state, "userdata coerced to placeholder")
+        return "[userdata]"
+    else
+        local ok, str = pcall(tostring, value)
+        if ok then
+            if #str > MAX_SERIALIZE_STRING_LENGTH then
+                markSerializationTruncated(state, "max fallback string length exceeded")
+                return str:sub(1, MAX_SERIALIZE_STRING_LENGTH) .. "... [truncated]"
+            end
+            return str
+        end
+        return "[" .. t .. "]"
+    end
+end
+
+-- ============================================================================
+-- Sandboxed Lua Execution Environment
+-- ============================================================================
+
+-- Build a sandboxed environment that inherits from _G but blocks dangerous functions.
+-- This prevents MCP execute_lua from performing file I/O, shell execution, or
+-- modifying the global environment directly.
+local sandboxedEnv
+do
+    local BLOCKED_FUNCTIONS = {
+        -- Shell execution
+        "os.execute",
+        -- File deletion / rename
+        "os.remove",
+        "os.rename",
+        -- Raw file I/O (cp.* and hs.* APIs are preferred)
+        "io.open",
+        "io.popen",
+        "io.input",
+        "io.output",
+        "io.lines",
+        -- Dynamic code loading from files
+        "dofile",
+        "loadfile",
+        -- Module escape vectors
+        "package.loadlib",
+        "rawget (global scope bypass)",
+    }
+
+    -- Modules that are forbidden via require() to prevent sandbox escapes.
+    -- Requesting one of these returns the already-sandboxed version instead of
+    -- the real module.
+    local BLOCKED_REQUIRE_MODULES = {
+        ["os"]  = true,
+        ["io"]  = true,
+    }
+
+    -- Create sandbox as a proxy table that inherits from _G
+    sandboxedEnv = setmetatable({}, {
+        __index = function(_, key)
+            return _G[key]
+        end,
+        __newindex = function(t, key, value)
+            -- Allow setting new locals/globals within the sandbox, but not on _G itself
+            rawset(t, key, value)
+        end,
+    })
+
+    -- Create shadowed versions of os and io that block dangerous functions
+    local sandboxedOs = setmetatable({}, {__index = os})
+    sandboxedOs.execute = function() error("os.execute is not permitted in MCP sandbox", 2) end
+    sandboxedOs.remove = function() error("os.remove is not permitted in MCP sandbox", 2) end
+    sandboxedOs.rename = function() error("os.rename is not permitted in MCP sandbox", 2) end
+    rawset(sandboxedEnv, "os", sandboxedOs)
+
+    local sandboxedIo = setmetatable({}, {__index = io})
+    sandboxedIo.open = function() error("io.open is not permitted in MCP sandbox", 2) end
+    sandboxedIo.popen = function() error("io.popen is not permitted in MCP sandbox", 2) end
+    sandboxedIo.input = function() error("io.input is not permitted in MCP sandbox", 2) end
+    sandboxedIo.output = function() error("io.output is not permitted in MCP sandbox", 2) end
+    sandboxedIo.lines = function() error("io.lines is not permitted in MCP sandbox", 2) end
+    rawset(sandboxedEnv, "io", sandboxedIo)
+
+    -- Block dofile and loadfile
+    rawset(sandboxedEnv, "dofile", function() error("dofile is not permitted in MCP sandbox", 2) end)
+    rawset(sandboxedEnv, "loadfile", function() error("loadfile is not permitted in MCP sandbox", 2) end)
+
+    -- Block rawget to prevent bypassing the sandbox metatable (e.g., rawget(_G, "os"))
+    rawset(sandboxedEnv, "rawget", function(t, k)
+        -- Allow rawget on non-global tables (needed by some CP modules internally)
+        if t == _G or t == sandboxedEnv then
+            error("rawget on the global environment is not permitted in MCP sandbox", 2)
+        end
+        return rawget(t, k)
+    end)
+
+    -- Block package.loadlib to prevent loading arbitrary C libraries
+    local sandboxedPackage = setmetatable({}, {__index = package})
+    sandboxedPackage.loadlib = function() error("package.loadlib is not permitted in MCP sandbox", 2) end
+    rawset(sandboxedEnv, "package", sandboxedPackage)
+
+    -- Wrap require() to prevent sandbox escape via require("os") / require("io")
+    local realRequire = _G.require
+    rawset(sandboxedEnv, "require", function(modname)
+        if type(modname) == "string" and BLOCKED_REQUIRE_MODULES[modname] then
+            -- Return the already-sandboxed version instead of the real module
+            return rawget(sandboxedEnv, modname)
+        end
+        return realRequire(modname)
+    end)
+
+    -- Also block hs.execute if available
+    pcall(function()
+        local hs_orig = _G.hs
+        if hs_orig and hs_orig.execute then
+            local sandboxedHs = setmetatable({}, {__index = hs_orig})
+            sandboxedHs.execute = function() error("hs.execute is not permitted in MCP sandbox", 2) end
+            rawset(sandboxedEnv, "hs", sandboxedHs)
+        end
+    end)
+
+    log.df("MCP Lua sandbox initialized — blocked: %s", table.concat(BLOCKED_FUNCTIONS, ", "))
+end
+
+-- Maximum number of Lua VM instructions before an execution is terminated.
+-- Prevents infinite loops from freezing CommandPost's main thread.
+-- 50 million instructions ≈ several seconds of CPU time on modern hardware,
+-- which is generous enough for legitimate operations but will catch runaway code.
+local MAX_EXECUTION_INSTRUCTIONS = 50000000
+
+-- executeLuaCode(code, previousResult) -> any, string | nil
+-- Function
+-- Compiles and executes Lua code in a sandboxed environment with an optional `_prev` value for chaining.
+--
+-- Parameters:
+--  * code - Lua source code
+--  * previousResult - Optional previous batch result exposed as `_prev`
+--
+-- Returns:
+--  * The serialized result, or nil if execution failed
+--  * An error message, or nil if execution succeeded
+local function executeLuaCode(code, previousResult, requestId)
+    local executeStartedAt = timer.secondsSinceEpoch()
+
+    -- Try as expression first (prepend "return"), then as statement.
+    -- `_prev` is injected as a local to avoid leaking shared global state
+    -- across concurrent requests.
+    -- NOTE: Uses sandboxedEnv instead of _G to restrict dangerous operations.
+    local fn, compileError = load("local _prev = ...; return " .. code, "mcp-execute", "t", sandboxedEnv)
+    if not fn then
+        fn, compileError = load("local _prev = ...; " .. code, "mcp-execute", "t", sandboxedEnv)
+    end
+    if not fn then
+        return nil, "Compilation error: " .. tostring(compileError)
+    end
+
+    -- Install an instruction-count hook to prevent infinite loops from
+    -- blocking CommandPost's main thread. The hook fires every 10000
+    -- instructions and errors if the budget is exceeded.
+    local instructionCount = 0
+    debug.sethook(function()
+        instructionCount = instructionCount + 10000
+        if instructionCount > MAX_EXECUTION_INSTRUCTIONS then
+            error("Execution limit exceeded (" .. MAX_EXECUTION_INSTRUCTIONS .. " instructions). Possible infinite loop.", 2)
+        end
+    end, "", 10000)
+
+    local results = {pcall(fn, previousResult)}
+    local ok = table.remove(results, 1)
+
+    -- Always clear the hook, even on error
+    debug.sethook()
+
+    if not ok then
+        return nil, "Runtime error: " .. tostring(results[1])
+    end
+
+    local serializeStartedAt = timer.secondsSinceEpoch()
+    local serializationState = createSerializationState()
+    local serialized
+
+    if #results == 0 then
+        serialized = json.null
+    elseif #results == 1 then
+        serialized = sanitizeForJson(results[1], serializationState, 0)
+    else
+        serialized = {}
+        for i, v in ipairs(results) do
+            serialized[i] = sanitizeForJson(v, serializationState, 0)
+        end
+    end
+
+    local serializeElapsed = timer.secondsSinceEpoch() - serializeStartedAt
+    local executeElapsed = timer.secondsSinceEpoch() - executeStartedAt
+    if executeElapsed >= SLOW_EXECUTE_WARNING_SECONDS
+        or serializeElapsed >= SLOW_SERIALIZE_WARNING_SECONDS
+        or serializationState.truncated then
+        log.wf(
+            "WebSocket execute diagnostics id=%s total=%.3fs serialize=%.3fs nodes=%d tables=%d userdata=%d depth=%d truncated=%s reason=%s code=%s",
+            tostring(requestId),
+            executeElapsed,
+            serializeElapsed,
+            serializationState.nodes or 0,
+            serializationState.tables or 0,
+            serializationState.userdata or 0,
+            serializationState.maxDepth or 0,
+            tostring(serializationState.truncated),
+            tostring(serializationState.truncationReason),
+            summarizeCode(code)
+        )
+    end
+
+    -- Return serialization metadata alongside the result
+    local meta = nil
+    if serializationState.truncated then
+        meta = {
+            _truncated = true,
+            _truncationReason = serializationState.truncationReason,
+            _serializationNodes = serializationState.nodes or 0,
+            _serializationDepth = serializationState.maxDepth or 0,
+        }
+    end
+
+    return serialized, nil, meta
+end
+
+--- plugins.core.websocket.manager.message-handler.handleExecute(data) -> table
+--- Function
+--- Handles an execute message by running arbitrary Lua code.
+---
+--- Parameters:
+---  * data - The message data with payload.code containing Lua source
+---  * previousResult - Optional previous batch result, exposed to Lua as `_prev`
+---
+--- Returns:
+---  * Response table with the execution result
+function mod.handleExecute(data, previousResult)
+    local code = data.payload and data.payload.code
+    if not code or type(code) ~= "string" then
+        return mod.createErrorResponse(data.id, "Missing or invalid 'code' field in payload")
+    end
+
+    local serialized, executeError, serializeMeta = executeLuaCode(code, previousResult, data.id)
+    if executeError then
+        return mod.createErrorResponse(data.id, executeError)
+    end
+
+    local result = {result = serialized}
+
+    -- Surface truncation metadata so callers know data was lost
+    if serializeMeta then
+        result._truncated = serializeMeta._truncated
+        result._truncationReason = serializeMeta._truncationReason
+        result._serializationNodes = serializeMeta._serializationNodes
+        result._serializationDepth = serializeMeta._serializationDepth
+    end
+
+    return mod.createSuccessResponse(data.id, result)
+end
+
+--- plugins.core.websocket.manager.message-handler.handleBatch(data) -> table
+--- Function
+--- Handles a batch message by executing multiple operations sequentially.
+--- Supports chaining execute and command operations.
+---
+--- Parameters:
+---  * data - The message data with payload.operations array and optional payload.stopOnError
+---
+--- Returns:
+---  * Response table with results array
+function mod.handleBatch(data)
+    local operations = data.payload and data.payload.operations
+    if not operations or type(operations) ~= "table" then
+        return mod.createErrorResponse(data.id, "Missing or invalid 'operations' array in payload")
+    end
+
+    local stopOnError = data.payload.stopOnError ~= false -- default true
+    local results = {}
+    local lastResult = nil
+
+    for i, op in ipairs(operations) do
+        local opId = (data.id or "batch") .. "_" .. i
+        local response
+
+        if op.type == "execute" then
+            response = mod.handleExecute({
+                id = opId,
+                payload = {code = op.code or ""},
+            }, lastResult)
+        elseif op.type == "command" then
+            response = mod.handleCommand({
+                id = opId,
+                payload = op,
+            })
+        elseif op.type == "query" then
+            response = mod.handleQuery({
+                id = opId,
+                payload = op,
+            })
+        elseif op.type == "delay" then
+            local delay = tonumber(op.seconds)
+            if delay == nil then
+                response = mod.createErrorResponse(opId, "Delay operation requires a numeric 'seconds' value")
+            elseif delay < 0 then
+                response = mod.createErrorResponse(opId, "Delay seconds must be non-negative")
+            else
+                local sleepTime = math.min(delay, 10)
+                wait(sleepTime)
+                response = mod.createSuccessResponse(opId, {delayed = sleepTime})
+            end
+        else
+            response = mod.createErrorResponse(opId,
+                "Unknown operation type: " .. tostring(op.type) .. ". Valid types: execute, command, query, delay")
+        end
+
+        -- Track last successful result for chaining
+        if response and response.status == "success" and response.result then
+            lastResult = response.result.result or response.result
+        end
+
+        table.insert(results, {
+            index = i,
+            status = response and response.status or "error",
+            result = response and response.result or nil,
+            error = response and response.error or nil,
+        })
+
+        if stopOnError and response and response.status == "error" then
+            break
+        end
+    end
+
+    return mod.createSuccessResponse(data.id, {
+        results = results,
+        totalOperations = #operations,
+        completedOperations = #results,
+    })
 end
 
 --- plugins.core.websocket.manager.message-handler.createSuccessResponse(id, result) -> table


### PR DESCRIPTION
## Summary

This PR adds a **Model Context Protocol (MCP) server** to CommandPost, enabling AI assistants (such as Claude, ChatGPT, or any MCP-compatible client) to control Final Cut Pro and macOS workflows through CommandPost's existing automation infrastructure.

The server exposes **76 tools** spanning timeline editing, effects, transitions, retiming, markers, keywords, generators, titles, import/export, color correction, and arbitrary Lua scripting — all accessible over a standard JSON-RPC protocol.

---

## Architecture

```
AI Assistant (Claude Code, etc.)
        │
        │ stdio (JSON-RPC / MCP protocol)
        ▼
  MCP Server (Node.js / TypeScript)
        │
        │ WebSocket (port 27480, authenticated)
        ▼
  CommandPost (Hammerspoon runtime)
        │
        │ Accessibility API + Lua scripting
        ▼
  Final Cut Pro / macOS
```

### How It Works

1. **MCP Protocol Layer** (`src/mcp-server/src/index.ts`) — A Node.js server implementing the [Model Context Protocol](https://modelcontextprotocol.io) specification. It communicates with AI assistants via stdio using JSON-RPC, translating tool calls into CommandPost operations.

2. **WebSocket Transport** (`src/mcp-server/src/commandpost.ts`) — A WebSocket client that maintains a persistent connection to CommandPost's built-in WebSocket server. Handles message correlation via unique IDs, automatic reconnection, request timeouts, deduplication of broadcast responses, and back-pressure protection (max 100 pending requests).

3. **CommandPost WebSocket Server** (`src/plugins/core/websocket/manager/`) — Enhanced with new message types (`execute`, `batch`), token-based authentication, audit logging, and improved plugin matching. The server generates a SHA-256 session token on startup, writes it to a well-known file path, and validates every incoming message.

4. **Lua Execution Environment** — Tool handlers generate Lua code that runs inside CommandPost's Hammerspoon environment with full access to `hs.*` APIs, `cp.*` modules, Final Cut Pro's accessibility tree, and all registered CommandPost plugins.

### Authentication

The WebSocket connection uses shared-secret authentication:

- On server start, CommandPost generates a random SHA-256 token from timestamp + random data + process ID
- The token is written to `~/Library/Application Support/CommandPost/mcp-auth-token` with `chmod 600`
- The MCP server reads this token automatically (with a 60-second TTL cache, force-refreshed on auth failures)
- Every WebSocket message includes an `auth` field; messages without valid tokens are rejected
- The token can also be set via the `COMMANDPOST_AUTH_TOKEN` environment variable

### Operation Verification

Editing tools use a `withVerification` wrapper that captures timeline state before and after operations:

```json
{
  "before": { "clipCount": 4, "timecode": "00:00:15:00" },
  "after": {
    "clipCount": 5,
    "timecode": "00:00:15:00",
    "undoText": "Undo Blade",
    "clips": [...]
  },
  "verified": {
    "undoText": "Undo Blade",
    "clipDelta": 1,
    "tcChanged": false
  }
}
```

Three verification signals confirm success:
- **`undoText`** — FCP's own name for the last action (read via AX, not menu reads that steal focus)
- **`clipDelta`** — Change in clip count (+1 = added, -1 = removed)
- **`tcChanged`** — Whether the playhead moved

### Focus Management

FCP keyboard shortcuts require the app to be frontmost. The server:
- Calls `activateFinalCutPro()` before shortcut-based operations
- Checks for and dismisses modal dialogs (sheets, system dialogs) that would block interaction
- Dismisses speed popovers that persist after retime operations
- Uses AX-based undo text reading instead of `getMenuItems()` to avoid stealing focus during verification
- Uses `{plain = true}` on all `selectMenu` calls to prevent Lua pattern matching crashes from special characters in menu item names

### Dialog Handling

A `handleFCPDialog` helper automatically detects and handles FCP modal dialogs (e.g., "not enough extra media beyond clip edges" when applying transitions). It scans for AXSheets and AXModal windows, reads their text content, and clicks the appropriate button. This is integrated into both `withVerification` and individual tool handlers.

---

## Complete Tools Reference (76 tools)

### System & Connection (9 tools)

| Tool | Description |
|------|-------------|
| `commandpost_ping` | Health check — verifies CommandPost is running and WebSocket is connected |
| `commandpost_list_handlers` | List all registered action handlers (fcpx_menu, fcpx_shortcuts, etc.) |
| `commandpost_get_handler_info` | Get handler details with paginated choice lists and parameter schemas |
| `commandpost_execute_lua` | Execute arbitrary Lua in CommandPost's Hammerspoon environment |
| `commandpost_execute_action` | Execute a registered action by handler ID and action ID |
| `commandpost_chain` | Execute multiple operations sequentially with result passing via `_prev` |
| `commandpost_get_preference` | Read a CommandPost preference value by key |
| `commandpost_set_preference` | Write a CommandPost preference value |
| `commandpost_alert` | Display an on-screen HUD alert |

### Final Cut Pro — Application (6 tools)

| Tool | Description |
|------|-------------|
| `fcp_launch` | Launch FCP or bring to front if already running |
| `fcp_quit` | Quit Final Cut Pro |
| `fcp_restart` | Quit and relaunch Final Cut Pro |
| `fcp_status` | Running state, version, frontmost status, active libraries with paths |
| `fcp_select_menu` | Select any FCP menu item by path array (e.g., `["File", "Share", "Master File..."]`) |
| `fcp_do_shortcut` | Execute a keyboard shortcut by FCP command ID |

### Final Cut Pro — Timeline (9 tools)

| Tool | Description |
|------|-------------|
| `fcp_timeline_show` | Show/focus timeline on primary or secondary display |
| `fcp_timeline_playback` | Play, pause, or toggle playback |
| `fcp_timeline_navigate` | Jump to beginning/end, next/previous frame or edit, or specific timecode |
| `fcp_timeline_select` | Select clips: `all`, `none`, `at_playhead`, or `by_index` (1-based, skips transitions) |
| `fcp_timeline_blade` | Blade (cut) at current playhead with before/after clip count verification |
| `fcp_timeline_delete` | Delete selected clips (auto-selects at playhead if nothing selected) |
| `fcp_timeline_clipboard` | Copy, cut, or paste timeline content |
| `fcp_timeline_zoom` | Zoom in, out, or fit to window |
| `fcp_timeline_get_info` | Full timeline state: clip list with descriptions/durations, playhead timecode, undo text, focus state |

### Final Cut Pro — Effects & Plugins (4 tools)

| Tool | Description |
|------|-------------|
| `fcp_apply_effect` | Apply video or audio effect by simplified path (e.g., `"Blur/Gaussian"`, `"Stylize/Comic Book"`) |
| `fcp_apply_transition` | Apply transition via CommandPost's action handler system (e.g., `"Dissolves/Cross Dissolve"`) with automatic dialog handling |
| `fcp_apply_generator` | Apply generator (e.g., `"Solids/Custom"`, `"Backgrounds/Gradient"`) |
| `fcp_apply_title` | Apply title (e.g., `"Basic Title"`, `"Bumper/Opener/Basic Title"`) |

### Final Cut Pro — Discovery (6 tools)

| Tool | Description |
|------|-------------|
| `fcp_list_effects` | List all installed video effects with categories |
| `fcp_list_audio_effects` | List all installed audio effects |
| `fcp_list_transitions` | List all installed transitions |
| `fcp_list_generators` | List all installed generators |
| `fcp_list_titles` | List all installed titles |
| `fcp_list_markers` | List markers in the current timeline via AX tree |

### Final Cut Pro — Browser & Libraries (3 tools)

| Tool | Description |
|------|-------------|
| `fcp_browser_show` | Show browser panel (libraries, media, or generators) |
| `fcp_browser_list_libraries` | List all open libraries with filesystem paths |
| `fcp_browser_select_library` | Select a specific library by name |

### Final Cut Pro — Inspector & Viewer (2 tools)

| Tool | Description |
|------|-------------|
| `fcp_inspector_show` | Show inspector, optionally selecting a tab (audio, video, info, color, share, text, generator) |
| `fcp_viewer_show` | Show viewer on primary or secondary display |

### Final Cut Pro — Color (1 tool)

| Tool | Description |
|------|-------------|
| `fcp_color_board` | Adjust Color Board: color/saturation/exposure for master/shadows/midtones/highlights |

### Final Cut Pro — Export & Import (4 tools)

| Tool | Description |
|------|-------------|
| `fcp_export` | Export/share with optional destination preset |
| `fcp_export_xml` | Export FCPXML via File > Export XML |
| `fcp_import_media` | Import media file or folder via Media Import window with Go-to-Folder support |
| `fcp_import_xml` | Import FCPXML file |

### Final Cut Pro — Projects & Playhead (5 tools)

| Tool | Description |
|------|-------------|
| `fcp_open_project` | Open a project by name |
| `fcp_project_properties` | Get project properties (resolution, frame rate, etc.) |
| `fcp_get_playhead_position` | Get current playhead timecode |
| `fcp_set_playhead_position` | Navigate playhead to specific timecode |
| `fcp_get_project_settings` | Full project settings (resolution, frame rate, color space, audio config) |

### Final Cut Pro — Markers & Keywords (2 tools)

| Tool | Description |
|------|-------------|
| `fcp_add_marker` | Add standard, to-do, or chapter marker with optional name |
| `fcp_add_keyword` | Add keyword to selected clips via Keyword Editor (auto-opens/closes) |

### Final Cut Pro — Clip Operations (10 tools)

| Tool | Description |
|------|-------------|
| `fcp_rename_clip` | Rename selected clip via inline text field (supports FCP v12 Clip menu location) |
| `fcp_rate_clip` | Rate as favorite, reject, or unrate |
| `fcp_get_selected_clips` | Get selected clip info (names, positions, durations) via AX |
| `fcp_get_clip_properties` | Get transform/compositing (position, scale, rotation, opacity, blend mode) |
| `fcp_set_clip_properties` | Set transform or compositing properties on selected clip |
| `fcp_duplicate_clip` | Duplicate selected clips (copy + paste as connected) |
| `fcp_enable_disable_clip` | Toggle clip enabled state |
| `fcp_create_compound_clip` | Create compound clip from selection |
| `fcp_create_audition` | Create audition from selection |
| `fcp_break_apart_compound` | Break apart a compound clip |

### Final Cut Pro — Speed & Retime (2 tools)

| Tool | Description |
|------|-------------|
| `fcp_retime` | Speed presets: slow (50%/25%/10%), fast (2x/4x/8x/20x), normal, reverse, hold |
| `fcp_speed_custom` | Set arbitrary speed percentage |

### Final Cut Pro — Advanced (9 tools)

| Tool | Description |
|------|-------------|
| `fcp_split_at_timecode` | Blade at a specific timecode (navigates playhead, then blades) |
| `fcp_set_range` | Set timeline in/out range selection |
| `fcp_clear_range` | Clear range selection |
| `fcp_captions` | Add, extract, or import captions |
| `fcp_multicam_switch_angle` | Switch multicam angle (video, audio, or both) |
| `fcp_assign_role` | Assign role to selected clips |
| `fcp_stabilization` | Toggle stabilization on selected clip |
| `fcp_proxy_toggle` | Toggle proxy/optimized/original media |
| `fcp_batch_apply_transition` | Apply transition to all edit points in selection |

### Final Cut Pro — Window & Undo (3 tools)

| Tool | Description |
|------|-------------|
| `fcp_window_layout` | Show/hide browser, inspector, timeline, viewer; toggle fullscreen |
| `fcp_undo_redo` | Undo or redo with optional count for multiple operations |
| `fcp_pasteboard` | Access CommandPost's clipboard history |

### Final Cut Pro — Workflow (1 tool)

| Tool | Description |
|------|-------------|
| `fcp_assemble_rough_cut` | Assemble rough cut from operation sequence in one call |

---

## FCP v12 Compatibility Fixes

This PR includes several fixes for Final Cut Pro v12 (12.0+):

### PrimaryToolbar.lua
FCP v12 no longer wraps toolbar checkboxes in `AXGroup` elements — they are now direct children of the toolbar. Updated all five checkbox properties (`keywordEditor`, `backgroundTasksWindow`, `browserShowing`, `timelineShowing`, `inspectorShowing`) to fall back to AXDescription-based matching when the legacy AXGroup wrapper is not found. Fully backwards-compatible with pre-v12.

### Menu Item Relocation
"Rename Clip" moved from the `Modify` menu to the `Clip` menu in FCP v12. The rename tool tries `Clip > Rename Clip` first, falling back to `Modify > Rename Clip`.

### Lua Pattern Safety
All `selectMenu` calls now pass `{plain = true}` to disable Lua pattern matching. This prevents crashes when menu items contain special pattern characters like `%` (e.g., "Normal (100%)"), `.`, `(`, or `)`.

### Plugin Name-Only Matching
`findFCPXPluginBySimplifiedPath` in the WebSocket message handler now supports name-only matching as a fallback. This allows matching `"Cross Dissolve"` without requiring the full `"Dissolves/Cross Dissolve"` path — important for transitions and other plugins that lack filesystem path metadata.

### Defensive Nil Handling
- `Contents:clipsUI()` and `Contents:positionClipsUI()` return empty tables `{}` instead of `nil` to prevent downstream nil index errors
- `Timeline:isShowing()` uses a safer prop composition
- Menu finder adds nil checks before calling `:gsub()` and `:find()` on potentially nil strings

---

## Files Changed

### New Files
| File | Lines | Description |
|------|-------|-------------|
| `src/mcp-server/src/index.ts` | 6,337 | MCP server: tool definitions, Lua code generation, verification wrappers |
| `src/mcp-server/src/commandpost.ts` | 408 | WebSocket client with auth, reconnection, deduplication |
| `src/mcp-server/README.md` | 462 | Full documentation with setup, tools reference, architecture |
| `src/mcp-server/package.json` | 31 | Dependencies: `@modelcontextprotocol/sdk`, `ws` |
| `src/mcp-server/test.mjs` | 1,163 | Protocol-level test suite (offline + live modes) |
| `src/mcp-server/test-edit-workflow.mjs` | 955 | End-to-end timeline editing test |
| `src/mcp-server/test-edit-workflow-mini.mjs` | 195 | Quick smoke test (markers + navigation) |
| `src/mcp-server/test-edit-workflow-storm.mjs` | 419 | Stress test (rapid sequential operations) |
| `.mcp.json` | 8 | Claude Code MCP server configuration |

### Modified Files
| File | Description |
|------|-------------|
| `src/plugins/core/websocket/manager/message-handler.lua` | +802 lines: `execute`/`batch` message types, auth, audit logging, plugin matching |
| `src/plugins/core/websocket/manager/init.lua` | +91 lines: auth token generation, `getAuthTokenPath()`, server-only mode |
| `src/extensions/cp/apple/finalcutpro/main/PrimaryToolbar.lua` | FCP v12 toolbar checkbox compatibility |
| `src/extensions/cp/apple/finalcutpro/import/MediaImport.lua` | `setPath()` and `importFiles()` methods for programmatic media import |
| `src/extensions/cp/apple/finalcutpro/timeline/Contents.lua` | Return `{}` instead of `nil` from clip query methods |
| `src/extensions/cp/apple/finalcutpro/timeline/Timeline.lua` | Safer `isShowing` prop |
| `src/extensions/cp/apple/finalcutpro/menu.lua` | Nil-safe pattern matching in menu finder |

---

## Setup

```bash
# 1. Enable WebSocket in CommandPost
defaults write org.latenitefilms.CommandPost "cp.websocket.enabled" -int 1
# Then restart CommandPost

# 2. Build the MCP server
cd src/mcp-server
npm install
npm run build

# 3. Add to Claude Code's .mcp.json
# {
#   "mcpServers": {
#     "commandpost": {
#       "command": "node",
#       "args": ["/path/to/CommandPost/src/mcp-server/dist/index.js"]
#     }
#   }
# }

# 4. Restart Claude Code session
```

---

## Test Plan

- [x] Blade cuts (3 cuts creating 4 clips) — verified clip count delta
- [x] Timeline navigation (beginning, next edit, end, timecode) — verified timecode changes
- [x] Select clip at playhead and by index — verified AX selection
- [x] Apply video effect (Gaussian Blur) — verified via action handler
- [x] Apply transition (Cross Dissolve) — verified transition count delta
- [x] Retime slow 50% and fast 4x — verified undo text "Speed Adjustment"
- [x] Reset to normal speed — verified undo text "Retime Reset Clip"
- [x] Add standard and chapter markers — verified marker added
- [x] Add keyword via Keyword Editor — verified with PrimaryToolbar v12 fix
- [x] Rename clip — verified via Clip menu (FCP v12 location)
- [x] Duplicate clip — verified clip count delta and undo text "Paste"
- [x] Apply generator (Custom Solid) — verified via action handler
- [x] Apply title (Basic Title) — verified via action handler
- [x] Delete clip — verified clip count delta
- [x] Undo/Redo — verified undo title changes
- [x] Select all / select none — verified count changes